### PR TITLE
LPD-88108 Add Export and Import actions to Design Libraries UI

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/servlet/taglib/DepotBreadcrumbEntryContributorImpl.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/servlet/taglib/DepotBreadcrumbEntryContributorImpl.java
@@ -84,9 +84,12 @@ public class DepotBreadcrumbEntryContributorImpl
 				return originalBreadcrumbEntries;
 			}
 
-			breadcrumbEntries.add(
-				_getAssetLibrariesBreadcrumbEntry(
-					themeDisplay.getControlPanelGroup(), httpServletRequest));
+			if (depotEntry.getType() != DepotConstants.TYPE_DESIGN_LIBRARY) {
+				breadcrumbEntries.add(
+					_getAssetLibrariesBreadcrumbEntry(
+						themeDisplay.getControlPanelGroup(),
+						httpServletRequest));
+			}
 
 			breadcrumbEntries.add(
 				_getAssetLibraryBreadcrumbEntry(

--- a/modules/apps/design-library/design-library-web/build.gradle
+++ b/modules/apps/design-library/design-library-web/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:depot:depot-api")
+	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-api")
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
@@ -8,6 +8,7 @@ package com.liferay.design.library.web.internal.display.context;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -208,14 +209,18 @@ public class DesignLibraryResourcesDisplayContext {
 				"symbolLeft", "users"
 			),
 			JSONUtil.put(
-				"href", "#import"
+				"href",
+				_getExportImportPortletURL(
+					group, ExportImportPortletKeys.IMPORT)
 			).put(
 				"label", LanguageUtil.get(_httpServletRequest, "import")
 			).put(
 				"symbolLeft", "import"
 			),
 			JSONUtil.put(
-				"href", "#export"
+				"href",
+				_getExportImportPortletURL(
+					group, ExportImportPortletKeys.EXPORT)
 			).put(
 				"label", LanguageUtil.get(_httpServletRequest, "export")
 			).put(
@@ -285,6 +290,13 @@ public class DesignLibraryResourcesDisplayContext {
 			).put(
 				"label", group.getName(_httpServletRequest.getLocale())
 			));
+	}
+
+	private String _getExportImportPortletURL(Group group, String portletId) {
+		return PortalUtil.getControlPanelPortletURL(
+			_httpServletRequest, group, portletId, 0, 0,
+			PortletRequest.RENDER_PHASE
+		).toString();
 	}
 
 	private boolean _hasManageStyleBookEntriesPermission(long groupId) {

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
@@ -293,10 +293,13 @@ public class DesignLibraryResourcesDisplayContext {
 	}
 
 	private String _getExportImportPortletURL(Group group, String portletId) {
-		return PortalUtil.getControlPanelPortletURL(
-			_httpServletRequest, group, portletId, 0, 0,
-			PortletRequest.RENDER_PHASE
-		).toString();
+		return PortletURLBuilder.create(
+			PortalUtil.getControlPanelPortletURL(
+				_httpServletRequest, group, portletId, 0, 0,
+				PortletRequest.RENDER_PHASE)
+		).setBackURL(
+			PortalUtil.getCurrentURL(_httpServletRequest)
+		).buildString();
 	}
 
 	private boolean _hasManageStyleBookEntriesPermission(long groupId) {

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/ViewDesignLibraryAdminDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/ViewDesignLibraryAdminDisplayContext.java
@@ -6,14 +6,18 @@
 package com.liferay.design.library.web.internal.display.context;
 
 import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -31,6 +35,9 @@ public class ViewDesignLibraryAdminDisplayContext {
 
 		_httpServletRequest = httpServletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	public String getAPIURL() {
@@ -40,8 +47,6 @@ public class ViewDesignLibraryAdminDisplayContext {
 
 	public Map<String, Object> getBreadcrumbProps() {
 		return HashMapBuilder.<String, Object>put(
-			"actionItems", _getActionItemsJSONArray()
-		).put(
 			"breadcrumbItems", _getBreadcrumbItemsJSONArray()
 		).build();
 	}
@@ -73,6 +78,16 @@ public class ViewDesignLibraryAdminDisplayContext {
 				"pencil", "edit", LanguageUtil.get(_httpServletRequest, "edit"),
 				null, null, "link"),
 			new FDSActionDropdownItem(
+				_getExportImportPortletURL(ExportImportPortletKeys.EXPORT),
+				"export", "export",
+				LanguageUtil.get(_httpServletRequest, "export"), "get",
+				"update", null),
+			new FDSActionDropdownItem(
+				_getExportImportPortletURL(ExportImportPortletKeys.IMPORT),
+				"import", "import",
+				LanguageUtil.get(_httpServletRequest, "import"), "get",
+				"update", null),
+			new FDSActionDropdownItem(
 				"{actions.delete.href}", "trash", "delete",
 				LanguageUtil.get(_httpServletRequest, "delete"), "delete",
 				"delete", null));
@@ -91,17 +106,6 @@ public class ViewDesignLibraryAdminDisplayContext {
 		).build();
 	}
 
-	private JSONArray _getActionItemsJSONArray() {
-		return JSONUtil.putAll(
-			JSONUtil.put(
-				"href", "#import"
-			).put(
-				"label", LanguageUtil.get(_httpServletRequest, "import")
-			).put(
-				"symbolLeft", "import"
-			));
-	}
-
 	private JSONArray _getBreadcrumbItemsJSONArray() {
 		return JSONUtil.putAll(
 			JSONUtil.put(
@@ -112,7 +116,15 @@ public class ViewDesignLibraryAdminDisplayContext {
 			));
 	}
 
+	private String _getExportImportPortletURL(String portletId) {
+		return StringBundler.concat(
+			_themeDisplay.getCDNBaseURL(),
+			_themeDisplay.getPathFriendlyURLPrivateGroup(),
+			"/asset-library-{id}/~/control_panel/manage?p_p_id=", portletId);
+	}
+
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
+	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/ViewDesignLibraryAdminDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/ViewDesignLibraryAdminDisplayContext.java
@@ -16,7 +16,9 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -117,10 +119,14 @@ public class ViewDesignLibraryAdminDisplayContext {
 	}
 
 	private String _getExportImportPortletURL(String portletId) {
-		return StringBundler.concat(
-			_themeDisplay.getCDNBaseURL(),
-			_themeDisplay.getPathFriendlyURLPrivateGroup(),
-			"/asset-library-{id}/~/control_panel/manage?p_p_id=", portletId);
+		return HttpComponentsUtil.addParameter(
+			StringBundler.concat(
+				_themeDisplay.getCDNBaseURL(),
+				_themeDisplay.getPathFriendlyURLPrivateGroup(),
+				"/asset-library-{id}/~/control_panel/manage?p_p_id=",
+				portletId),
+			"_" + portletId + "_backURL",
+			PortalUtil.getCurrentURL(_httpServletRequest));
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/test/playwright/tests/design-library-web/main/designLibrary.spec.ts
+++ b/modules/test/playwright/tests/design-library-web/main/designLibrary.spec.ts
@@ -336,6 +336,76 @@ test(
 );
 
 test(
+	'Can export a design library from the listing row',
+	{tag: ['@LPD-88108', '@LPD-79455']},
+	async ({apiHelpers, designLibrariesPage, page}) => {
+		const designLibraryName = getRandomString();
+
+		const createdDesignLibrary =
+			await test.step('Create temporary design library via headless', async () => {
+				return await apiHelpers.headlessAssetLibrary.createAssetLibrary(
+					{
+						name: designLibraryName,
+						settings: {},
+						type: 'DesignLibrary',
+					}
+				);
+			});
+
+		await test.step('Listing row ellipsis exposes Export and Import actions', async () => {
+			await designLibrariesPage.goto();
+
+			await page
+				.locator('table.table tbody tr', {hasText: designLibraryName})
+				.first()
+				.getByRole('button', {name: 'Actions'})
+				.click();
+
+			await expect(page.getByRole('menu')).toBeVisible();
+
+			await expect(
+				page.getByRole('menu').getByRole('menuitem', {name: 'Export'})
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('menu').getByRole('menuitem', {name: 'Import'})
+			).toBeVisible();
+		});
+
+		await test.step('Clicking Export navigates to the Export portlet scoped to the design library with a back URL', async () => {
+			await page
+				.getByRole('menu')
+				.getByRole('menuitem', {name: 'Export'})
+				.click();
+
+			await expect(page).toHaveURL(
+				/p_p_id=com_liferay_exportimport_web_portlet_ExportPortlet/
+			);
+
+			await expect(page).toHaveURL(/asset-library-\d+/);
+
+			await expect(page).toHaveURL(/backURL=/);
+		});
+
+		await test.step('Breadcrumb omits Asset Libraries and includes the design library', async () => {
+			const breadcrumb = page.locator('.breadcrumb').first();
+
+			await expect(breadcrumb).toBeVisible();
+
+			await expect(breadcrumb.getByText('Asset Libraries')).toBeHidden();
+
+			await expect(breadcrumb.getByText(designLibraryName)).toBeVisible();
+		});
+
+		await test.step('Remove temporary design library', async () => {
+			await apiHelpers.headlessAssetLibrary.deleteAssetLibrary(
+				createdDesignLibrary.externalReferenceCode
+			);
+		});
+	}
+);
+
+test(
 	'Can view and edit a design library settings',
 	{tag: '@LPD-79533'},
 	async ({apiHelpers, designLibrariesPage, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88108

## What Is Being Fixed

Design Libraries had no UI affordance to export their contents as a `.lar` file or import a `.lar` back in. The detail-view ellipsis menu contained placeholder Export and Import items that pointed at empty hash hrefs, and the listing-view row ellipsis exposed only Edit and Delete. Once the user reached the Export or Import portlet through any other route, the header lacked a back button and the breadcrumb led with an "Asset Libraries" entry that does not appear for CMS Spaces, making the two surfaces feel inconsistent.

## How It Is Being Fixed

The Design Library admin UI is wired to the existing Export and Import portlets at the asset library scope, matching the redirect pattern CMS Spaces already uses. The listing view's per-row ellipsis gains Export and Import items whose URLs target `/group/asset-library-{id}/~/control_panel/manage` for the matching portlet; the detail-view ellipsis builds the equivalent URL via `PortalUtil.getControlPanelPortletURL`. Both URLs carry a namespaced `backURL` parameter, which the Export and Import portlets read to set the header back arrow. The `DepotBreadcrumbEntryContributorImpl` skips the leading "Asset Libraries" entry when the depot is a Design Library — the existing `TYPE_SPACE` early-return is extended to the new type so spaces and design libraries behave consistently. A Playwright spec covers the row Export click, the URL pattern, the backURL parameter, and the cleaned-up breadcrumb.