### PR TITLE
LPD-92238 Support date time range filters in custom Data Sets

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/ImportSystemDataSetMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/ImportSystemDataSetMVCResourceCommand.java
@@ -16,6 +16,7 @@ import com.liferay.frontend.data.set.action.util.FDSActionUtil;
 import com.liferay.frontend.data.set.admin.web.internal.constants.FDSAdminPortletKeys;
 import com.liferay.frontend.data.set.filter.BaseClientExtensionFDSFilter;
 import com.liferay.frontend.data.set.filter.BaseDateRangeFDSFilter;
+import com.liferay.frontend.data.set.filter.BaseDateTimeRangeFDSFilter;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilterRegistry;
@@ -581,7 +582,9 @@ public class ImportSystemDataSetMVCResourceCommand
 					"r_dataSetToDataSetClientExtensionFilters_l_dataSetId",
 					objectEntry.getObjectEntryId());
 			}
-			else if (fdsFilter instanceof BaseDateRangeFDSFilter) {
+			else if (fdsFilter instanceof BaseDateRangeFDSFilter ||
+					 fdsFilter instanceof BaseDateTimeRangeFDSFilter) {
+
 				externalReferenceCode = "L_DATA_SET_DATE_FILTER";
 
 				JSONObject jsonObject = JSONUtil.put(

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/constants/FDSEntityFieldTypes.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/constants/FDSEntityFieldTypes.java
@@ -10,6 +10,8 @@ package com.liferay.frontend.data.set.constants;
  */
 public class FDSEntityFieldTypes {
 
+	public static final String BOOLEAN = "boolean";
+
 	public static final String COLLECTION = "collection";
 
 	public static final String COLLECTION_INTEGER = "collection-integer";

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseDateRangeFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseDateRangeFDSFilter.java
@@ -5,10 +5,17 @@
 
 package com.liferay.frontend.data.set.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+
 /**
  * @author Luca Pellizzon
  */
 public abstract class BaseDateRangeFDSFilter implements FDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.DATE;
+	}
 
 	public abstract DateFDSFilterItem getMaxDateFDSFilterItem();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseDateTimeRangeFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseDateTimeRangeFDSFilter.java
@@ -5,10 +5,17 @@
 
 package com.liferay.frontend.data.set.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+
 /**
  * @author Mikel Lorza
  */
 public abstract class BaseDateTimeRangeFDSFilter implements FDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.DATE_TIME;
+	}
 
 	public abstract DateTimeFDSFilterItem getMaxDateTimeFDSFilterItem();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -878,7 +878,9 @@ public class CustomFDSSerializer
 	@Reference
 	protected FDSFilterRegistry fdsFilterRegistry;
 
-	private JSONObject _getDateJSONObject(Object object) {
+	private JSONObject _getDateOrDateTimeJSONObject(
+		boolean dateTime, Object object) {
+
 		if (object == null) {
 			return null;
 		}
@@ -887,37 +889,25 @@ public class CustomFDSSerializer
 
 		calendar.setTime(Date.from(Instant.parse(String.valueOf(object))));
 
-		return JSONUtil.put(
+		JSONObject jsonObject = JSONUtil.put(
 			"day", calendar.get(Calendar.DATE)
 		).put(
 			"month", calendar.get(Calendar.MONTH) + 1
 		).put(
 			"year", calendar.get(Calendar.YEAR)
 		);
-	}
 
-	private JSONObject _getDateTimeJSONObject(Object object) {
-		if (object == null) {
-			return null;
+		if (dateTime) {
+			jsonObject.put(
+				"hour", calendar.get(Calendar.HOUR_OF_DAY)
+			).put(
+				"minute", calendar.get(Calendar.MINUTE)
+			).put(
+				"second", calendar.get(Calendar.SECOND)
+			);
 		}
 
-		Calendar calendar = Calendar.getInstance();
-
-		calendar.setTime(Date.from(Instant.parse(String.valueOf(object))));
-
-		return JSONUtil.put(
-			"day", calendar.get(Calendar.DATE)
-		).put(
-			"hour", calendar.get(Calendar.HOUR_OF_DAY)
-		).put(
-			"minute", calendar.get(Calendar.MINUTE)
-		).put(
-			"month", calendar.get(Calendar.MONTH) + 1
-		).put(
-			"second", calendar.get(Calendar.SECOND)
-		).put(
-			"year", calendar.get(Calendar.YEAR)
-		);
+		return jsonObject;
 	}
 
 	private Object _getListTypeEntryKey(
@@ -1142,21 +1132,20 @@ public class CustomFDSSerializer
 			String fieldName, Map<String, Object> properties, String type)
 		throws Exception {
 
-		boolean isDate = Objects.equals(type, "date");
+		boolean dateTime = Objects.equals(type, FDSEntityFieldTypes.DATE_TIME);
 
-		String entityFieldType =
-			isDate ? FDSEntityFieldTypes.DATE :
-				FDSEntityFieldTypes.DATE_TIME;
-
-		JSONObject fromJSONObject = isDate ? _getDateJSONObject(properties.get("from")) : _getDateTimeJSONObject(properties.get("from"));
-		JSONObject toJSONObject = isDate ? _getDateJSONObject(properties.get("to")) : _getDateTimeJSONObject(properties.get("to"));
+		JSONObject fromJSONObject = _getDateOrDateTimeJSONObject(
+			dateTime, properties.get("from"));
+		JSONObject toJSONObject = _getDateOrDateTimeJSONObject(
+			dateTime, properties.get("to"));
 
 		boolean active = (fromJSONObject != null) || (toJSONObject != null);
 
 		return JSONUtil.put(
 			"active", active
 		).put(
-			"entityFieldType", entityFieldType
+			"entityFieldType",
+			dateTime ? FDSEntityFieldTypes.DATE_TIME : FDSEntityFieldTypes.DATE
 		).put(
 			"id", fieldName
 		).put(
@@ -1176,9 +1165,7 @@ public class CustomFDSSerializer
 				);
 			}
 		).put(
-			"type",
-			isDate ? "dateRange" :
-				"dateTimeRange"
+			"type", dateTime ? "dateTimeRange" : "dateRange"
 		);
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -1132,7 +1132,7 @@ public class CustomFDSSerializer
 			String fieldName, Map<String, Object> properties, String type)
 		throws Exception {
 
-		boolean dateTime = Objects.equals(type, FDSEntityFieldTypes.DATE_TIME);
+		boolean dateTime = !Objects.equals(type, FDSEntityFieldTypes.DATE);
 
 		JSONObject fromJSONObject = _getDateOrDateTimeJSONObject(
 			dateTime, properties.get("from"));

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -896,6 +896,30 @@ public class CustomFDSSerializer
 		);
 	}
 
+	private JSONObject _getDateTimeJSONObject(Object object) {
+		if (object == null) {
+			return null;
+		}
+
+		Calendar calendar = Calendar.getInstance();
+
+		calendar.setTime(Date.from(Instant.parse(String.valueOf(object))));
+
+		return JSONUtil.put(
+			"day", calendar.get(Calendar.DATE)
+		).put(
+			"hour", calendar.get(Calendar.HOUR_OF_DAY)
+		).put(
+			"minute", calendar.get(Calendar.MINUTE)
+		).put(
+			"month", calendar.get(Calendar.MONTH) + 1
+		).put(
+			"second", calendar.get(Calendar.SECOND)
+		).put(
+			"year", calendar.get(Calendar.YEAR)
+		);
+	}
+
 	private Object _getListTypeEntryKey(
 		String entityFieldType, ListTypeEntry listTypeEntry) {
 
@@ -1118,17 +1142,21 @@ public class CustomFDSSerializer
 			String fieldName, Map<String, Object> properties, String type)
 		throws Exception {
 
-		JSONObject fromJSONObject = _getDateJSONObject(properties.get("from"));
-		JSONObject toJSONObject = _getDateJSONObject(properties.get("to"));
+		boolean isDate = Objects.equals(type, "date");
+
+		String entityFieldType =
+			isDate ? FDSEntityFieldTypes.DATE :
+				FDSEntityFieldTypes.DATE_TIME;
+
+		JSONObject fromJSONObject = isDate ? _getDateJSONObject(properties.get("from")) : _getDateTimeJSONObject(properties.get("from"));
+		JSONObject toJSONObject = isDate ? _getDateJSONObject(properties.get("to")) : _getDateTimeJSONObject(properties.get("to"));
 
 		boolean active = (fromJSONObject != null) || (toJSONObject != null);
 
 		return JSONUtil.put(
 			"active", active
 		).put(
-			"entityFieldType",
-			Objects.equals(type, "date") ? FDSEntityFieldTypes.DATE :
-				FDSEntityFieldTypes.DATE_TIME
+			"entityFieldType", entityFieldType
 		).put(
 			"id", fieldName
 		).put(
@@ -1148,7 +1176,9 @@ public class CustomFDSSerializer
 				);
 			}
 		).put(
-			"type", "dateRange"
+			"type",
+			isDate ? "dateRange" :
+				"dateTimeRange"
 		);
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/filter/DateTimeRangeFDSFilterContextContributorTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/filter/DateTimeRangeFDSFilterContextContributorTest.java
@@ -105,11 +105,6 @@ public class DateTimeRangeFDSFilterContextContributorTest {
 		}
 
 		@Override
-		public String getEntityFieldType() {
-			return "date-time";
-		}
-
-		@Override
 		public String getId() {
 			return "testField";
 		}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
@@ -487,6 +487,76 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		_resetFDSSerializer();
 
+		// Date time range filter
+
+		_mockSerializeFilters(
+			FDS_NAMES[0],
+			HashMapBuilder.<String, Object>put(
+				"fieldName", FIELD_NAMES[0]
+			).put(
+				"from", "2000-12-31T09:15:00.000Z"
+			).put(
+				"label", LABELS[0]
+			).put(
+				"to", "2025-10-03T18:33:56.000Z"
+			).put(
+				"type", FDSEntityFieldTypes.DATE_TIME
+			).build());
+
+		JSONAssert.assertEquals(
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"active", true
+				).put(
+					"entityFieldType", FDSEntityFieldTypes.DATE_TIME
+				).put(
+					"id", FIELD_NAMES[0]
+				).put(
+					"label", LABELS[0]
+				).put(
+					"preloadedData",
+					JSONUtil.put(
+						"from",
+						JSONUtil.put(
+							"day", 31
+						).put(
+							"hour", 9
+						).put(
+							"minute", 15
+						).put(
+							"month", 12
+						).put(
+							"second", 0
+						).put(
+							"year", 2000
+						)
+					).put(
+						"to",
+						JSONUtil.put(
+							"day", 3
+						).put(
+							"hour", 18
+						).put(
+							"minute", 33
+						).put(
+							"month", 10
+						).put(
+							"second", 56
+						).put(
+							"year", 2025
+						)
+					)
+				).put(
+					"type", "dateTimeRange"
+				)
+			).toString(),
+			_customFDSSerializer.serializeFilters(
+				FDS_NAMES[0], httpServletRequest
+			).toString(),
+			JSONCompareMode.STRICT);
+
+		_resetFDSSerializer();
+
 		// Different filters
 
 		_mockSerializeFilters(

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
@@ -1767,11 +1767,6 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 		return new BaseDateRangeFDSFilter() {
 
 			@Override
-			public String getEntityFieldType() {
-				return FDSEntityFieldTypes.DATE;
-			}
-
-			@Override
 			public String getId() {
 				return id;
 			}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/AdvancedDateTimeRangeFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/AdvancedDateTimeRangeFDSFilter.java
@@ -5,7 +5,6 @@
 
 package com.liferay.frontend.data.set.sample.web.internal.filter;
 
-import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseDateTimeRangeFDSFilter;
 import com.liferay.frontend.data.set.filter.DateTimeFDSFilterItem;
 import com.liferay.frontend.data.set.filter.FDSFilter;
@@ -21,11 +20,6 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class AdvancedDateTimeRangeFDSFilter extends BaseDateTimeRangeFDSFilter {
-
-	@Override
-	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.DATE_TIME;
-	}
 
 	@Override
 	public String getId() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/CreateDateTimeRangeFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/CreateDateTimeRangeFDSFilter.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
-import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseDateTimeRangeFDSFilter;
 import com.liferay.frontend.data.set.filter.DateTimeFDSFilterItem;
 import com.liferay.frontend.data.set.filter.FDSFilter;
@@ -32,11 +31,6 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class CreateDateTimeRangeFDSFilter extends BaseDateTimeRangeFDSFilter {
-
-	@Override
-	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.DATE_TIME;
-	}
 
 	@Override
 	public String getId() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/DisplayDateTimeRangeFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/DisplayDateTimeRangeFDSFilter.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
-import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseDateTimeRangeFDSFilter;
 import com.liferay.frontend.data.set.filter.DateTimeFDSFilterItem;
 import com.liferay.frontend.data.set.filter.FDSFilter;
@@ -31,11 +30,6 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class DisplayDateTimeRangeFDSFilter extends BaseDateTimeRangeFDSFilter {
-
-	@Override
-	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.DATE_TIME;
-	}
 
 	@Override
 	public String getId() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExpirationDateTimeRangeFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExpirationDateTimeRangeFDSFilter.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
-import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseDateTimeRangeFDSFilter;
 import com.liferay.frontend.data.set.filter.DateTimeFDSFilterItem;
 import com.liferay.frontend.data.set.filter.FDSFilter;
@@ -32,11 +31,6 @@ import org.osgi.service.component.annotations.Component;
 )
 public class ExpirationDateTimeRangeFDSFilter
 	extends BaseDateTimeRangeFDSFilter {
-
-	@Override
-	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.DATE_TIME;
-	}
 
 	@Override
 	public String getId() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ModifiedDateTimeRangeFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ModifiedDateTimeRangeFDSFilter.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
-import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseDateTimeRangeFDSFilter;
 import com.liferay.frontend.data.set.filter.DateTimeFDSFilterItem;
 import com.liferay.frontend.data.set.filter.FDSFilter;
@@ -32,11 +31,6 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class ModifiedDateTimeRangeFDSFilter extends BaseDateTimeRangeFDSFilter {
-
-	@Override
-	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.DATE_TIME;
-	}
 
 	@Override
 	public String getId() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/PublishDateTimeRangeFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/PublishDateTimeRangeFDSFilter.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
-import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseDateTimeRangeFDSFilter;
 import com.liferay.frontend.data.set.filter.DateTimeFDSFilterItem;
 import com.liferay.frontend.data.set.filter.FDSFilter;
@@ -31,11 +30,6 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class PublishDateTimeRangeFDSFilter extends BaseDateTimeRangeFDSFilter {
-
-	@Override
-	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.DATE_TIME;
-	}
 
 	@Override
 	public String getId() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ReviewDateTimeRangeFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ReviewDateTimeRangeFDSFilter.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
-import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseDateTimeRangeFDSFilter;
 import com.liferay.frontend.data.set.filter.DateTimeFDSFilterItem;
 import com.liferay.frontend.data.set.filter.FDSFilter;
@@ -31,11 +30,6 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class ReviewDateTimeRangeFDSFilter extends BaseDateTimeRangeFDSFilter {
-
-	@Override
-	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.DATE_TIME;
-	}
 
 	@Override
 	public String getId() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92238

## What Is Being Fixed

Custom Data Set serialization and the System Data Set import process did
not handle date time range filters. `CustomFDSSerializer` only emitted
day/month/year values and always tagged filters as `dateRange`, so date
time filters lost their time component and type. The import process did
not recognize `BaseDateTimeRangeFDSFilter`, so such filters arriving via
import were not mapped to the date filter external reference code. The
Java and TypeScript representations of entity field types were also out
of sync.

## How It Is Being Fixed

`CustomFDSSerializer` now distinguishes date from date time filters:
`_getDateOrDateTimeJSONObject` adds hour/minute/second when serializing a
date time field, and the emitted `entityFieldType` and filter `type`
(`dateRange` vs `dateTimeRange`) are derived from the field type. The
import command treats `BaseDateTimeRangeFDSFilter` like
`BaseDateRangeFDSFilter` so date time filters are included in the import.
Each base date filter provides a default entity field type matching its
purpose, the Java and TS entity field types are harmonized (adding the
`boolean` constant), and tests cover serializing a date time range
filter. There is currently no UI to create these filters from the Data
Set Manager, but they can still arrive through the import process.
