### PR TITLE
LPD-92861 Provide a ThemeDisplay to the import maps include test

### DIFF
--- a/modules/apps/frontend-js/frontend-js-importmaps-extender-test/src/testIntegration/java/com/liferay/frontend/js/importmaps/extender/internal/servlet/taglib/test/JSImportMapsExtenderTopHeadDynamicIncludeTest.java
+++ b/modules/apps/frontend-js/frontend-js-importmaps-extender-test/src/testIntegration/java/com/liferay/frontend/js/importmaps/extender/internal/servlet/taglib/test/JSImportMapsExtenderTopHeadDynamicIncludeTest.java
@@ -12,10 +12,12 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -148,6 +150,13 @@ public class JSImportMapsExtenderTopHeadDynamicIncludeTest {
 
 			mockHttpServletRequest.setAttribute(WebKeys.COMPANY_ID, companyId);
 
+			ThemeDisplay themeDisplay = new ThemeDisplay();
+
+			themeDisplay.setCompany(_companyLocalService.getCompany(companyId));
+
+			mockHttpServletRequest.setAttribute(
+				WebKeys.THEME_DISPLAY, themeDisplay);
+
 			MockHttpServletResponse mockHttpServletResponse =
 				new MockHttpServletResponse();
 
@@ -187,6 +196,9 @@ public class JSImportMapsExtenderTopHeadDynamicIncludeTest {
 
 	@DeleteAfterTestRun
 	private Company _company2;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject(
 		filter = "component.name=com.liferay.frontend.js.importmaps.extender.internal.servlet.taglib.JSImportMapsExtenderTopHeadDynamicInclude"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92861

## What Is Being Fixed

The integration test JSImportMapsExtenderTopHeadDynamicIncludeTest started failing. The dynamic include under test resolves the company from the ThemeDisplay stored in the request, but the test built its mock request without a ThemeDisplay, so the include hit a null value and the test failed.

## How It Is Being Fixed

The test now builds a ThemeDisplay, sets the company resolved from the injected CompanyLocalService for the request's company ID, and stores it under WebKeys.THEME_DISPLAY before invoking the include.