### PR TITLE
LPD-93517 Do not fail when the empty state has no action items

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/init.jsp
@@ -7,7 +7,8 @@
 
 <%@ include file="/init.jsp" %>
 
-<%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem" %>
+<%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem" %><%@
+page import="com.liferay.portal.kernel.util.ListUtil" %>
 
 <%
 List<DropdownItem> actionDropdownItems = (List<DropdownItem>)request.getAttribute("liferay-frontend:empty-result-message:actionDropdownItems");

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
@@ -27,7 +27,7 @@
 		</p>
 	</c:if>
 
-	<c:if test="<%= Validator.isNotNull(actionDropdownItems) %>">
+	<c:if test="<%= ListUtil.isNotEmpty(actionDropdownItems) %>">
 		<c:choose>
 			<c:when test="<%= actionDropdownItems.size() > 1 %>">
 				<clay:dropdown-menu


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93517

## What Is Being Fixed

Opening the Pages administration of a site template with no pages throws `java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0` when private layouts are disabled. The Pages admin passes a non-null but empty action dropdown item list to `liferay-frontend:empty-result-message`, whose JSP only null-checks the list before calling `actionDropdownItems.get(0)` (a site template group hides the public page action and disabled private layouts hide the private one, leaving zero items).

## How It Is Being Fixed

The taglib now treats an empty list like a null one: the guard switches from `Validator.isNotNull` to `ListUtil.isNotEmpty`, so the empty state renders without an action button instead of crashing. Fixing the taglib rather than the caller protects every consumer of the tag, mirroring the empty-menu check the management toolbar already performs.

## Why Are There No Tests?

JSP-only change with no unit-testable surface; verified manually against a running bundle (before: exception; after: the empty state renders correctly).