### PR TITLE
LPD-92713 Ai creator button should follow configuration settings

### DIFF
--- a/modules/apps/ai-creator/ai-creator-openai-test/src/testIntegration/java/com/liferay/ai/creator/openai/web/internal/editor/configuration/test/AICreatorOpenAIEditorConfigurationTest.java
+++ b/modules/apps/ai-creator/ai-creator-openai-test/src/testIntegration/java/com/liferay/ai/creator/openai/web/internal/editor/configuration/test/AICreatorOpenAIEditorConfigurationTest.java
@@ -6,7 +6,6 @@
 package com.liferay.ai.creator.openai.web.internal.editor.configuration.test;
 
 import com.liferay.ai.creator.openai.configuration.manager.AICreatorOpenAIConfigurationManager;
-import com.liferay.ai.creator.openai.manager.AICreatorOpenAIManager;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
@@ -27,10 +26,11 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -79,6 +79,48 @@ public class AICreatorOpenAIEditorConfigurationTest {
 	}
 
 	@Test
+	public void testAICreatorCKEditor5ConfigCompanyAndGroupEnabledJournalPortlet()
+		throws Exception {
+
+		_aiCreatorOpenAIConfigurationManager.
+			saveAICreatorOpenAICompanyConfiguration(
+				_group.getCompanyId(), RandomTestUtil.randomString(), true,
+				true);
+		_aiCreatorOpenAIConfigurationManager.
+			saveAICreatorOpenAIGroupConfiguration(
+				_group.getGroupId(), RandomTestUtil.randomString(), true, true);
+
+		_assertCKEditor5EditorConfigurationConfigJSONObject(
+			true, JournalPortletKeys.JOURNAL);
+	}
+
+	@Test
+	public void testAICreatorCKEditor5ConfigCompanyAndGroupEnabledNoJournalPortlet()
+		throws Exception {
+
+		_aiCreatorOpenAIConfigurationManager.
+			saveAICreatorOpenAICompanyConfiguration(
+				_group.getCompanyId(), RandomTestUtil.randomString(), true,
+				true);
+		_aiCreatorOpenAIConfigurationManager.
+			saveAICreatorOpenAIGroupConfiguration(
+				_group.getGroupId(), RandomTestUtil.randomString(), true, true);
+
+		_assertCKEditor5EditorConfigurationConfigJSONObject(
+			false, RandomTestUtil.randomString());
+	}
+
+	@Test
+	public void testAICreatorCKEditor5ConfigCompanyDisabled() throws Exception {
+		_aiCreatorOpenAIConfigurationManager.
+			saveAICreatorOpenAICompanyConfiguration(
+				_group.getCompanyId(), StringPool.BLANK, false, false);
+
+		_assertCKEditor5EditorConfigurationConfigJSONObject(
+			false, RandomTestUtil.randomString());
+	}
+
+	@Test
 	public void testAICreatorToolbarCompanyAndGroupEnabledWithAPIKeyInCompany()
 		throws Exception {
 
@@ -92,7 +134,7 @@ public class AICreatorOpenAIEditorConfigurationTest {
 				_group.getGroupId(), StringPool.BLANK, true, true);
 
 		_assertEditorConfigurationConfigJSONObject(
-			true, true, JournalPortletKeys.JOURNAL);
+			true, true, true, JournalPortletKeys.JOURNAL);
 	}
 
 	@Test
@@ -107,7 +149,7 @@ public class AICreatorOpenAIEditorConfigurationTest {
 				_group.getGroupId(), RandomTestUtil.randomString(), true, true);
 
 		_assertEditorConfigurationConfigJSONObject(
-			true, true, JournalPortletKeys.JOURNAL);
+			true, true, true, JournalPortletKeys.JOURNAL);
 	}
 
 	@Test
@@ -123,7 +165,7 @@ public class AICreatorOpenAIEditorConfigurationTest {
 				_group.getGroupId(), RandomTestUtil.randomString(), true, true);
 
 		_assertEditorConfigurationConfigJSONObject(
-			false, false, RandomTestUtil.randomString());
+			false, false, false, RandomTestUtil.randomString());
 	}
 
 	@Test
@@ -138,7 +180,7 @@ public class AICreatorOpenAIEditorConfigurationTest {
 				_group.getGroupId(), StringPool.BLANK, true, true);
 
 		_assertEditorConfigurationConfigJSONObject(
-			false, true, JournalPortletKeys.JOURNAL);
+			false, true, true, JournalPortletKeys.JOURNAL);
 	}
 
 	@Test
@@ -154,7 +196,7 @@ public class AICreatorOpenAIEditorConfigurationTest {
 				false);
 
 		_assertEditorConfigurationConfigJSONObject(
-			false, false, JournalPortletKeys.JOURNAL);
+			false, false, false, JournalPortletKeys.JOURNAL);
 	}
 
 	@Test
@@ -171,27 +213,19 @@ public class AICreatorOpenAIEditorConfigurationTest {
 				false);
 
 		_assertEditorConfigurationConfigJSONObject(
-			false, false, JournalPortletKeys.JOURNAL);
+			false, false, false, JournalPortletKeys.JOURNAL);
 	}
 
-	private void _assertEditorConfigurationConfigJSONObject(
-			boolean expectedAPIKey, boolean expectedEnabled, String portletId)
+	private void _assertCKEditor5EditorConfigurationConfigJSONObject(
+			boolean expectedEnabled, String portletId)
 		throws Exception {
 
-		ThemeDisplay themeDisplay = _getThemeDisplay();
+		ThemeDisplay themeDisplay = _getThemeDisplay(portletId);
 
 		EditorConfiguration editorConfiguration =
 			EditorConfigurationFactoryUtil.getEditorConfiguration(
-				portletId, "rich_text", "ckeditor_classic",
-				HashMapBuilder.<String, Object>put(
-					"liferay-ui:input-editor:name", "testEditor"
-				).put(
-					"liferay-ui:input-editor:showAICreator",
-					_aiCreatorOpenAIManager.isAICreatorToolbarEnabled(
-						_group.getCompanyId(), _group.getGroupId(),
-						_portal.getPortletNamespace(portletId))
-				).build(),
-				themeDisplay,
+				portletId, RandomTestUtil.randomString(), "ckeditor5_classic",
+				new HashMap<String, Object>(), themeDisplay,
 				RequestBackedPortletURLFactoryUtil.create(
 					themeDisplay.getRequest()));
 
@@ -204,26 +238,62 @@ public class AICreatorOpenAIEditorConfigurationTest {
 		Assert.assertEquals(
 			expectedEnabled, configJSONObject.has("isAICreatorOpenAIAPIKey"));
 		Assert.assertEquals(
-			expectedAPIKey && expectedEnabled,
+			expectedEnabled, configJSONObject.has("showAICreator"));
+	}
+
+	private void _assertEditorConfigurationConfigJSONObject(
+			boolean expectedAPIKey, boolean expectedAICreatorConfig,
+			boolean expectedAICreatorToolbar, String portletId)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(portletId);
+
+		EditorConfiguration editorConfiguration =
+			EditorConfigurationFactoryUtil.getEditorConfiguration(
+				portletId, "rich_text", "ckeditor_classic",
+				HashMapBuilder.<String, Object>put(
+					"liferay-ui:input-editor:name", "testEditor"
+				).build(),
+				themeDisplay,
+				RequestBackedPortletURLFactoryUtil.create(
+					themeDisplay.getRequest()));
+
+		JSONObject configJSONObject = editorConfiguration.getConfigJSONObject();
+
+		Assert.assertEquals(
+			expectedAICreatorConfig,
+			configJSONObject.has("aiCreatorOpenAIURL"));
+		Assert.assertEquals(
+			expectedAICreatorConfig,
+			configJSONObject.has("aiCreatorPortletNamespace"));
+		Assert.assertEquals(
+			expectedAICreatorConfig,
+			configJSONObject.has("isAICreatorOpenAIAPIKey"));
+		Assert.assertEquals(
+			expectedAPIKey && expectedAICreatorConfig,
 			configJSONObject.getBoolean("isAICreatorOpenAIAPIKey"));
+		Assert.assertEquals(
+			expectedAICreatorConfig, configJSONObject.has("showAICreator"));
 
 		String extraPlugins = configJSONObject.getString("extraPlugins");
 
 		Assert.assertNotNull(extraPlugins);
 		Assert.assertEquals(
-			expectedEnabled, extraPlugins.contains("aicreator"));
+			expectedAICreatorToolbar, extraPlugins.contains("aicreator"));
 
 		Assert.assertEquals(
-			expectedEnabled, _isAICreatorInToolbars(configJSONObject));
+			expectedAICreatorToolbar, _isAICreatorInToolbars(configJSONObject));
 	}
 
-	private ThemeDisplay _getThemeDisplay() throws Exception {
+	private ThemeDisplay _getThemeDisplay(String portletId) throws Exception {
 		Layout layout = LayoutTestUtil.addTypePortletLayout(
 			_group.getGroupId());
 
 		ThemeDisplay themeDisplay = ContentLayoutTestUtil.getThemeDisplay(
 			_companyLocalService.getCompany(_group.getCompanyId()), _group,
 			layout);
+
+		themeDisplay.setPpid(portletId);
 
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
@@ -273,9 +343,6 @@ public class AICreatorOpenAIEditorConfigurationTest {
 		_aiCreatorOpenAIConfigurationManager;
 
 	@Inject
-	private AICreatorOpenAIManager _aiCreatorOpenAIManager;
-
-	@Inject
 	private CompanyLocalService _companyLocalService;
 
 	private Group _group;
@@ -286,8 +353,5 @@ public class AICreatorOpenAIEditorConfigurationTest {
 	private String _originalAPIKey;
 	private boolean _originalChatGPTEnabled;
 	private boolean _originalDALLEEnabled;
-
-	@Inject
-	private Portal _portal;
 
 }

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/editor/configuration/AICreatorOpenAIEditorConfigContributor.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/editor/configuration/AICreatorOpenAIEditorConfigContributor.java
@@ -6,10 +6,13 @@
 package com.liferay.ai.creator.openai.web.internal.editor.configuration;
 
 import com.liferay.ai.creator.openai.configuration.manager.AICreatorOpenAIConfigurationManager;
+import com.liferay.ai.creator.openai.manager.AICreatorOpenAIManager;
 import com.liferay.ai.creator.openai.web.internal.constants.AICreatorOpenAIPortletKeys;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
@@ -17,7 +20,6 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -33,8 +35,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"editor.config.key=rich_text", "editor.name=ckeditor_classic",
-		"editor.name=ckeditor5_classic"
+		"editor.name=ckeditor_classic", "editor.name=ckeditor5_classic",
+		"service.ranking:Integer=101"
 	},
 	service = EditorConfigContributor.class
 )
@@ -47,9 +49,9 @@ public class AICreatorOpenAIEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		if (!_isAICreatorChatGPTGroupEnabled(
-				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId()) ||
-			!_isShowAICreator(inputEditorTaglibAttributes)) {
+		if (!_aiCreatorOpenAIManager.isAICreatorToolbarEnabled(
+				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),
+				_portal.getPortletNamespace(themeDisplay.getPpid()))) {
 
 			return;
 		}
@@ -93,34 +95,52 @@ public class AICreatorOpenAIEditorConfigContributor
 
 				return false;
 			}
+		).put(
+			"showAICreator", true
 		);
+
+		// CKEditor 4 (ckeditor_classic) renders the AI Creator button from the
+		// "aicreator" plugin and a toolbar item. CKEditor 5 (ckeditor5_classic)
+		// reads the "showAICreator" configuration directly, so only the classic
+		// editor populates "extraPlugins".
+
+		String extraPlugins = jsonObject.getString("extraPlugins");
+
+		if (Validator.isNotNull(extraPlugins)) {
+			jsonObject.put("extraPlugins", extraPlugins + ",aicreator");
+
+			_addAICreatorToolbarItem(jsonObject);
+		}
 	}
 
-	private boolean _isAICreatorChatGPTGroupEnabled(
-		long companyId, long groupId) {
+	private void _addAICreatorToolbarItem(JSONObject jsonObject) {
+		for (String key : jsonObject.keySet()) {
+			if (!key.startsWith("toolbar_")) {
+				continue;
+			}
 
-		try {
-			if (_aiCreatorOpenAIConfigurationManager.
-					isAICreatorChatGPTGroupEnabled(companyId, groupId)) {
+			JSONArray toolbarJSONArray = jsonObject.getJSONArray(key);
+
+			if ((toolbarJSONArray != null) &&
+				!_hasAICreatorToolbarItem(toolbarJSONArray)) {
+
+				toolbarJSONArray.put(toJSONArray("['AICreator']"));
+			}
+		}
+	}
+
+	private boolean _hasAICreatorToolbarItem(JSONArray toolbarJSONArray) {
+		for (int i = 0; i < toolbarJSONArray.length(); i++) {
+			JSONArray itemJSONArray = toolbarJSONArray.getJSONArray(i);
+
+			if ((itemJSONArray != null) &&
+				JSONUtil.hasValue(itemJSONArray, "AICreator")) {
 
 				return true;
 			}
 		}
-		catch (ConfigurationException configurationException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(configurationException);
-			}
-		}
 
 		return false;
-	}
-
-	private boolean _isShowAICreator(
-		Map<String, Object> inputEditorTaglibAttributes) {
-
-		return GetterUtil.getBoolean(
-			inputEditorTaglibAttributes.get(
-				"liferay-ui:input-editor:showAICreator"));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -129,6 +149,9 @@ public class AICreatorOpenAIEditorConfigContributor
 	@Reference
 	private AICreatorOpenAIConfigurationManager
 		_aiCreatorOpenAIConfigurationManager;
+
+	@Reference
+	private AICreatorOpenAIManager _aiCreatorOpenAIManager;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/build.gradle
@@ -8,7 +8,6 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
-	compileOnly project(":apps:ai-creator:ai-creator-openai-api")
 	compileOnly project(":apps:captcha:captcha-taglib")
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:document-library:document-library-api")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributor.java
@@ -5,7 +5,6 @@
 
 package com.liferay.dynamic.data.mapping.form.field.type.internal.rich.text;
 
-import com.liferay.ai.creator.openai.manager.AICreatorOpenAIManager;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTemplateContextContributor;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.form.field.type.internal.util.DDMFormFieldTypeUtil;
@@ -30,7 +29,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Carlos Lancha
@@ -117,12 +115,6 @@ public class RichTextDDMFormFieldTemplateContextContributor
 				).put(
 					"liferay-ui:input-editor:name",
 					ddmFormFieldRenderingContext.getName()
-				).put(
-					"liferay-ui:input-editor:showAICreator",
-					_aiCreatorOpenAIManager.isAICreatorToolbarEnabled(
-						themeDisplay.getCompanyId(),
-						themeDisplay.getScopeGroupId(),
-						ddmFormFieldRenderingContext.getPortletNamespace())
 				).build(),
 				themeDisplay,
 				RequestBackedPortletURLFactoryUtil.create(httpServletRequest));
@@ -158,8 +150,5 @@ public class RichTextDDMFormFieldTemplateContextContributor
 		return localizedValue.getString(
 			ddmFormFieldRenderingContext.getLocale());
 	}
-
-	@Reference
-	private AICreatorOpenAIManager _aiCreatorOpenAIManager;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributorTest.java
@@ -5,13 +5,11 @@
 
 package com.liferay.dynamic.data.mapping.form.field.type.internal.rich.text;
 
-import com.liferay.ai.creator.openai.manager.AICreatorOpenAIManager;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -22,7 +20,6 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,23 +38,6 @@ public class RichTextDDMFormFieldTemplateContextContributorTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
-
-	@Before
-	public void setUp() throws Exception {
-		AICreatorOpenAIManager aiCreatorOpenAIManager = Mockito.mock(
-			AICreatorOpenAIManager.class);
-
-		Mockito.when(
-			aiCreatorOpenAIManager.isAICreatorToolbarEnabled(
-				Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString())
-		).thenReturn(
-			RandomTestUtil.randomBoolean()
-		);
-
-		ReflectionTestUtil.setFieldValue(
-			_richTextDDMFormFieldTemplateContextContributor,
-			"_aiCreatorOpenAIManager", aiCreatorOpenAIManager);
-	}
 
 	@After
 	public void tearDown() {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -63,10 +63,6 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			extraPlugins += ",ajaxsave,restore";
 		}
 
-		if (_isShowAICreator(inputEditorTaglibAttributes)) {
-			extraPlugins += ",aicreator";
-		}
-
 		jsonObject.put(
 			"applicationTitle",
 			_language.get(themeDisplay.getLocale(), "rich-text-editor")
@@ -186,14 +182,6 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 
 				return null;
 			}
-		).put(
-			() -> {
-				if (_isShowAICreator(inputEditorTaglibAttributes)) {
-					return toJSONArray("['AICreator']");
-				}
-
-				return null;
-			}
 		);
 	}
 
@@ -217,14 +205,6 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 
 				return null;
 			}
-		).put(
-			() -> {
-				if (_isShowAICreator(inputEditorTaglibAttributes)) {
-					return toJSONArray("['AICreator']");
-				}
-
-				return null;
-			}
 		);
 	}
 
@@ -244,23 +224,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 
 				return null;
 			}
-		).put(
-			() -> {
-				if (_isShowAICreator(inputEditorTaglibAttributes)) {
-					return toJSONArray("['AICreator']");
-				}
-
-				return null;
-			}
 		);
-	}
-
-	private boolean _isShowAICreator(
-		Map<String, Object> inputEditorTaglibAttributes) {
-
-		return GetterUtil.getBoolean(
-			inputEditorTaglibAttributes.get(
-				CKEditorConstants.ATTRIBUTE_NAMESPACE + ":showAICreator"));
 	}
 
 	@Reference

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/BalloonEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/BalloonEditor.tsx
@@ -40,6 +40,7 @@ const BalloonEditor = ({
 				...getDefaultEditorConfig({
 					editorVariant: EEditorVariant.BALLOON,
 					preset: config?.preset || EEditorConfigPreset.ADVANCED,
+					showAICreator: config?.showAICreator,
 				}),
 				...config,
 			}}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
@@ -46,6 +46,7 @@ const ClassicEditor = ({
 				...getDefaultEditorConfig({
 					editorVariant: EEditorVariant.CLASSIC,
 					preset: config?.preset || EEditorConfigPreset.ADVANCED,
+					showAICreator: config?.showAICreator,
 				}),
 				...config,
 			}}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
@@ -56,9 +56,11 @@ import {EEditorConfigPreset, EEditorVariant} from './types';
 const getDefaultEditorConfig = ({
 	editorVariant,
 	preset,
+	showAICreator,
 }: {
 	editorVariant: EEditorVariant;
 	preset: EEditorConfigPreset;
+	showAICreator?: boolean;
 }): EditorConfig => {
 	const basicPlugins = [
 		BlockToolbar,
@@ -127,7 +129,6 @@ const getDefaultEditorConfig = ({
 
 	const advancedPlugins = [
 		...basicPlugins,
-		AICreator,
 		Alignment,
 		BlockQuote,
 		Font,
@@ -151,6 +152,10 @@ const getDefaultEditorConfig = ({
 		TableProperties,
 		TableToolbar,
 	];
+
+	if (showAICreator) {
+		advancedPlugins.push(AICreator);
+	}
 
 	if (editorVariant === EEditorVariant.CLASSIC) {
 		advancedPlugins.push(SourceEditing);
@@ -196,9 +201,12 @@ const getDefaultEditorConfig = ({
 		'horizontalLine',
 		'|',
 		'alignment',
-		'|',
-		'aiCreator',
 	];
+
+	if (showAICreator) {
+		toolbarItems.push('|');
+		toolbarItems.push('aiCreator');
+	}
 
 	if (editorVariant === EEditorVariant.CLASSIC) {
 		toolbarItems.push('|');

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
@@ -33,6 +33,7 @@ export interface LiferayEditorConfig extends EditorConfig {
 	itemSelectorEventName?: string;
 	itemSelectorRememberSelectionFolder?: boolean;
 	preset?: EEditorConfigPreset;
+	showAICreator?: boolean;
 }
 
 export type TEditor = BalloonEditor | ClassicEditor;

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
@@ -62,7 +62,6 @@ test(
 				'Video',
 				'Horizontal line',
 				'Text alignment',
-				'AI Creator',
 				'Source',
 			];
 
@@ -75,7 +74,7 @@ test(
 		await test.step('Toolbar buttons have Clay icons', async () => {
 			await expect(
 				classicPage.toolbar.container.locator('svg use[href*="/clay/"]')
-			).toHaveCount(23);
+			).toHaveCount(22);
 		});
 	}
 );
@@ -288,27 +287,10 @@ test(
 	}
 );
 
-test('Open AI Creator popover', async ({classicPage, page}) => {
-	const AICreatorButton = classicPage.toolbar.container.getByRole('button', {
-		name: 'Create AI Content',
-	});
-
-	await AICreatorButton.click();
-
-	await expect(page.getByText('Configure OpenAI')).toBeVisible();
-});
-
 test(
 	'Opening source editing disables all custom controls',
 	{tag: '@LPD-11235'},
 	async ({classicPage}) => {
-		const AICreatorButton = classicPage.toolbar.container.getByRole(
-			'button',
-			{
-				name: 'Create AI Content',
-			}
-		);
-
 		const imageButton = classicPage.toolbar.container.getByRole('button', {
 			name: 'Image',
 		});
@@ -321,13 +303,11 @@ test(
 
 		await sourceButton.click();
 
-		await expect(AICreatorButton).toBeDisabled();
 		await expect(imageButton).toBeDisabled();
 		await expect(videoButton).toBeDisabled();
 
 		await sourceButton.click();
 
-		await expect(AICreatorButton).toBeEnabled();
 		await expect(imageButton).toBeEnabled();
 		await expect(videoButton).toBeEnabled();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92713
https://liferay.atlassian.net/browse/LPP-64251

The Ai Creator button is displayed when the `Enable ChatGPT to Create Content` setting is disabled. This was an oversight as this works in CKE4 but was never implemented into CKE5.

In order to do this, I had to remove `"editor.config.key=rich_text"` in AICreatorOpenAIEditorConfigContributor.java so that other editors will display the button and not just rich_text editors. Then I added `showAICreator` to add the button if enabled or leave it out if disabled.

Please let me know if there are any questions or comments about this.
Thank you!