### PR TITLE
LPD-88400 Make legacy Poshi tests use CKEditor 4

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -16907,8 +16907,6 @@ jdbc.default.password=${database.mysql.password}</echo>
 			<arg value="${default.portal.url}/o/headless-portal-instances/v1.0/portal-instances" />
 		</exec>
 
-		<echo>JSON: ${json}</echo>
-
 		<beanshell>
 			<![CDATA[
 				String json = project.getProperty("json");
@@ -16923,8 +16921,6 @@ jdbc.default.password=${database.mysql.password}</echo>
 				}
 			]]>
 		</beanshell>
-
-		<echo>Company Id: ${companyId}</echo>
 
 		<exec executable="curl" failonerror="true">
 			<arg value="-f" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -557,6 +557,38 @@ passwords.encryption.algorithm=NONE</echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="enable-ckeditor4">
+		<sequential>
+			<local name="company.id" />
+			<local name="portal.instances.json" />
+
+			<exec executable="curl" failonerror="true" outputproperty="portal.instances.json">
+				<arg value="-f" />
+				<arg value="-s" />
+				<arg value="-u" />
+				<arg value="test@liferay.com:${test.portal.default.admin.password}" />
+				<arg value="${default.portal.url}/o/headless-portal-instances/v1.0/portal-instances" />
+			</exec>
+
+			<propertyregex
+				input="${portal.instances.json}"
+				property="company.id"
+				regexp="&quot;companyId&quot;\s*:\s*&quot;?(\d+)"
+				select="\1"
+			/>
+
+			<exec executable="curl" failonerror="true">
+				<arg value="-d" />
+				<arg value="companyId=${company.id}&amp;enabled=true&amp;key=LPD-11235" />
+				<arg value="-f" />
+				<arg value="-s" />
+				<arg value="-u" />
+				<arg value="test@liferay.com:${test.portal.default.admin.password}" />
+				<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
+			</exec>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="export-database-mysql">
 		<attribute default="mysql" name="database.file.prefix" />
 		<attribute default="lportal" name="database.schema.name" />
@@ -813,38 +845,6 @@ passwords.encryption.algorithm=NONE</echo>
 			/>
 
 			<delete failonerror="false" file="${project.dir}/export_database_postgresql_export.sh" />
-		</sequential>
-	</macrodef>
-
-	<macrodef name="force-feature-flag-LPD-11235">
-		<sequential>
-			<local name="company.id" />
-			<local name="portal.instances.json" />
-
-			<exec executable="curl" failonerror="true" outputproperty="portal.instances.json">
-				<arg value="-f" />
-				<arg value="-s" />
-				<arg value="-u" />
-				<arg value="test@liferay.com:${test.portal.default.admin.password}" />
-				<arg value="${default.portal.url}/o/headless-portal-instances/v1.0/portal-instances" />
-			</exec>
-
-			<propertyregex
-				input="${portal.instances.json}"
-				property="company.id"
-				regexp="&quot;companyId&quot;\s*:\s*&quot;?(\d+)"
-				select="\1"
-			/>
-
-			<exec executable="curl" failonerror="true">
-				<arg value="-d" />
-				<arg value="companyId=${company.id}&amp;enabled=true&amp;key=LPD-11235" />
-				<arg value="-f" />
-				<arg value="-s" />
-				<arg value="-u" />
-				<arg value="test@liferay.com:${test.portal.default.admin.password}" />
-				<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
-			</exec>
 		</sequential>
 	</macrodef>
 
@@ -16833,7 +16833,7 @@ if (ppstate.equals("normal")) {
 	</target>
 
 	<target depends="prepare-selenium" name="run-selenium-test">
-		<force-feature-flag-LPD-11235 />
+		<enable-ckeditor4 />
 
 		<if>
 			<and>

--- a/build-test.xml
+++ b/build-test.xml
@@ -16896,43 +16896,47 @@ jdbc.default.password=${database.mysql.password}</echo>
 	-->
 
 	<target name="force-feature-flag-LPD-11235">
-		<exec executable="curl" failonerror="false" outputproperty="force.ff.company.json">
+		<local name="json" />
+		<local name="companyId" />
+
+		<exec executable="curl" failonerror="true" outputproperty="json">
+			<arg value="-f" />
 			<arg value="-s" />
 			<arg value="-u" />
 			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
 			<arg value="${default.portal.url}/o/headless-portal-instances/v1.0/portal-instances" />
 		</exec>
 
+		<echo>JSON: ${json}</echo>
+
 		<beanshell>
 			<![CDATA[
-				String json = project.getProperty("force.ff.company.json");
+				String json = project.getProperty("json");
 
 				if (json != null) {
 					java.util.regex.Matcher matcher =
-						java.util.regex.Pattern.compile("\"id\"\\s*:\\s*\"?(\\d+)").matcher(json);
+						java.util.regex.Pattern.compile("\"companyId\"\\s*:\\s*\"?(\\d+)").matcher(json);
 
 					if (matcher.find()) {
-						project.setProperty("force.ff.companyId", matcher.group(1));
+						project.setProperty("companyId", matcher.group(1));
 					}
 				}
 			]]>
 		</beanshell>
 
-		<if>
-			<isset property="force.ff.companyId" />
-			<then>
-				<exec executable="curl" failonerror="false">
-					<arg value="-s" />
-					<arg value="-X" />
-					<arg value="POST" />
-					<arg value="-u" />
-					<arg value="test@liferay.com:${test.portal.default.admin.password}" />
-					<arg value="-d" />
-					<arg value="companyId=${force.ff.companyId}&amp;key=LPD-11235&amp;enabled=true" />
-					<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
-				</exec>
-			</then>
-		</if>
+		<echo>Company Id: ${companyId}</echo>
+
+		<exec executable="curl" failonerror="true">
+			<arg value="-f" />
+			<arg value="-s" />
+			<arg value="-X" />
+			<arg value="POST" />
+			<arg value="-u" />
+			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
+			<arg value="-d" />
+			<arg value="companyId=${companyId}&amp;key=LPD-11235&amp;enabled=true" />
+			<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
+		</exec>
 	</target>
 
 	<target name="run-simple-server">

--- a/build-test.xml
+++ b/build-test.xml
@@ -577,6 +577,8 @@ passwords.encryption.algorithm=NONE</echo>
 				select="\1"
 			/>
 
+			<fail message="Unable to get company ID" unless="company.id" />
+
 			<exec executable="curl" failonerror="true">
 				<arg value="-d" />
 				<arg value="companyId=${company.id}&amp;enabled=true&amp;key=LPD-11235" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -16800,7 +16800,7 @@ if (ppstate.equals("normal")) {
 		<poshi-execute failonerror="true" task="validatePoshi" />
 	</target>
 
-	<target depends="prepare-selenium" name="run-selenium-test">
+	<target depends="prepare-selenium,force-feature-flag-LPD-11235" name="run-selenium-test">
 		<if>
 			<and>
 				<equals arg1="${test.class}" arg2="PortalWebTestSuite" />
@@ -17708,8 +17708,6 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 				</echo>
 			</then>
 		</if>
-
-		<antcall target="force-feature-flag-LPD-11235" />
 
 		<get-testcase-property property.name="skip.run.selenium.test" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -16911,12 +16911,12 @@ jdbc.default.password=${database.mysql.password}</echo>
 		/>
 
 		<exec executable="curl" failonerror="true">
+			<arg value="-d" />
+			<arg value="companyId=${company.id}&amp;key=LPD-11235&amp;enabled=true" />
 			<arg value="-f" />
 			<arg value="-s" />
 			<arg value="-u" />
 			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
-			<arg value="-d" />
-			<arg value="companyId=${company.id}&amp;key=LPD-11235&amp;enabled=true" />
 			<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
 		</exec>
 	</target>

--- a/build-test.xml
+++ b/build-test.xml
@@ -16913,8 +16913,6 @@ jdbc.default.password=${database.mysql.password}</echo>
 		<exec executable="curl" failonerror="true">
 			<arg value="-f" />
 			<arg value="-s" />
-			<arg value="-X" />
-			<arg value="POST" />
 			<arg value="-u" />
 			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
 			<arg value="-d" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -16891,6 +16891,50 @@ jdbc.default.password=${database.mysql.password}</echo>
 		<antcall target="clean-up-selenium-driver" />
 	</target>
 
+	<!--
+	LPD-88400 Make legacy Poshi tests use CKEditor 4 (enable LPD-11235 (CKEditor 4) per company)
+	-->
+
+	<target name="force-feature-flag-LPD-11235">
+		<exec executable="curl" failonerror="false" outputproperty="force.ff.company.json">
+			<arg value="-s" />
+			<arg value="-u" />
+			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
+			<arg value="${default.portal.url}/o/headless-portal-instances/v1.0/portal-instances" />
+		</exec>
+
+		<beanshell>
+			<![CDATA[
+				String json = project.getProperty("force.ff.company.json");
+
+				if (json != null) {
+					java.util.regex.Matcher matcher =
+						java.util.regex.Pattern.compile("\"id\"\\s*:\\s*\"?(\\d+)").matcher(json);
+
+					if (matcher.find()) {
+						project.setProperty("force.ff.companyId", matcher.group(1));
+					}
+				}
+			]]>
+		</beanshell>
+
+		<if>
+			<isset property="force.ff.companyId" />
+			<then>
+				<exec executable="curl" failonerror="false">
+					<arg value="-s" />
+					<arg value="-X" />
+					<arg value="POST" />
+					<arg value="-u" />
+					<arg value="test@liferay.com:${test.portal.default.admin.password}" />
+					<arg value="-d" />
+					<arg value="companyId=${force.ff.companyId}&amp;key=LPD-11235&amp;enabled=true" />
+					<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
+				</exec>
+			</then>
+		</if>
+	</target>
+
 	<target name="run-simple-server">
 		<if>
 			<not>
@@ -17664,6 +17708,8 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 				</echo>
 			</then>
 		</if>
+
+		<antcall target="force-feature-flag-LPD-11235" />
 
 		<get-testcase-property property.name="skip.run.selenium.test" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -16896,10 +16896,10 @@ jdbc.default.password=${database.mysql.password}</echo>
 	-->
 
 	<target name="force-feature-flag-LPD-11235">
-		<local name="json" />
-		<local name="companyId" />
+		<local name="company.id" />
+		<local name="portal.instances.json" />
 
-		<exec executable="curl" failonerror="true" outputproperty="json">
+		<exec executable="curl" failonerror="true" outputproperty="portal.instances.json">
 			<arg value="-f" />
 			<arg value="-s" />
 			<arg value="-u" />
@@ -16907,20 +16907,12 @@ jdbc.default.password=${database.mysql.password}</echo>
 			<arg value="${default.portal.url}/o/headless-portal-instances/v1.0/portal-instances" />
 		</exec>
 
-		<beanshell>
-			<![CDATA[
-				String json = project.getProperty("json");
-
-				if (json != null) {
-					java.util.regex.Matcher matcher =
-						java.util.regex.Pattern.compile("\"companyId\"\\s*:\\s*\"?(\\d+)").matcher(json);
-
-					if (matcher.find()) {
-						project.setProperty("companyId", matcher.group(1));
-					}
-				}
-			]]>
-		</beanshell>
+		<propertyregex
+			input="${portal.instances.json}"
+			property="company.id"
+			regexp="&quot;companyId&quot;\s*:\s*&quot;?(\d+)"
+			select="\1"
+		/>
 
 		<exec executable="curl" failonerror="true">
 			<arg value="-f" />
@@ -16930,7 +16922,7 @@ jdbc.default.password=${database.mysql.password}</echo>
 			<arg value="-u" />
 			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
 			<arg value="-d" />
-			<arg value="companyId=${companyId}&amp;key=LPD-11235&amp;enabled=true" />
+			<arg value="companyId=${company.id}&amp;key=LPD-11235&amp;enabled=true" />
 			<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
 		</exec>
 	</target>

--- a/build-test.xml
+++ b/build-test.xml
@@ -816,6 +816,38 @@ passwords.encryption.algorithm=NONE</echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="force-feature-flag-LPD-11235">
+		<sequential>
+			<local name="company.id" />
+			<local name="portal.instances.json" />
+
+			<exec executable="curl" failonerror="true" outputproperty="portal.instances.json">
+				<arg value="-f" />
+				<arg value="-s" />
+				<arg value="-u" />
+				<arg value="test@liferay.com:${test.portal.default.admin.password}" />
+				<arg value="${default.portal.url}/o/headless-portal-instances/v1.0/portal-instances" />
+			</exec>
+
+			<propertyregex
+				input="${portal.instances.json}"
+				property="company.id"
+				regexp="&quot;companyId&quot;\s*:\s*&quot;?(\d+)"
+				select="\1"
+			/>
+
+			<exec executable="curl" failonerror="true">
+				<arg value="-d" />
+				<arg value="companyId=${company.id}&amp;enabled=true&amp;key=LPD-11235" />
+				<arg value="-f" />
+				<arg value="-s" />
+				<arg value="-u" />
+				<arg value="test@liferay.com:${test.portal.default.admin.password}" />
+				<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
+			</exec>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="generate-gulp-user-config-json">
 		<attribute name="portlet.name" />
 
@@ -16800,7 +16832,9 @@ if (ppstate.equals("normal")) {
 		<poshi-execute failonerror="true" task="validatePoshi" />
 	</target>
 
-	<target depends="prepare-selenium,force-feature-flag-LPD-11235" name="run-selenium-test">
+	<target depends="prepare-selenium" name="run-selenium-test">
+		<force-feature-flag-LPD-11235 />
+
 		<if>
 			<and>
 				<equals arg1="${test.class}" arg2="PortalWebTestSuite" />
@@ -16889,36 +16923,6 @@ jdbc.default.password=${database.mysql.password}</echo>
 		</if>
 
 		<antcall target="clean-up-selenium-driver" />
-	</target>
-
-	<target name="force-feature-flag-LPD-11235">
-		<local name="company.id" />
-		<local name="portal.instances.json" />
-
-		<exec executable="curl" failonerror="true" outputproperty="portal.instances.json">
-			<arg value="-f" />
-			<arg value="-s" />
-			<arg value="-u" />
-			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
-			<arg value="${default.portal.url}/o/headless-portal-instances/v1.0/portal-instances" />
-		</exec>
-
-		<propertyregex
-			input="${portal.instances.json}"
-			property="company.id"
-			regexp="&quot;companyId&quot;\s*:\s*&quot;?(\d+)"
-			select="\1"
-		/>
-
-		<exec executable="curl" failonerror="true">
-			<arg value="-d" />
-			<arg value="companyId=${company.id}&amp;enabled=true&amp;key=LPD-11235" />
-			<arg value="-f" />
-			<arg value="-s" />
-			<arg value="-u" />
-			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
-			<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
-		</exec>
 	</target>
 
 	<target name="run-simple-server">

--- a/build-test.xml
+++ b/build-test.xml
@@ -16912,7 +16912,7 @@ jdbc.default.password=${database.mysql.password}</echo>
 
 		<exec executable="curl" failonerror="true">
 			<arg value="-d" />
-			<arg value="companyId=${company.id}&amp;key=LPD-11235&amp;enabled=true" />
+			<arg value="companyId=${company.id}&amp;enabled=true&amp;key=LPD-11235" />
 			<arg value="-f" />
 			<arg value="-s" />
 			<arg value="-u" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -16891,10 +16891,6 @@ jdbc.default.password=${database.mysql.password}</echo>
 		<antcall target="clean-up-selenium-driver" />
 	</target>
 
-	<!--
-	LPD-88400 Make legacy Poshi tests use CKEditor 4 (enable LPD-11235 (CKEditor 4) per company)
-	-->
-
 	<target name="force-feature-flag-LPD-11235">
 		<local name="company.id" />
 		<local name="portal.instances.json" />


### PR DESCRIPTION
Reworks the CKEditor-4-for-Poshi change to address the format feedback on brianchandotcom#175511, keeping the mechanism Ivan verified against a baseline build: enable the LPD-11235 feature flag per company before each Poshi run (headless portal-instances lookup → feature-flag-web `set-enabled`).

Ivan's three original commits are preserved as the base; each cleanup is a separate commit on top:

- Removed the debug echoes, the explanatory comment, and the redundant `-X POST`.
- Replaced the BeanShell company-id parsing with the existing `<propertyregex>` idiom; `<fail>` with a clear message if it can't be parsed.
- Sorted the curl arguments and alphabetized the `set-enabled` form parameters.
- Converted the `force-feature-flag-LPD-11235` target to an `enable-ckeditor4` macrodef (alphabetical macrodef section), called inline from `run-selenium-test`.

Supersedes the portal-property variant in #5515 (which didn't enable the flag in our testing). Source formatter passes. CI-only — a Poshi batch run is the empirical confirmation.