### PR TITLE
LPD-93693 Apply aria-selected to tabs

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portal/tabs.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portal/tabs.es.js
@@ -68,9 +68,11 @@ export function applyTabSelectionDOMChanges({
 
 		if (activeTab) {
 			activeTab.classList.remove('active');
+			activeTab.setAttribute('aria-selected', 'false');
 		}
 
 		selectedTabLink.classList.add('active');
+		selectedTabLink.setAttribute('aria-selected', 'true');
 	}
 
 	if (selectedTabSection) {

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/portal/tabs.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/portal/tabs.es.js
@@ -53,13 +53,13 @@ describe('Liferay.Portal.Tabs.applyTabSelectionDOMChanges', () => {
 		document.body.innerHTML = `
 			<div>
 				<div id="${ids[0]}TabsId">
-					<a class="active">First</a>
+					<a aria-selected="true" class="active">First</a>
 				</div>
 				<div id="${ids[1]}TabsId">
-					<a><b>Second</b></a>
+					<a aria-selected="false"><b>Second</b></a>
 				</div>
 				<div id="${ids[2]}TabsId">
-					<a>Third</a>
+					<a aria-selected="false">Third</a>
 				</div>
 			<div>
 			<div>
@@ -85,6 +85,9 @@ describe('Liferay.Portal.Tabs.applyTabSelectionDOMChanges', () => {
 		expect(link1.classList.contains('active')).toBe(false);
 		expect(link2.classList.contains('active')).toBe(true);
 		expect(link3.classList.contains('active')).toBe(false);
+
+		expect(link1.getAttribute('aria-selected')).toBe('false');
+		expect(link2.getAttribute('aria-selected')).toBe('true');
 
 		const section1 = document.getElementById(`${ids[0]}TabsSection`);
 		const section2 = document.getElementById(`${ids[1]}TabsSection`);

--- a/portal-web/docroot/html/taglib/ui/tabs/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/tabs/start.jsp
@@ -194,7 +194,7 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ui:tabs
 
 		<li class="nav-item" data-tab-name="<%= names[i] %>" id="<%= namespace %><%= param %><%= StringUtil.toCharCode(values[i]) %>TabsId" role="none">
 			<liferay-ui:csp>
-				<a class="<%= linkCssClass %>" href="<%= Validator.isNotNull(curURL) ? HtmlUtil.escapeAttribute(curURL) : "javascript:void(0);" %>" onClick="<%= Validator.isNotNull(curOnClick) ? curOnClick : StringPool.BLANK %>" role="tab">
+				<a aria-selected="<%= selected %>" class="<%= linkCssClass %>" href="<%= Validator.isNotNull(curURL) ? HtmlUtil.escapeAttribute(curURL) : "javascript:void(0);" %>" onClick="<%= Validator.isNotNull(curOnClick) ? curOnClick : StringPool.BLANK %>" role="tab">
 					<liferay-ui:message key="<%= HtmlUtil.escape(names[i]) %>" />
 				</a>
 			</liferay-ui:csp>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93693

## What Is Being Fixed

The tab links rendered by the `liferay-ui:tabs` taglib carried `role="tab"` but no `aria-selected` state, so assistive technology and automated checks could not determine which tab was active. Selection was conveyed only through the `active` CSS class, which is invisible to the accessibility tree.

## How It Is Being Fixed

The tabs taglib `start.jsp` now renders `aria-selected` on each tab link, initialized from the server-side `selected` flag. On the client, `applyTabSelectionDOMChanges` keeps the attribute in sync: it sets `aria-selected="true"` on the newly selected tab and `aria-selected="false"` on the previously active one, alongside the existing `active` class toggling. The unit test for `applyTabSelectionDOMChanges` is extended to assert the `aria-selected` transitions.

## PR Check

**pr-check: SKIPPED** — pre-existing baseline Log4jConfigUtil coverage failure unrelated to this branch (diff touches only tabs JS/JSP)

<!-- pr-check {"reason": "pre-existing baseline Log4jConfigUtil coverage failure unrelated to this branch (diff touches only tabs JS/JSP)", "result": "skipped", "sha": "b5463de2b655e3173387c5968ed789a104294846"} -->