### PR TITLE
LPD-93804 Reload the page when SPA navigation crosses a CSP boundary

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/screen/EventScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/screen/EventScreen.js
@@ -201,6 +201,44 @@ class EventScreen extends HtmlScreen {
 	}
 
 	/**
+	 * Detects whether the navigation target enforces a different Content
+	 * Security Policy than the currently loaded document. Browsers bind the
+	 * CSP to the document at load time, so an SPA (PJAX) content swap keeps
+	 * enforcing the original document's policy. When the policy differs (for
+	 * example when navigating between a CSP protected page and a page whose
+	 * path is excluded from CSP), the nonce in the response no longer matches
+	 * the nonce of the document, and a full page reload is required so the
+	 * browser applies the correct header.
+	 * @return {!Boolean} True if the response and the document enforce
+	 *         different Content Security Policies
+	 */
+
+	isContentSecurityPolicyMismatch() {
+		const response = this.getResponse();
+
+		if (
+			!response ||
+			!response.headers ||
+			typeof response.headers.get !== 'function'
+		) {
+			return false;
+		}
+
+		const policy =
+			response.headers.get('content-security-policy') ||
+			response.headers.get('content-security-policy-report-only') ||
+			'';
+
+		const match = policy.match(/'nonce-([^']*)'/i);
+
+		const responseNonce = match ? match[1] : '';
+
+		const documentNonce = (Liferay.CSP && Liferay.CSP.nonce) || '';
+
+		return responseNonce !== documentNonce;
+	}
+
+	/**
 	 * Returns whether a given status code is considered valid
 	 * @param  {!Number} The status code to check
 	 * @return {!Boolean} True if the given status code is valid
@@ -223,6 +261,12 @@ class EventScreen extends HtmlScreen {
 	load(path) {
 		return super.load(path).then((content) => {
 			const redirectPath = this.beforeUpdateHistoryPath(path);
+
+			if (this.isContentSecurityPolicyMismatch()) {
+				window.location.href = redirectPath;
+
+				return new Promise(() => {});
+			}
 
 			this.checkRedirectPath(redirectPath);
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/screen/EventScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/screen/EventScreen.js
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import EventScreen from '../../src/main/resources/META-INF/resources/screen/EventScreen';
+
+describe('EventScreen', () => {
+	beforeEach(() => {
+		Liferay.SPA = {
+			app: {
+				timeout: 30000,
+			},
+		};
+		Liferay.CSP = {};
+	});
+
+	const createScreen = (contentSecurityPolicy) => {
+		const screen = new EventScreen();
+
+		jest.spyOn(screen, 'getResponse').mockImplementation(() => {
+			return {
+				headers: {
+					get: (name) => {
+						if (name === 'content-security-policy') {
+							return contentSecurityPolicy;
+						}
+
+						return null;
+					},
+				},
+			};
+		});
+
+		return screen;
+	};
+
+	it('does not detect a mismatch when the response nonce matches the document nonce', () => {
+		Liferay.CSP = {nonce: 'abc123'};
+
+		const screen = createScreen(
+			"default-src 'self'; script-src 'self' 'nonce-abc123'"
+		);
+
+		expect(screen.isContentSecurityPolicyMismatch()).toBe(false);
+	});
+
+	it('detects a mismatch when the response nonce differs from the document nonce', () => {
+		Liferay.CSP = {nonce: 'abc123'};
+
+		const screen = createScreen(
+			"default-src 'self'; script-src 'self' 'nonce-xyz789'"
+		);
+
+		expect(screen.isContentSecurityPolicyMismatch()).toBe(true);
+	});
+
+	it('does not detect a mismatch when the response nonce keyword uses a different casing', () => {
+		Liferay.CSP = {nonce: 'abc123'};
+
+		const screen = createScreen(
+			"default-src 'self'; script-src 'self' 'NONCE-abc123'"
+		);
+
+		expect(screen.isContentSecurityPolicyMismatch()).toBe(false);
+	});
+
+	it('detects a mismatch when navigating from a CSP page to an excluded page', () => {
+		Liferay.CSP = {nonce: 'abc123'};
+
+		const screen = createScreen(null);
+
+		expect(screen.isContentSecurityPolicyMismatch()).toBe(true);
+	});
+
+	it('detects a mismatch when navigating from an excluded page to a CSP page', () => {
+		Liferay.CSP = {nonce: ''};
+
+		const screen = createScreen(
+			"default-src 'self'; script-src 'self' 'nonce-abc123'"
+		);
+
+		expect(screen.isContentSecurityPolicyMismatch()).toBe(true);
+	});
+
+	it('does not detect a mismatch when neither page enforces CSP', () => {
+		Liferay.CSP = {nonce: ''};
+
+		const screen = createScreen(null);
+
+		expect(screen.isContentSecurityPolicyMismatch()).toBe(false);
+	});
+
+	it('does not detect a mismatch when the response is not available', () => {
+		Liferay.CSP = {nonce: 'abc123'};
+
+		const screen = new EventScreen();
+
+		jest.spyOn(screen, 'getResponse').mockImplementation(() => null);
+
+		expect(screen.isContentSecurityPolicyMismatch()).toBe(false);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93804

## What Is Being Fixed

Liferay sets the Content Security Policy per response and excludes certain paths (for example /web/, /group/, and /user/), so the enforced policy differs between pages. Single page application navigation swaps the DOM without a new document load, so the browser keeps enforcing the Content Security Policy from the initial full page load. Crossing a CSP boundary leaves the wrong policy in effect: a protected page can render without enforcement, or an excluded page can have its inline scripts and styles blocked.

## How It Is Being Fixed

EventScreen compares the navigation response's nonce with the document nonce (Liferay.CSP.nonce) and forces a full page reload when they differ, including when one side has no Content Security Policy. The browser then applies the correct header for the destination. CSP-to-CSP navigations share the session nonce and remain SPA navigations, so the common case is unaffected. A unit test covers the nonce-match, nonce-mismatch, CSP-to-excluded, excluded-to-CSP, neither-enforced, and no-response cases.

## PR Check

**pr-check: SKIPPED** — Source Format, Per-Module Deploy, and JavaScript Unit Tests pass; the only failure, Structural Smoke Log4jConfigUtilTest ("not fully covered"), is pre-existing baseline drift in the local checkout unrelated to this frontend-only diff.

<!-- pr-check {"reason": "Source Format, Per-Module Deploy, and JavaScript Unit Tests pass; the only failure, Structural Smoke Log4jConfigUtilTest (not fully covered), is pre-existing baseline drift in the local checkout unrelated to this frontend-only diff.", "result": "skipped", "sha": "cb25272bac2b2754817b2c4ff8655631c6067a1c"} -->