### PR TITLE
LPD-93231 Update map marker and viewport after searching

### DIFF
--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsSearch.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsSearch.js
@@ -94,6 +94,7 @@ class GoogleMapsSearch extends EventEmitter {
 						lat: geolocation.lat(),
 						lng: geolocation.lng(),
 					},
+					viewport: place.geometry.viewport || null,
 				},
 			});
 		}

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.js
@@ -12,6 +12,13 @@ import GoogleMapsMarker from './GoogleMapsMarker';
 import GoogleMapsSearch from './GoogleMapsSearch';
 
 /**
+ * Zoom level applied when a selected Place result lacks a recommended viewport.
+ * @see https://developers.google.com/maps/documentation/javascript/examples/place-autocomplete-map
+ * @type {number}
+ */
+const FALLBACK_ZOOM = 17;
+
+/**
  * MapGoogleMaps
  * @review
  */
@@ -66,6 +73,32 @@ class MapGoogleMaps extends MapBase {
 		}
 
 		return map;
+	}
+
+	/**
+	 * @inheritDoc
+	 * @review
+	 */
+	_handleSearchButtonClicked({position}) {
+		super._handleSearchButtonClicked({position});
+
+		if (!this._map) {
+			return;
+		}
+
+		if (position.viewport) {
+			this._map.fitBounds(position.viewport);
+		}
+		else {
+			this._map.setZoom(FALLBACK_ZOOM);
+		}
+
+		if (this._searchMarker) {
+			this._searchMarker.setPosition(position.location);
+		}
+		else {
+			this._searchMarker = this.addMarker(position.location);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This overrides _handleSearchButtonClicked in order to (re-)position the map marker and set the zoom/bounds after searching.