### PR TITLE
LPD-93943 Apply the CSP nonce to dynamic page editor style elements

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/CommonStylesManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/CommonStylesManager.js
@@ -139,6 +139,10 @@ function createOrUpdateStyleTag({globalContext, id, styleSheet}) {
 		styleTag.type = 'text/css';
 		styleTag.dataset.sennaTrack = 'temporary';
 
+		if (Liferay.CSP?.nonce) {
+			styleTag.setAttribute('nonce', Liferay.CSP.nonce);
+		}
+
 		globalContext.document.head.appendChild(styleTag);
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_content/FragmentContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_content/FragmentContent.js
@@ -297,7 +297,9 @@ const FragmentContent = ({
 				/>
 
 				{backgroundImageValue.mediaQueries ? (
-					<style>{backgroundImageValue.mediaQueries}</style>
+					<style nonce={Liferay.CSP?.nonce}>
+						{backgroundImageValue.mediaQueries}
+					</style>
 				) : null}
 			</FragmentContentInteractionsFilter>
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/Container.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/Container.js
@@ -124,7 +124,9 @@ const Container = React.memo(
 				style={style}
 			>
 				{backgroundImageValue.mediaQueries ? (
-					<style>{backgroundImageValue.mediaQueries}</style>
+					<style nonce={Liferay.CSP?.nonce}>
+						{backgroundImageValue.mediaQueries}
+					</style>
 				) : null}
 
 				{children}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/FormStepContainer.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/FormStepContainer.js
@@ -91,7 +91,9 @@ const FormStepContainer = React.forwardRef(({children, item}, ref) => {
 				style={style}
 			>
 				{backgroundImageValue.mediaQueries ? (
-					<style>{backgroundImageValue.mediaQueries}</style>
+					<style nonce={Liferay.CSP?.nonce}>
+						{backgroundImageValue.mediaQueries}
+					</style>
 				) : null}
 
 				{children}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/Row.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/Row.js
@@ -74,7 +74,9 @@ const Row = React.forwardRef(({children, className, item}, ref) => {
 				ref={ref}
 			>
 				{backgroundImageValue.mediaQueries ? (
-					<style>{backgroundImageValue.mediaQueries}</style>
+					<style nonce={Liferay.CSP?.nonce}>
+						{backgroundImageValue.mediaQueries}
+					</style>
 				) : null}
 
 				{children}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout_data_items/Container.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/layout_data_items/Container.test.js
@@ -11,6 +11,11 @@ import Container from '../../../../../src/main/resources/META-INF/resources/page
 import {LAYOUT_DATA_ITEM_TYPES} from '../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/layoutDataItemTypes';
 import {VIEWPORT_SIZES} from '../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/viewportSizes';
 import {StoreAPIContextProvider} from '../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
+import useBackgroundImageValue from '../../../../../src/main/resources/META-INF/resources/page_editor/app/utils/useBackgroundImageValue';
+
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/page_editor/app/utils/useBackgroundImageValue'
+);
 
 const renderContainer = (config) => {
 	return render(
@@ -36,6 +41,10 @@ const renderContainer = (config) => {
 };
 
 describe('Container', () => {
+	beforeEach(() => {
+		useBackgroundImageValue.mockReturnValue({mediaQueries: '', url: ''});
+	});
+
 	it('wraps the container inside a link if configuration is specified', async () => {
 		const {findByRole} = renderContainer({
 			link: {
@@ -61,5 +70,31 @@ describe('Container', () => {
 		);
 
 		expect(container.style.contentVisibility).toBe('auto');
+	});
+
+	it('adds the CSP nonce to the background image media queries style', () => {
+		const originalCSP = Liferay.CSP;
+
+		Liferay.CSP = {nonce: 'test-nonce'};
+
+		try {
+			useBackgroundImageValue.mockReturnValue({
+				mediaQueries:
+					'@media (max-width: 100px) { #containerId { background-image: url(image.png) !important; } }',
+				url: 'image.png',
+			});
+
+			renderContainer({});
+
+			const styleElement = document.querySelector(
+				'.lfr-layout-structure-item-container style'
+			);
+
+			expect(styleElement).not.toBeNull();
+			expect(styleElement.getAttribute('nonce')).toBe('test-nonce');
+		}
+		finally {
+			Liferay.CSP = originalCSP;
+		}
 	});
 });


### PR DESCRIPTION
## What

When a Content Security Policy with a `style-src` nonce is enforced, the page editor logs `style-src` violations in edit mode because some style elements are inserted without the document nonce:

- `#layout-common-styles` — the layout common styles `<style>` created/updated client-side by `createOrUpdateStyleTag` in `CommonStylesManager.js` never received a nonce.
- The background-image media-query `<style>` elements rendered by `Container`, `Row`, `FormStepContainer`, and `FragmentContent` were emitted without one.

The browser blocks these, so the styles are not applied and the console fills with violations.

## Fix

Stamp `Liferay.CSP.nonce` on these elements so they match the enforced policy, mirroring the handling already in place for the scripts recreated by `UnsafeHTML`:

- `CommonStylesManager.js` — `styleTag.setAttribute('nonce', Liferay.CSP.nonce)` on creation.
- The four components — `<style nonce={Liferay.CSP?.nonce}>`.

## Out of scope

- `.cke{visibility:hidden;}` is injected by the third-party CKEditor library, not this module, and is left for a separate effort.
- The various `innerHTML` sinks that inject editable/user content are intentionally not auto-nonced — blindly stamping a nonce on user-supplied markup would defeat CSP. Those rely on the server-rendered nonce.

## Tests

`Container.test.js` renders the real component with non-empty `mediaQueries` and asserts the rendered `<style>` carries the nonce. Verified the test fails without the fix (negative control).

## Manual verification

Confirmed live in the page editor: `#layout-common-styles` now carries the document nonce and the previously firing `style-src` violations are gone (only the excluded CKEditor `.cke` style remains un-nonced).
