### PR TITLE
LPD-92839 Fix broken tests due to changes in data-id attribute

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/visualizationModes.spec.ts
@@ -423,6 +423,7 @@ test('Configure table visualization mode @LPD-11049', async ({
 	const sampleScalarFieldName = 'label';
 	const sampleObjectField = 'removedBy';
 	const sampleObjectChildField = 'id';
+	const sampleObjectType = 'string';
 
 	await test.step('Navigate to table visualization mode page', async () => {
 		await visualizationModesPage.goto({
@@ -448,12 +449,12 @@ test('Configure table visualization mode @LPD-11049', async ({
 		});
 
 		await visualizationModesPage.selectField({
-			dataId: `${sampleObjectField}.*`,
+			dataId: `${sampleObjectType},${sampleObjectField}.*`,
 			fieldName: sampleObjectField,
 		});
 
 		await visualizationModesPage.selectField({
-			dataId: `${sampleObjectField}.${sampleObjectChildField}`,
+			dataId: `${sampleObjectType},${sampleObjectField}.${sampleObjectChildField}`,
 			fieldName: sampleObjectChildField,
 		});
 
@@ -567,6 +568,7 @@ test('Add a field and assert its added to the last position in the table and ass
 	const sampleScalarField = 'id';
 	const sampleObjectField = 'removedBy';
 	const sampleObjectChildField = 'id';
+	const sampleObjectType = 'string';
 
 	await test.step('Navigate to table visualization mode page', async () => {
 		await visualizationModesPage.goto({
@@ -588,12 +590,12 @@ test('Add a field and assert its added to the last position in the table and ass
 		});
 
 		await visualizationModesPage.selectField({
-			dataId: `${sampleObjectField}.*`,
+			dataId: `${sampleObjectType},${sampleObjectField}.*`,
 			fieldName: sampleObjectField,
 		});
 
 		await visualizationModesPage.selectField({
-			dataId: `${sampleObjectField}.${sampleObjectChildField}`,
+			dataId: `${sampleObjectType},${sampleObjectField}.${sampleObjectChildField}`,
 			fieldName: sampleObjectChildField,
 		});
 
@@ -757,6 +759,7 @@ test('Check cancel in table visualization mode', async ({
 }) => {
 	const sampleScalarField = 'id';
 	const sampleObjectField = 'removedBy';
+	const sampleObjectType = 'string';
 
 	await test.step('Navigate to table visualization mode page', async () => {
 		await visualizationModesPage.goto({
@@ -802,7 +805,7 @@ test('Check cancel in table visualization mode', async ({
 		});
 
 		await visualizationModesPage.selectField({
-			dataId: `${sampleObjectField}.*`,
+			dataId: `${sampleObjectType},${sampleObjectField}.*`,
 			fieldName: sampleObjectField,
 		});
 
@@ -1128,6 +1131,7 @@ test('Assert the CellRenderer is displayed', async ({
 	const sampleScalarField = 'id';
 	const sampleObjectField = 'removedBy';
 	const sampleObjectChildField = 'id';
+	const sampleObjectType = 'string';
 
 	await test.step('Navigate to table visualization mode page', async () => {
 		await visualizationModesPage.goto({
@@ -1149,12 +1153,12 @@ test('Assert the CellRenderer is displayed', async ({
 		});
 
 		await visualizationModesPage.selectField({
-			dataId: `${sampleObjectField}.*`,
+			dataId: `${sampleObjectType},${sampleObjectField}.*`,
 			fieldName: sampleObjectField,
 		});
 
 		await visualizationModesPage.selectField({
-			dataId: `${sampleObjectField}.${sampleObjectChildField}`,
+			dataId: `${sampleObjectType},${sampleObjectField}.${sampleObjectChildField}`,
 			fieldName: sampleObjectChildField,
 		});
 


### PR DESCRIPTION
Actual `data-id` attribute is including the type in the value: `string,removedBy.*`, `string.removedBy.id`,... So we need to update the locator to find them.