### PR TITLE
LPD-93192 Fix invalid nested ul elements in the selection toolbar

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.tsx
@@ -221,7 +221,7 @@ function BulkActions({
 	return showBulkActionsManagementBar && selectedItemsValue.length ? (
 		<FrontendDataSetContext.Consumer>
 			{({formId, formName, loadData, namespace, sidePanelId}) => (
-				<ManagementToolbar.ItemList
+				<div
 					className="container-fluid ml-2 navbar navbar-expand-md"
 					data-qa-id="selectionToolbar"
 				>
@@ -391,7 +391,7 @@ function BulkActions({
 							)}
 						</ManagementToolbar.ItemList>
 					)}
-				</ManagementToolbar.ItemList>
+				</div>
 			)}
 		</FrontendDataSetContext.Consumer>
 	) : null;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93192

## What Is Being Fixed

The selection (bulk actions) toolbar wrapped its contents in `ManagementToolbar.ItemList`, which renders a `<ul>`. The inner list of bulk-action items is itself a `ManagementToolbar.ItemList` (a `<ul>`), so the markup placed a `<ul>` as a direct child of another `<ul>` — invalid HTML and an accessibility violation.

## How It Is Being Fixed

The outer `ManagementToolbar.ItemList` wrapper in `BulkActions.tsx` is replaced with a plain `<div>` that carries the same classes and attributes. The inner item list stays a `<ul>`, so list elements are no longer nested as direct children of one another while the toolbar layout and styling are preserved.

## Why Are There No Tests?

This is covered by the existing Playwright accessibility test at `modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts`.

## PR Check

**pr-check: PASS** — tested on `640b727d4ec0b4b2ed48d8c77a77932ad5bc72ce`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |

<!-- pr-check {"result": "success", "sha": "640b727d4ec0b4b2ed48d8c77a77932ad5bc72ce"} -->