### PR TITLE
LPD-93193 Provide accessible name for icon-only FDS action links

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/renderers/ActionLinkRenderer.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/renderers/ActionLinkRenderer.tsx
@@ -84,6 +84,8 @@ function ActionLinkRenderer({
 		currentAction.href &&
 		formatActionURL(currentAction.href, itemData, currentAction.target);
 
+	const showValue = hasValue(value);
+
 	function handleClickOnLink(event: React.MouseEvent) {
 		const doAction = () => {
 			if (currentAction?.target === 'modal') {
@@ -166,6 +168,11 @@ function ActionLinkRenderer({
 			className={classNames({'table-list-title': !options?.displayType})}
 		>
 			<ClayLink
+				aria-label={
+					showValue
+						? undefined
+						: currentAction.accessibleName || currentAction.label
+				}
 				data-senna-off
 				decoration={options?.decoration}
 				displayType={options?.displayType}
@@ -195,7 +202,7 @@ function ActionLinkRenderer({
 							}
 				}
 			>
-				{hasValue(value)
+				{showValue
 					? value
 					: currentAction.icon && (
 							<ClayIcon symbol={currentAction.icon} />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93193

## What Is Being Fixed

In a Frontend Data Set table cell, an action link renders only an icon
when the action has no display value. Because the icon carries no text,
the link had no accessible name, so screen readers announced it as an
unlabeled link.

## How It Is Being Fixed

`ActionLinkRenderer` now computes whether a display value is present and,
when it is not, sets an `aria-label` on the `ClayLink` using the action's
`accessibleName` (falling back to its `label`). When a display value is
present, the visible text already names the link, so no `aria-label` is
applied. The existing `hasValue(value)` call is hoisted into a `showValue`
constant and reused for both the label decision and the rendered content.

## Why Are There No Tests?

This icon-only accessibility behavior is covered by the Playwright suite
at tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts.

## PR Check

**pr-check: PASS** — tested on `b1689247094a033fbe547cf9a33f31a4bf4a3413`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |

<!-- pr-check {"result": "success", "sha": "b1689247094a033fbe547cf9a33f31a4bf4a3413"} -->