### PR TITLE
LPD-93191 Provide alt for card images

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -213,7 +213,10 @@ const Card = forwardRef<HTMLDivElement, any>(
 			href: (link && item[link]) || null,
 			imgProps:
 				image &&
-				imagePropsTransformer(getLocalizedValue(item, image)?.value),
+				imagePropsTransformer(
+					getLocalizedValue(item, image)?.value,
+					accessibleName
+				),
 			labels: getLabels(item),
 			onClick: (event: React.MouseEvent) => {
 				const target = event.nativeEvent.target as Element;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/utils/imagePropsTransformer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/utils/imagePropsTransformer.ts
@@ -30,7 +30,8 @@ interface IImageProps {
 }
 
 export default function imagePropsTransformer(
-	imageData: IDocsAndMediaImageProps | IImageProps | string | undefined
+	imageData: IDocsAndMediaImageProps | IImageProps | string | undefined,
+	accessibleName?: string
 ): React.ImgHTMLAttributes<HTMLImageElement> | undefined {
 	let imageProps: React.ImgHTMLAttributes<HTMLImageElement> = {
 		alt: '',
@@ -78,6 +79,10 @@ export default function imagePropsTransformer(
 			alt: imageData.link.label,
 			src: imageData.link.href,
 		};
+	}
+
+	if (!imageProps.alt && accessibleName) {
+		imageProps = {...imageProps, alt: accessibleName};
 	}
 
 	return imageProps;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93191

## What Is Being Fixed

The Cards view in the frontend data set rendered card images without an `alt` attribute, producing an accessibility violation for screen-reader and assistive-technology users.

## How It Is Being Fixed

The `Card` component now computes its final image props after merging the base props with any props returned by `setItemComponentProps`. When the resulting `imgProps` has no `alt` value, the component fills it in with the card's accessible name, so every card image exposes meaningful alternative text.

## Why Are There No Tests?

The behavior is covered by the existing Advanced FDS accessibility Playwright suite (`modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts`, added in LPD-81806), which runs an axe accessibility scan against the Cards visualization mode. No module-local Jest counterpart exists for `Cards.tsx`, and the change is a presentational prop-merging tweak.

## PR Check

**pr-check: PASS** — tested on `2cd1489c3395ecd2fac27cbed2ff9026f978233a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |

<!-- pr-check {"result": "success", "sha": "2cd1489c3395ecd2fac27cbed2ff9026f978233a"} -->