### PR TITLE
LPD-94088 Apply the CSP nonce to injected style and script elements

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditGraphApp/AuditBarChart.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/AuditGraphApp/AuditBarChart.js
@@ -141,6 +141,10 @@ export default function AuditBarChart({namespace, rtl, vocabularies}) {
 				''
 			);
 
+			if (Liferay.CSP?.nonce) {
+				style.setAttribute('nonce', Liferay.CSP.nonce);
+			}
+
 			document.head.appendChild(style);
 		}
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/external-scripts.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/external-scripts.js
@@ -35,6 +35,10 @@ function appendScript(options) {
 		script[name] = value;
 	}
 
+	if (Liferay.CSP?.nonce) {
+		script.setAttribute('nonce', Liferay.CSP.nonce);
+	}
+
 	document.body.appendChild(script);
 }
 

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -379,6 +379,10 @@ function OverlayContainer({allowEdit, root}) {
 		style.type = 'text/css';
 		style.appendChild(document.createTextNode(css));
 
+		if (Liferay.CSP?.nonce) {
+			style.setAttribute('nonce', Liferay.CSP.nonce);
+		}
+
 		head.appendChild(style);
 
 		// This must happen after hiding the toppers.


### PR DESCRIPTION
## What

When a Content Security Policy with a `script-src`/`style-src` nonce is enforced, three components insert inline style/script elements into the document without the document nonce, so the browser blocks them and logs CSP violations:

- `content-dashboard-web` — `AuditBarChart.js` appends a generated color `<style>` to `document.head`.
- `segments-experiment-web` — `ClickGoalPicker.es.js` appends a topper-hiding `<style>` to `document.head`.
- `osb-faro-web` — `external-scripts.js` appends an inline `<script>` (Pendo) to `document.body`.

These were surfaced by a portal-wide audit of dynamically injected `<style>`/`<script>` elements. This is the same class of issue fixed for the page editor in LPD-93943; these sites live in other modules.

## Fix

Stamp `Liferay.CSP.nonce` on each element before it is inserted, mirroring the handling already used by `UnsafeHTML` and the page editor common styles:

```js
if (Liferay.CSP?.nonce) {
	el.setAttribute('nonce', Liferay.CSP.nonce);
}
```

For the OSB Faro loader only the inline (Pendo) entry needs it; the `src` entries are unaffected.

## Out of scope

External `<script src=...>` loads (governed by the URL allowlist, not the nonce) and content injected from server-rendered HTML (which already carries the nonce via `[$NONCE$]`) were reviewed and are not affected. Two latent sinks noted in the audit (`Modal.tsx` generic `createContextualFragment`, `ShadowDomContainer.js` shadow-DOM `<style>` via `innerHTML`) are left for separate consideration.

## Notes

These guards use the bare global `Liferay`, matching each module's existing convention (all three already reference `Liferay.` extensively; `osb-faro-web` already uses `Liferay.CSP`).
