### PR TITLE
LPD-93549 Convert CKEditor SCSS files to atlas-custom-properties

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor4/editor.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor4/editor.scss
@@ -1,6 +1,8 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-editable {
-	$edit-color: #68bb30;
-	$edit-color-hover: darken(#68bb30, 10);
+	$edit-color: $green-l2;
+	$edit-color-hover: $green-l1;
 
 	outline: 1px dashed $edit-color;
 	outline-offset: 2px;
@@ -31,7 +33,7 @@
 	}
 
 	&:hover {
-		background-color: rgba(255, 255, 255, 0.3);
+		background-color: unquote('hsl(from #{$white} h s l / 0.3)');
 		outline-color: $edit-color-hover;
 
 		&:after {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor4/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor4/main.scss
@@ -1,27 +1,27 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-balloon-editor {
 	&.cke_balloon.cke_balloontoolbar {
-		background: white;
-		border-color: #e7e7ed;
-		box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+		background: $white;
+		border-color: $gray-300;
+		box-shadow: unquote('0 8px 16px hsl(from #{$black} h s l / 0.2)');
 		z-index: 1100;
 	}
 
 	.cke_balloon_triangle_outer.cke_balloon_triangle_bottom {
-		border-color: #e7e7ed transparent;
+		border-color: $gray-300 transparent;
 	}
 
 	.cke_balloon_triangle_outer.cke_balloon_triangle_top {
-		border-color: #e7e7ed transparent;
+		border-color: $gray-300 transparent;
 	}
 
 	.cke_balloon_triangle_inner.cke_balloon_triangle_bottom {
-		border-color: white transparent;
+		border-color: $white transparent;
 	}
 
 	.cke_balloon_triangle_inner.cke_balloon_triangle_top {
-		border-color: white transparent;
+		border-color: $white transparent;
 	}
 
 	.cke_inner .cke_top {
@@ -70,8 +70,8 @@
 		padding: 4px;
 
 		input {
-			background: #f1f2f5;
-			border: 1px solid #e7e7ed;
+			background: $gray-200;
+			border: 1px solid $gray-300;
 			border-radius: 4px;
 			max-width: 32px;
 			padding: 6px 12px;
@@ -84,7 +84,7 @@
 
 	.ui-select {
 		border: none;
-		color: grey;
+		color: $gray-600;
 		float: left;
 		line-height: 30px;
 		margin: 2px;
@@ -95,7 +95,7 @@
 
 		option {
 			border: none;
-			color: grey;
+			color: $gray-600;
 			float: left;
 			line-height: 30px;
 			outline: none;
@@ -110,7 +110,7 @@
 	}
 
 	.ui-textinput {
-		background: white;
+		background: $white;
 		border-radius: 4px;
 		float: left;
 		height: 16px;
@@ -127,7 +127,7 @@
 
 .lfr-balloon-editor-insert-button {
 	align-items: center;
-	background: white;
+	background: $white;
 	border: 0.75px solid $primary;
 	border-radius: 2px;
 	color: $primary;
@@ -178,8 +178,8 @@
 			display: inline;
 
 			&:after {
-				background-image: linear-gradient(#fff, #e4e4e4);
-				border: 1px solid #a6a6a6;
+				background-image: linear-gradient($white, $gray-300);
+				border: 1px solid $gray-500;
 				border-radius: 2px;
 				content: 'Alt+0';
 				font-family: 'Courier New', Courier, 'Lucida Sans Typewriter',
@@ -189,7 +189,7 @@
 			}
 
 			&:hover:after {
-				background-image: linear-gradient(#f2f2f2, #ccc);
+				background-image: linear-gradient($gray-200, $gray-400);
 			}
 
 			&.mac:after {
@@ -202,7 +202,7 @@
 .cke_widget_embedurl,
 .cke_widget_videoembed {
 	.embed-help-message {
-		color: #fff;
+		color: $white;
 		font-weight: 600;
 		opacity: 0;
 		position: absolute;
@@ -223,7 +223,7 @@
 	}
 
 	.cke_widget_mask {
-		background-color: #000;
+		background-color: $black;
 		cursor: pointer;
 		opacity: 0;
 		transition: opacity 0.15s ease-in-out;
@@ -304,10 +304,10 @@
 	word-wrap: break-word;
 
 	blockquote {
-		background: #eef0f2
+		background: $gray-200
 			url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB8AAAAYCAMAAAA1ddazAAAALVBMVEX////Q3enT3+rZ5O3d5u/g6PDi6vLm7fPp7/Xs8vbv9Pjy9vn2+Pv5+vz8/f47YiUzAAAAAXRSTlMAQObYZgAAAJNJREFUeNqt0dsOhCAMRVFPuRUd+P/PlRrkiAnxZfbbogkpYftbNQfZn9Ygx1CJAiA8jJbeVJtKKrO19qsCWrGp25tTvemMues2d/F9vLBibEZHWsy/pTOsben4YXd5XxpX7mX/MnxZWNBzmQbtMUovqzmBldli8wJ20HxlpMts4XddBZr78MBVmrZyaFIjbc/77gQWOwQvaraRrQAAAABJRU5ErkJggg==)
 			no-repeat 5px 5px;
-		border: 1px solid #777;
+		border: 1px solid $gray-600;
 		padding: 5px 45px;
 
 		&:after {
@@ -330,8 +330,8 @@
 	}
 
 	pre {
-		background: #f9f9f9;
-		border: 1px solid #777;
+		background: $gray-100;
+		border: 1px solid $gray-600;
 		padding: 0.5em;
 	}
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
@@ -1,8 +1,126 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 :root {
-	--ck-font-family: $font-family-base;
+	--ck-font-family: #{$font-family-base};
 	--ck-icon-font-size: 0.67em;
+
+	--ck-color-base-action: #{$green-l1};
+	--ck-color-base-background: #{$white};
+	--ck-color-base-border: #{$gray-400};
+	--ck-color-base-foreground: #{$gray-100};
+	--ck-color-base-text: #{$dark-l1};
+
+	--ck-color-base-focus: #{$blue-l2};
+
+	--ck-color-base-active: #{$blue-l1};
+
+	--ck-color-base-active-focus: #{$primary};
+
+	--ck-color-base-error: #{$orange};
+
+	--ck-color-focus-border: #{$blue-l1};
+	--ck-color-focus-outer-shadow: #{$blue-l4};
+
+	--ck-color-focus-disabled-shadow: hsl(from #{$blue-l2} h s l / 0.3);
+
+	--ck-color-focus-error-shadow: hsl(from #{$orange-l1} h s l / 0.3);
+
+	--ck-color-shadow-drop: hsl(from #{$black} h s l / 0.15);
+
+	--ck-color-shadow-drop-active: hsl(from #{$black} h s l / 0.2);
+
+	--ck-color-shadow-inner: hsl(from #{$black} h s l / 0.1);
+
+	--ck-color-text: var(--ck-color-base-text);
+
+	--ck-color-button-default-background: transparent;
+
+	--ck-color-button-default-hover-background: #{$gray-200};
+
+	--ck-color-button-default-active-background: #{$gray-200};
+
+	--ck-color-button-default-disabled-background: transparent;
+
+	--ck-color-button-on-background: #{$primary-l3};
+	--ck-color-button-on-color: #{$blue-l1};
+
+	--ck-color-button-on-hover-background: #{$blue-l5};
+
+	--ck-color-button-on-active-background: #{$blue-l5};
+
+	--ck-color-button-on-disabled-background: #{$gray-200};
+
+	--ck-color-button-action-background: var(--ck-color-base-action);
+	--ck-color-button-action-text: var(--ck-color-base-background);
+
+	--ck-color-button-action-hover-background: #{$green-l1};
+
+	--ck-color-button-action-active-background: #{$green-l1};
+
+	--ck-color-button-action-disabled-background: #{$success-l1};
+
+	--ck-color-button-save: #{$green-d1};
+
+	--ck-color-button-cancel: #{$orange};
+
+	--ck-color-switch-button-off-background: #{$secondary-l0};
+	--ck-color-switch-button-off-hover-background: #{$secondary};
+
+	--ck-color-switch-button-on-background: var(
+		--ck-color-button-action-background
+	);
+	--ck-color-switch-button-on-hover-background: #{$green-l1};
+
+	--ck-color-switch-button-inner-background: var(--ck-color-base-background);
+	--ck-color-switch-button-inner-shadow: hsl(from #{$black} h s l / 0.1);
+
+	--ck-color-dropdown-panel-background: var(--ck-color-base-background);
+	--ck-color-dropdown-panel-border: var(--ck-color-base-border);
+
+	--ck-color-dialog-background: var(--ck-custom-background);
+	--ck-color-dialog-form-header-border: var(--ck-custom-border);
+
+	--ck-color-input-background: var(--ck-color-base-background);
+	--ck-color-input-border: var(--ck-color-base-border);
+	--ck-color-input-text: var(--ck-color-base-text);
+
+	--ck-color-input-disabled-background: #{$gray-200};
+	--ck-color-input-disabled-border: var(--ck-color-base-border);
+	--ck-color-input-disabled-text: #{$secondary};
+
+	--ck-color-input-error-border: var(--ck-color-base-error);
+
+	--ck-color-list-background: var(--ck-color-base-background);
+
+	--ck-color-list-button-hover-background: var(
+		--ck-color-button-default-hover-background
+	);
+
+	--ck-color-list-button-on-background: var(--ck-color-button-on-color);
+	--ck-color-list-button-on-text: var(--ck-color-base-background);
+
+	--ck-color-list-button-on-background-focus: var(--ck-color-button-on-color);
+
+	--ck-color-panel-background: var(--ck-color-base-background);
+	--ck-color-panel-border: var(--ck-color-base-border);
+
+	--ck-color-toolbar-background: var(--ck-color-base-background);
+	--ck-color-toolbar-border: var(--ck-color-base-border);
+
+	--ck-color-tooltip-background: var(--ck-color-base-text);
+	--ck-color-tooltip-text: var(--ck-color-base-background);
+
+	--ck-color-engine-placeholder-text: #{$secondary};
+	--ck-color-upload-bar-background: #{$blue-l2};
+
+	--ck-color-link-default: #{$indigo-d4};
+
+	--ck-color-link-selected-background: hsl(from #{$cyan-l2} h s l / 0.1);
+
+	--ck-color-link-fake-selection: hsl(from #{$cyan-l2} h s l / 0.3);
+
+	--ck-color-highlight-background: #{$yellow};
+	--ck-color-light-red: #{$pink-l4};
 }
 
 .lfr-ck {
@@ -20,7 +138,7 @@
 		&.ck-balloon-panel.ck-tooltip {
 			background-color: $dark-d2;
 			border-radius: 0.25rem;
-			box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.4);
+			box-shadow: unquote('0 1px 4px 0 hsl(from #{$black} h s l / 0.4)');
 			max-width: 230px;
 			padding: 0.75rem;
 			text-align: center;
@@ -80,19 +198,19 @@
 
 		&.lfr-editor {
 			&-heading_paragraph .ck-button__label {
-				@include font-size($font-size-base);
+				font-size: $font-size-base;
 			}
 
 			&-heading_heading1 .ck-button__label {
-				@include font-size($h1-font-size);
+				font-size: $h1-font-size;
 			}
 
 			&-heading_heading2 .ck-button__label {
-				@include font-size($h2-font-size);
+				font-size: $h2-font-size;
 			}
 
 			&-heading_heading3 .ck-button__label {
-				@include font-size($h3-font-size);
+				font-size: $h3-font-size;
 			}
 		}
 
@@ -126,7 +244,7 @@
 }
 
 .writing-assistant__content--highlight {
-	background-color: #cce6d3;
+	background-color: $success-l2;
 	border-radius: 2px;
 	transition: background-color 0.5s ease;
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93549

<img width="2076" height="914" alt="cke-dark" src="https://github.com/user-attachments/assets/59e4b2eb-ede9-4fa3-b4ba-595ac6db16df" />

## What Is Being Fixed

The CKEditor SCSS files used hardcoded color literals (hex values, named colors, `rgba(...)`) and imported the legacy `atlas-variables` partial. As a result, the CKEditor surface did not pick up atlas-custom-properties tokens and would not respond to dark-mode theming.

## How It Is Being Fixed

The three CKEditor SCSS files now import `atlas-custom-properties/_variables` and replace the hardcoded colors with the matching atlas tokens — `#fff` becomes `$white`, `#e7e7ed` becomes `$gray-300`, `rgba(0, 0, 0, 0.2)` becomes `unquote('hsl(from #{$black} h s l / 0.2)')`, and so on. In `ckeditor4/main.scss`, the legacy `@import 'atlas-variables'` is replaced with the single `atlas-custom-properties/_variables` import per the project convention. In `ckeditor5/editor.scss`, the `:root` block of CKEditor CSS custom properties is rewritten to wrap each SCSS variable in `#{}` interpolation; bare `$var` does not resolve inside a custom property declaration, so the previous form was emitting unresolved Sass tokens into the compiled CSS.

## Why Are There No Tests?

Pure styling refactor — SCSS variable substitutions converting hardcoded colors to atlas-custom-properties tokens. There is no behavior change beyond rendered styling, and CKEditor styling is not covered by any automated visual test layer in this repository.

## PR Check

**pr-check: PASS** — tested on `a47a743d7b7e45889794beef9e82ebde6f677cb8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |

<!-- pr-check {"result": "success", "sha": "a47a743d7b7e45889794beef9e82ebde6f677cb8"} -->