### PR TITLE
LPD-94267 Page editor + Item Selector CSP

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -9,6 +9,7 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -70,7 +71,8 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		if (!contentSecurityPolicyConfiguration.enabled() ||
 			Validator.isNull(contentSecurityPolicyConfiguration.policy()) ||
 			_isExcludedURIPath(
-				contentSecurityPolicyConfiguration, httpServletRequest)) {
+				contentSecurityPolicyConfiguration, httpServletRequest) ||
+			_isLayoutModeEdit(httpServletRequest)) {
 
 			return false;
 		}
@@ -150,6 +152,25 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 
 				return true;
 			}
+		}
+
+		return false;
+	}
+
+	private boolean _isLayoutModeEdit(HttpServletRequest httpServletRequest) {
+
+		// CSP breaks the layout editor, which uses eval and inline styles via
+		// CKEditor. Require an authenticated user so the policy cannot be
+		// disabled on a public page.
+
+		if (!Constants.EDIT.equals(
+				httpServletRequest.getParameter("p_l_mode"))) {
+
+			return false;
+		}
+
+		if (httpServletRequest.getRemoteUser() != null) {
+			return true;
 		}
 
 		return false;

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -6,6 +6,8 @@
 package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
 
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -51,6 +53,17 @@ public class ContentSecurityPolicyFilterTest {
 		_testIsExcludedURIPath(true, null, "/group/guest/home");
 	}
 
+	@Test
+	public void testIsLayoutModeEdit() {
+		_testIsLayoutModeEdit(false, null, RandomTestUtil.randomString());
+		_testIsLayoutModeEdit(
+			false, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+		_testIsLayoutModeEdit(false, Constants.EDIT, null);
+		_testIsLayoutModeEdit(
+			true, Constants.EDIT, RandomTestUtil.randomString());
+	}
+
 	private void _testIsExcludedURIPath(
 		boolean excludedURIPath, String forwardRequestURI, String requestURI) {
 
@@ -79,6 +92,31 @@ public class ContentSecurityPolicyFilterTest {
 					HttpServletRequest.class
 				},
 				_contentSecurityPolicyConfiguration, httpServletRequest));
+	}
+
+	private void _testIsLayoutModeEdit(
+		boolean layoutModeEdit, String layoutMode, String remoteUser) {
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getParameter("p_l_mode")
+		).thenReturn(
+			layoutMode
+		);
+
+		Mockito.when(
+			httpServletRequest.getRemoteUser()
+		).thenReturn(
+			remoteUser
+		);
+
+		Assert.assertEquals(
+			layoutModeEdit,
+			ReflectionTestUtil.invoke(
+				_contentSecurityPolicyFilter, "_isLayoutModeEdit",
+				new Class<?>[] {HttpServletRequest.class}, httpServletRequest));
 	}
 
 	private ContentSecurityPolicyConfiguration


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94267

## What

When CSP is enabled, editing a page — dropping a widget, or configuring a Web Content Display widget and saving — throws CSP errors in the browser console.

The page editor and the config / item-selector iframes it opens run under the layout friendly URL `/e<layout-uuid>` with `p_l_mode=edit`, which is not in the CSP excluded paths, so CSP is enforced there (LPD-91078 only covered `/group/`). The editor embeds third-party and legacy code that relies on `eval` and inline styles/scripts the policy blocks:

- CKEditor — `new Function("return this")()` (eval) and injected inline `<style>` / `style=""`.

## How

Exclude the layout edit-mode surface from CSP in `ContentSecurityPolicyFilter._isLayoutModeEdit`: skip enforcement when `p_l_mode=edit`.

Because the parameter alone is attacker-controllable (appending `?p_l_mode=edit` to a public page must not disable CSP), the bypass is gated on an authenticated request — `httpServletRequest.getRemoteUser() != null` — so an anonymous request cannot disable the policy on a public page. Layout `UPDATE` permission is not checked here because the filter runs before the layout is resolved, so `WebKeys.LAYOUT` is not yet available.

## Tests

`ContentSecurityPolicyFilterTest.testIsLayoutModeEdit` covers the new `_isLayoutModeEdit` gate across its branches:

- `p_l_mode` absent → not layout edit mode (CSP still enforced).
- a non-edit `p_l_mode` value → not layout edit mode (CSP still enforced).
- `p_l_mode=edit` with an anonymous request (null remote user) → not bypassed, so an attacker appending `?p_l_mode=edit` to a public page cannot disable CSP.
- `p_l_mode=edit` with an authenticated user → layout edit mode (CSP skipped).

The console errors were also reproduced and diagnosed on a CSP-enforced instance: editing a page and configuring a Web Content Display widget (select web content → "Use a specific template" → testTemplate → Save) triggers CSP violations only because the layout edit-mode surface (`/e<layout-uuid>`, `p_l_mode=edit`) is CSP-enforced. Excluding that surface removes the policy on those requests, so the violations no longer apply. The source formatter passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)