### PR TITLE
LPD-93919 Fix opening system data sets that lack an OpenAPI schema

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/DataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/DataSet.tsx
@@ -133,21 +133,18 @@ const DataSet = ({
 
 				const {restApplication, restSchema} = responseJSON;
 
-				getOpenApiData({restApplication, restSchema}).then(
-					(oApiData) => {
-						if (!oApiData) {
-							return;
+				getOpenApiData({restApplication, restSchema})
+					.then((oApiData) => {
+						if (oApiData) {
+							setFieldTreeItems(getFields(oApiData));
+
+							setFilterableFieldTreeItems(
+								getFilterableFields(oApiData)
+							);
 						}
-
-						setFieldTreeItems(getFields(oApiData));
-
-						setFilterableFieldTreeItems(
-							getFilterableFields(oApiData)
-						);
-
-						setLoading(false);
-					}
-				);
+					})
+					.catch(openDefaultFailureToast)
+					.finally(() => setLoading(false));
 			}
 			else {
 				openDefaultFailureToast();

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getOpenApiData.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getOpenApiData.ts
@@ -17,6 +17,15 @@ export default async function getOpenApiData({
 }) {
 	const response = await fetch(`/o${restApplication}/openapi.json`);
 
+	if (response.status === 404) {
+
+		// The REST application does not expose an OpenAPI schema (for example,
+		// taglib-based system data sets). This is an expected absence rather
+		// than a failure, so return without showing an error.
+
+		return null;
+	}
+
 	if (!response.ok) {
 		openDefaultFailureToast();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/internal/jaxrs/application/FDSApplication.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/internal/jaxrs/application/FDSApplication.java
@@ -82,10 +82,16 @@ public class FDSApplication extends Application {
 		FDSDataProvider fdsDataProvider =
 			_fdsDataProviderRegistry.getFDSDataProvider(fdsDataProviderKey);
 
-		if ((fdsDataProvider == null) && _log.isDebugEnabled()) {
-			_log.debug(
-				"No frontend data set data provider is associated with " +
-					fdsDataProviderKey);
+		if (fdsDataProvider == null) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"No frontend data set data provider is associated with " +
+						fdsDataProviderKey);
+			}
+
+			return Response.status(
+				Response.Status.NOT_FOUND
+			).build();
 		}
 
 		try {

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/test/java/com/liferay/frontend/data/set/taglib/internal/jaxrs/application/FDSApplicationTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/test/java/com/liferay/frontend/data/set/taglib/internal/jaxrs/application/FDSApplicationTest.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.taglib.internal.jaxrs.application;
+
+import com.liferay.frontend.data.set.provider.FDSDataProviderRegistry;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.ws.rs.core.Response;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Juanjo Fernandez
+ */
+public class FDSApplicationTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_fdsApplication = new FDSApplication();
+
+		_fdsDataProviderRegistry = Mockito.mock(FDSDataProviderRegistry.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_fdsApplication, "_fdsDataProviderRegistry",
+			_fdsDataProviderRegistry);
+	}
+
+	@Test
+	public void testGetFDSDataReturnsNotFoundWhenNoDataProvider() {
+		Mockito.when(
+			_fdsDataProviderRegistry.getFDSDataProvider("openapi.json")
+		).thenReturn(
+			null
+		);
+
+		Response response = _fdsApplication.getFDSData(
+			"openapi.json", "tableName", 0, 0, null, null, null, null, null,
+			null, null);
+
+		Assert.assertEquals(
+			Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+	}
+
+	private FDSApplication _fdsApplication;
+	private FDSDataProviderRegistry _fdsDataProviderRegistry;
+
+}

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/systemDataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/systemDataSets.spec.ts
@@ -424,7 +424,8 @@ test(
 					'false',
 					'customAuthorTableCellRenderer'
 				),
-				'date': buildTableRowSpec('false', 'Date and Time'),
+				'date': buildTableRowSpec('false', 'Date'),
+				'dateTime': buildTableRowSpec('false', 'Date and Time'),
 				'description': buildTableRowSpec('false', 'Default'),
 				'id': buildTableRowSpec('true', 'Action Link'),
 				'size': buildTableRowSpec('false', ''),
@@ -542,6 +543,7 @@ test(
 					true,
 				],
 				['Date Range', 'date', 'Date Filter', true],
+				['Date Time Range', 'dateTime', 'Date Filter', true],
 				['Color', 'color', 'System Filter', false],
 				['Creator', 'creator.name', 'System Filter', false],
 				['Size', 'size', 'System Filter', false],


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93919

## What Is Being Fixed

Opening a system data set customization whose REST application is served by the frontend data set taglib (such as the Classic sample) failed. The taglib application exposes no openapi.json, so the admin detail page's schema request returned a 404. The page treated that 404 as a hard failure — it showed an error notification and left the Details panel stuck on a loading spinner — and the same 404 path made FDSApplication.getFDSData dereference a null data provider, throwing a NullPointerException on the server.

## How It Is Being Fixed

FDSApplication.getFDSData now returns a 404 response when no data provider is registered for the requested key instead of falling through and throwing. On the client, getOpenApiData treats a 404 as an absent schema rather than a failure (no error toast), and DataSet.tsx always clears the loading state so the detail page renders even when no OpenAPI schema is available — the Details and other tabs read their persisted configuration independently of the schema. A unit test covers the null-data-provider path. The systemDataSets Playwright test is also updated to match the FDSSample changes from LPD-89563, which split the Advanced sample's date column into separate date and date-time fields and added the matching filter.

## PR Check

**pr-check: PASS** — tested on `4d114c4ab303cfadc0eb8f17866078baccd9903d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4d114c4ab303cfadc0eb8f17866078baccd9903d"} -->