### PR TITLE
LPD-94490 Fix flaky language switch in input_localized test

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/input_localized.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/input_localized.spec.ts
@@ -7,7 +7,6 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../../fixtures/loginTest';
-import {clickAndExpectToBeVisible} from '../../../../../utils/clickAndExpectToBeVisible';
 import {inputLocalizedPageTest} from '../../../../frontend-editor-ckeditor5-sample-web/fixtures/inputLocalizedPageTest';
 
 export const test = mergeTests(
@@ -45,17 +44,11 @@ test(
 			});
 
 			await test.step('Switch to es-ES locale', async () => {
-				await clickAndExpectToBeVisible({
-					autoClick: true,
-					target: inputLocalizedPage.spanishOption,
-					trigger: inputLocalizedPage.content.languageButton,
-				});
-
-				await expect(async () => {
-					await expect(
-						inputLocalizedPage.content.languageButton
-					).toContainText('es-ES');
-				}).toPass();
+				await inputLocalizedPage.switchLanguage(
+					inputLocalizedPage.content.languageButton,
+					inputLocalizedPage.spanishOption,
+					'es-ES'
+				);
 			});
 
 			await test.step('Check that "Spanish" is in the editor', async () => {
@@ -65,17 +58,11 @@ test(
 			});
 
 			await test.step('Switch to en-US locale', async () => {
-				await clickAndExpectToBeVisible({
-					autoClick: true,
-					target: inputLocalizedPage.englishOption,
-					trigger: inputLocalizedPage.content.languageButton,
-				});
-
-				await expect(async () => {
-					await expect(
-						inputLocalizedPage.content.languageButton
-					).toContainText('en-US');
-				}).toPass();
+				await inputLocalizedPage.switchLanguage(
+					inputLocalizedPage.content.languageButton,
+					inputLocalizedPage.englishOption,
+					'en-US'
+				);
 			});
 		});
 
@@ -85,33 +72,21 @@ test(
 			});
 
 			await test.step('Switch to es-ES and fill editor with "Spanish"', async () => {
-				await clickAndExpectToBeVisible({
-					autoClick: true,
-					target: inputLocalizedPage.spanishOption,
-					trigger: inputLocalizedPage.default.languageButton,
-				});
-
-				await expect(async () => {
-					await expect(
-						inputLocalizedPage.default.languageButton
-					).toContainText('es-ES');
-				}).toPass();
+				await inputLocalizedPage.switchLanguage(
+					inputLocalizedPage.default.languageButton,
+					inputLocalizedPage.spanishOption,
+					'es-ES'
+				);
 
 				await inputLocalizedPage.default.editor.fill('Spanish');
 			});
 
 			await test.step('Switch to en-US and check editor displays "English" still', async () => {
-				await clickAndExpectToBeVisible({
-					autoClick: true,
-					target: inputLocalizedPage.englishOption,
-					trigger: inputLocalizedPage.default.languageButton,
-				});
-
-				await expect(async () => {
-					await expect(
-						inputLocalizedPage.default.languageButton
-					).toContainText('en-US');
-				}).toPass();
+				await inputLocalizedPage.switchLanguage(
+					inputLocalizedPage.default.languageButton,
+					inputLocalizedPage.englishOption,
+					'en-US'
+				);
 
 				await expect(async () => {
 					await expect(inputLocalizedPage.default.editor).toHaveText(
@@ -121,17 +96,11 @@ test(
 			});
 
 			await test.step('Switch to es-ES and check editor displays "Spanish" still', async () => {
-				await clickAndExpectToBeVisible({
-					autoClick: true,
-					target: inputLocalizedPage.spanishOption,
-					trigger: inputLocalizedPage.default.languageButton,
-				});
-
-				await expect(async () => {
-					await expect(
-						inputLocalizedPage.default.languageButton
-					).toContainText('es-ES');
-				}).toPass();
+				await inputLocalizedPage.switchLanguage(
+					inputLocalizedPage.default.languageButton,
+					inputLocalizedPage.spanishOption,
+					'es-ES'
+				);
 
 				await expect(async () => {
 					expect(inputLocalizedPage.default.editor).toHaveText(
@@ -141,17 +110,11 @@ test(
 			});
 
 			await test.step('Switch back to english to reset to original state', async () => {
-				await clickAndExpectToBeVisible({
-					autoClick: true,
-					target: inputLocalizedPage.englishOption,
-					trigger: inputLocalizedPage.default.languageButton,
-				});
-
-				await expect(async () => {
-					await expect(
-						inputLocalizedPage.default.languageButton
-					).toContainText('en-US');
-				}).toPass();
+				await inputLocalizedPage.switchLanguage(
+					inputLocalizedPage.default.languageButton,
+					inputLocalizedPage.englishOption,
+					'en-US'
+				);
 			});
 		});
 
@@ -165,11 +128,11 @@ test(
 
 		await test.step('Check the languages dropdown are synced', async () => {
 			await test.step('Switch to es-ES locale', async () => {
-				await clickAndExpectToBeVisible({
-					autoClick: true,
-					target: inputLocalizedPage.spanishOption,
-					trigger: inputLocalizedPage.default.languageButton,
-				});
+				await inputLocalizedPage.switchLanguage(
+					inputLocalizedPage.default.languageButton,
+					inputLocalizedPage.spanishOption,
+					'es-ES'
+				);
 			});
 
 			await test.step('Check the default and content language buttons are displaying es-ES', async () => {
@@ -187,11 +150,11 @@ test(
 			});
 
 			await test.step('Switch to en-US locale', async () => {
-				await clickAndExpectToBeVisible({
-					autoClick: true,
-					target: inputLocalizedPage.englishOption,
-					trigger: inputLocalizedPage.content.languageButton,
-				});
+				await inputLocalizedPage.switchLanguage(
+					inputLocalizedPage.content.languageButton,
+					inputLocalizedPage.englishOption,
+					'en-US'
+				);
 			});
 
 			await test.step('Check the default and content language buttons are displaying en-US', async () => {

--- a/modules/test/playwright/tests/frontend-editor-ckeditor5-sample-web/pages/InputLocalizedPage.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor5-sample-web/pages/InputLocalizedPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 export class InputLocalizedPage {
 	readonly content: {
@@ -53,5 +53,34 @@ export class InputLocalizedPage {
 		this.spanishOption = page.locator('.dropdown-menu.show #es_ES');
 
 		this.page = page;
+	}
+
+	/**
+	 * Opens the editor's language dropdown, selects the given option, and
+	 * verifies the language button reflects the new locale. The whole flow is
+	 * retried as a unit: on slower environments the option click can register
+	 * as a highlight without committing the selection (the menu is still
+	 * rendering when the click lands), leaving the dropdown open and the locale
+	 * unchanged. Re-running open + click until the button text updates recovers
+	 * from that missed click instead of polling a value that never changes.
+	 */
+	async switchLanguage(
+		languageButton: Locator,
+		option: Locator,
+		expectedLanguageId: string
+	) {
+		await expect(async () => {
+			const expanded = await languageButton.getAttribute('aria-expanded');
+
+			if (expanded !== 'true') {
+				await languageButton.click({timeout: 1000});
+			}
+
+			await option.click({timeout: 1000});
+
+			await expect(languageButton).toContainText(expectedLanguageId, {
+				timeout: 1000,
+			});
+		}).toPass();
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94490

## What Is Being Fixed

The Playwright test ckeditor5/input_localized.spec.ts failed intermittently in CI while passing locally. In the "Switch to es-ES locale" step the editor's language dropdown was opened and the locale option clicked through clickAndExpectToBeVisible with autoClick. On slower CI machines the option click landed while the dropdown was still rendering, so it only highlighted the option (aria-activedescendant="es_ES") without committing the selection — the dropdown stayed open and the locale never changed. The follow-up toContainText assertion only polled the button text and never re-clicked, so the missed click could never recover and the test hit the 90s timeout.

## How It Is Being Fixed

A new InputLocalizedPage.switchLanguage method wraps the open → click → verify cycle in a single retrying expect(...).toPass() assertion. If the language button does not reflect the new locale (the click failed to commit), the whole open-and-click sequence is retried with short per-attempt timeouts until it does. All eight language switches in the spec now go through this method, and the now-unused clickAndExpectToBeVisible import was removed.

## Why Are There No Tests?

This change modifies test code only. Its purpose is to stabilize the existing input_localized.spec.ts Playwright test, which is itself the coverage; no product code changed, so no new test is added.

## PR Check

**pr-check: PASS** — tested on `1dd952265707f92dd26eb2880082048552ebbecb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "1dd952265707f92dd26eb2880082048552ebbecb"} -->
