### PR TITLE
LPD-94734 Scroll language dropdown into view before selecting a locale

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor5-sample-web/pages/InputLocalizedPage.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor5-sample-web/pages/InputLocalizedPage.ts
@@ -57,18 +57,27 @@ export class InputLocalizedPage {
 
 	/**
 	 * Opens the editor's language dropdown, selects the given option, and
-	 * verifies the language button reflects the new locale. The whole flow is
-	 * retried as a unit: on slower environments the option click can register
-	 * as a highlight without committing the selection (the menu is still
-	 * rendering when the click lands), leaving the dropdown open and the locale
-	 * unchanged. Re-running open + click until the button text updates recovers
-	 * from that missed click instead of polling a value that never changes.
+	 * verifies the language button reflects the new locale.
+	 *
+	 * The dropdown menu is a portal aligned to its trigger. When the trigger
+	 * sits low on the page the menu opens below the viewport fold, so clicking
+	 * an option forces a page scroll that realigns the menu; on a slow CI
+	 * machine the menu shifts in the gap between Playwright computing the click
+	 * point and dispatching the event, and the click lands off the option
+	 * without committing the selection. Scrolling the trigger up first lets the
+	 * menu open fully on-screen, so the option click needs no scroll and lands
+	 * cleanly. The open/click/verify flow is still retried as a unit as a
+	 * safety net.
 	 */
 	async switchLanguage(
 		languageButton: Locator,
 		option: Locator,
 		expectedLanguageId: string
 	) {
+		await languageButton.evaluate((element) =>
+			element.scrollIntoView({block: 'start'})
+		);
+
 		await expect(async () => {
 			const expanded = await languageButton.getAttribute('aria-expanded');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94734

## What Is Being Fixed

The ckeditor5 input_localized Playwright test fails in CI while passing locally. The content editor sits low on the page, so its language dropdown — a portal aligned to the trigger — opens below the viewport fold. Selecting an option forces Playwright to scroll the page, which realigns the portal menu; on a slow CI machine the menu shifts in the gap between Playwright computing the click coordinates and dispatching the event, so the synthesized click lands off the option and never fires its onClick. The selection never commits, the dropdown stays open, and the test times out. A direct DOM click on the same option commits instantly, confirming the handler is fine and the miss is purely positional.

## How It Is Being Fixed

InputLocalizedPage.switchLanguage now scrolls the trigger to the top of the viewport before opening the dropdown, so the menu opens fully on-screen and the option click needs no page scroll and lands cleanly. The change was reproduced under CPU throttling with a shortened viewport, where it turns a 100% failure rate into a 100% pass rate; the unthrottled test continues to pass.

## Why Are There No Tests?

This change modifies test code only. It stabilizes the existing input_localized.spec.ts Playwright test, which is itself the coverage; no product code changed, so no new test is added.

## PR Check

**pr-check: PASS** — tested on `fb428193f51d4928e89b7d93ae9e7f20fea0c4a7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "fb428193f51d4928e89b7d93ae9e7f20fea0c4a7"} -->
