### PR TITLE
LPD-93799 Honor the portal locale for User Views snapshot group labels

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializer.java
@@ -116,7 +116,8 @@ public abstract class BaseFDSSerializer {
 					"items", _toJSONArray(ownedObjectEntries)
 				).put(
 					"label",
-					language.get(httpServletRequest.getLocale(), "owned")
+					language.get(
+						PortalUtil.getLocale(httpServletRequest), "owned")
 				));
 
 			if (!sharedObjectEntries.isEmpty()) {
@@ -128,7 +129,8 @@ public abstract class BaseFDSSerializer {
 					).put(
 						"label",
 						language.get(
-							httpServletRequest.getLocale(), "shared-with-me")
+							PortalUtil.getLocale(httpServletRequest),
+							"shared-with-me")
 					));
 			}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93799

## What Is Being Fixed

In the User Views dropdown of a Frontend Data Set, the "Shared With Me" group header rendered in the wrong language — it showed up in Spanish regardless of the page language (reproduced in CMS Data Sets). The header is built server-side, and its label was localized with `httpServletRequest.getLocale()`, which resolves to the browser's `Accept-Language` locale rather than the user's configured page language.

## How It Is Being Fixed

`BaseFDSSerializer` now resolves the locale through `PortalUtil.getLocale(httpServletRequest)` for both the "owned" and the visible "shared-with-me" group labels. That method returns the ThemeDisplay locale when one is present and falls back gracefully otherwise, so the header honors the user's configured/page language instead of the browser preference.

## Why Are There No Tests?

The change only swaps the locale source. The corrected behavior depends on portal request / ThemeDisplay state resolved by `PortalUtil.getLocale`, which is not present in the existing plain unit tests (`CustomFDSSerializerTest`, `SystemFDSSerializerTest`) that already cover this serializer, so it cannot be meaningfully asserted there.

## PR Check

**pr-check: PASS** — tested on `0354dfa7b3095c19c43b793d98826c64c44521ae`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0354dfa7b3095c19c43b793d98826c64c44521ae"} -->