### PR TITLE
LPD-94350 Run object definition batch in test setup so new fields get columns

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test-util/src/main/java/com/liferay/frontend/data/set/test/util/FrontendDataSetTestUtil.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test-util/src/main/java/com/liferay/frontend/data/set/test/util/FrontendDataSetTestUtil.java
@@ -7,9 +7,6 @@ package com.liferay.frontend.data.set.test.util;
 
 import com.liferay.batch.engine.test.util.BatchEngineTestUtil;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 
 import java.util.Map;
 
@@ -64,15 +61,6 @@ public class FrontendDataSetTestUtil {
 	}
 
 	public static void initialize(Class<?> clazz) throws Exception {
-		ObjectDefinition objectDefinition =
-			ObjectDefinitionLocalServiceUtil.
-				fetchObjectDefinitionByExternalReferenceCode(
-					"L_DATA_SET", TestPropsValues.getCompanyId());
-
-		if (objectDefinition != null) {
-			return;
-		}
-
 		BatchEngineTestUtil.processBatchEngineUnits(
 			_BUNDLE_SYMBOLIC_NAME + ".impl", clazz,
 			new String[] {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94350

## What Is Being Fixed

The integration tests DataSetOrderValuesUpgradeProcessTest and
DataSetShowSearchUpgradeProcessTest fail in CI with `column "active_" of
relation "l_<companyId>_dataset" does not exist`. The failure is
intermittent across environments: it passes locally and on fresh
databases but fails when the test runs against a database where the
L_DATA_SET object definition already exists from before the "active"
field was added (LPD-44336).

The cause is in the test setup. FrontendDataSetTestUtil.initialize
short-circuited when L_DATA_SET already existed, returning before it ran
the object definition batch. That batch (an idempotent UPSERT) is the
only step that reconciles the definition with the current field set, so
on a pre-existing definition the "active_" column was never added.
addObjectEntry then writes "active_" (the field's default value forces
it into the INSERT) and the database rejects it.

## How It Is Being Fixed

The early return in FrontendDataSetTestUtil.initialize is removed so the
batch always runs. The batch is an UPSERT, so it still creates L_DATA_SET
on a fresh database and now also updates an existing one. In test mode
ObjectDefinitionUtil.isInvokerBundleAllowed() is true, so the update path
reaches ObjectFieldLocalServiceImpl and adds the missing column to the
existing definition. The now-unused imports are removed.

## Why Are There No Tests?

This change fixes test-setup code rather than product code. Its coverage
is the existing DataSetOrderValuesUpgradeProcessTest and
DataSetShowSearchUpgradeProcessTest upgrade tests, which this fix makes
pass against a pre-existing L_DATA_SET object definition.

## PR Check

**pr-check: PASS** — tested on `793d7ec3a971cd837dbfd0a77caeab80d075f4e8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "793d7ec3a971cd837dbfd0a77caeab80d075f4e8"} -->
