### PR TITLE
LPD-94865 Show User Views shared with a user's User Groups

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializer.java
@@ -21,7 +21,9 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -82,15 +84,10 @@ public abstract class BaseFDSSerializer {
 
 			long userId = PortalUtil.getUserId(httpServletRequest);
 
-			List<SharingEntry> sharingEntries =
-				sharingEntryLocalService.getToUserSharingEntries(
-					userId,
-					classNameLocalService.getClassNameId(
-						objectDefinition.getClassName()));
-
-			Set<Long> sharingEntriesClassPKs = SetUtil.fromCollection(
-				TransformUtil.transform(
-					sharingEntries, SharingEntry::getClassPK));
+			Set<Long> sharingEntriesClassPKs = _getSharingEntriesClassPKs(
+				classNameLocalService.getClassNameId(
+					objectDefinition.getClassName()),
+				userId);
 
 			Page<ObjectEntry> page = objectEntryManager.getObjectEntries(
 				companyId, objectDefinition, null, null,
@@ -160,6 +157,9 @@ public abstract class BaseFDSSerializer {
 	@Reference
 	protected SharingEntryLocalService sharingEntryLocalService;
 
+	@Reference
+	protected UserGroupLocalService userGroupLocalService;
+
 	private String _getFilterString(
 		String fdsName, Set<Long> sharingEntriesClassPKs, long userId) {
 
@@ -179,6 +179,34 @@ public abstract class BaseFDSSerializer {
 		sb.append("))");
 
 		return sb.toString();
+	}
+
+	private Set<Long> _getSharingEntriesClassPKs(
+		long classNameId, long userId) {
+
+		Set<Long> sharingEntriesClassPKs = SetUtil.fromCollection(
+			TransformUtil.transform(
+				sharingEntryLocalService.getToUserSharingEntries(
+					userId, classNameId),
+				SharingEntry::getClassPK));
+
+		for (UserGroup userGroup :
+				userGroupLocalService.getUserUserGroups(userId)) {
+
+			sharingEntriesClassPKs.addAll(
+				TransformUtil.transform(
+					sharingEntryLocalService.getToUserGroupSharingEntries(
+						userGroup.getUserGroupId()),
+					sharingEntry -> {
+						if (sharingEntry.getClassNameId() != classNameId) {
+							return null;
+						}
+
+						return sharingEntry.getClassPK();
+					}));
+		}
+
+		return sharingEntriesClassPKs;
 	}
 
 	private JSONArray _toJSONArray(List<ObjectEntry> objectEntries)

--- a/modules/apps/frontend-data-set/frontend-data-set-test/build.gradle
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationImplementation project(":apps:frontend-data-set:frontend-data-set-api")
 	testIntegrationImplementation project(":apps:frontend-data-set:frontend-data-set-test-util")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:portal:portal-props-test-util")

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/serializer/test/SystemFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/serializer/test/SystemFDSSerializerTest.java
@@ -1,0 +1,224 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.serializer.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.frontend.data.set.serializer.FDSSerializer;
+import com.liferay.frontend.data.set.test.util.FrontendDataSetTestUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.Serializable;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Juanjo Fernandez
+ */
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-34594"), @FeatureFlag("LPS-164563")}
+)
+@RunWith(Arquillian.class)
+public class SystemFDSSerializerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		FrontendDataSetTestUtil.initialize(SystemFDSSerializerTest.class);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_DATA_SET_SNAPSHOT", TestPropsValues.getCompanyId());
+
+		Assert.assertNotNull(objectDefinition);
+
+		_fdsName = RandomTestUtil.randomString();
+		_label = RandomTestUtil.randomString();
+		_memberUser = UserTestUtil.addUser();
+		_otherUser = UserTestUtil.addUser();
+
+		_userGroup = UserGroupTestUtil.addUserGroup();
+
+		_objectEntry = _addSnapshotObjectEntry(
+			_fdsName, _label, objectDefinition);
+
+		_sharingEntry = _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, _userGroup.getUserGroupId(),
+			0,
+			_classNameLocalService.getClassNameId(
+				objectDefinition.getClassName()),
+			_objectEntry.getObjectEntryId(), 0, true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId(), TestPropsValues.getUserId()));
+
+		_userLocalService.addUserGroupUser(
+			_userGroup.getUserGroupId(), _memberUser.getUserId());
+	}
+
+	@Test
+	public void testSerializeSnapshotsSharedWithUserGroupForOtherUser()
+		throws Exception {
+
+		JSONArray jsonArray = _fdsSerializer.serializeSnapshots(
+			_fdsName, _getHttpServletRequest(_otherUser.getUserId()));
+
+		Assert.assertNull(
+			_findSharedItemJSONObject(
+				jsonArray, _objectEntry.getObjectEntryId()));
+	}
+
+	@Test
+	public void testSerializeSnapshotsSharedWithUserGroupMember()
+		throws Exception {
+
+		JSONArray jsonArray = _fdsSerializer.serializeSnapshots(
+			_fdsName, _getHttpServletRequest(_memberUser.getUserId()));
+
+		JSONObject itemJSONObject = _findSharedItemJSONObject(
+			jsonArray, _objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(_label, itemJSONObject.getString("label"));
+	}
+
+	private ObjectEntry _addSnapshotObjectEntry(
+			String fdsName, String label, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(), 0, null,
+			HashMapBuilder.<String, Serializable>put(
+				"fdsName", fdsName
+			).put(
+				"label", label
+			).put(
+				"viewConfig", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private JSONObject _findSharedItemJSONObject(
+		JSONArray jsonArray, long objectEntryId) {
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			JSONObject groupJSONObject = jsonArray.getJSONObject(i);
+
+			if (!groupJSONObject.getBoolean("headerVisible")) {
+				continue;
+			}
+
+			JSONArray itemsJSONArray = groupJSONObject.getJSONArray("items");
+
+			for (int j = 0; j < itemsJSONArray.length(); j++) {
+				JSONObject itemJSONObject = itemsJSONArray.getJSONObject(j);
+
+				if (itemJSONObject.getLong("id") == objectEntryId) {
+					return itemJSONObject;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private HttpServletRequest _getHttpServletRequest(long userId)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.COMPANY_ID, TestPropsValues.getCompanyId());
+		mockHttpServletRequest.setAttribute(WebKeys.LOCALE, LocaleUtil.US);
+		mockHttpServletRequest.setAttribute(WebKeys.USER_ID, userId);
+
+		return mockHttpServletRequest;
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	private String _fdsName;
+
+	@Inject(filter = "frontend.data.set.serializer.type=system")
+	private FDSSerializer _fdsSerializer;
+
+	private String _label;
+
+	@DeleteAfterTestRun
+	private User _memberUser;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectEntry _objectEntry;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@DeleteAfterTestRun
+	private User _otherUser;
+
+	@DeleteAfterTestRun
+	private SharingEntry _sharingEntry;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@DeleteAfterTestRun
+	private UserGroup _userGroup;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94865

## What Is Being Fixed

The User Views Share modal lets an owner share a view with a User Group, but the shared view never appeared in the User Views dropdown for that group's members. Snapshot serialization only queried direct user-to-user sharing entries, so group-scoped entries were silently ignored — owners believed the share worked while recipients never saw the view.

## How It Is Being Fixed

`BaseFDSSerializer` now aggregates group-scoped sharing entries in addition to the direct ones. The collection logic moved into a helper that, for the current user, walks their User Groups via `UserGroupLocalService.getUserUserGroups`, fetches each group's `getToUserGroupSharingEntries`, filters those to the snapshot class name, and unions their class PKs into the existing OData snapshot filter. This mirrors the established pattern in `SharedAssetResourceImpl`. The existing `id in (...)` clause already supports the extra primary keys, so no filter-shape change was needed.

A `SnapshotsFDSSerializerTest` integration test covers both directions: a group member now sees the shared view, and a user outside the group does not.

## PR Check

**pr-check: PASS** — tested on `04ab790ccb84753b09ebafda6a43d8b0433dda0e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "04ab790ccb84753b09ebafda6a43d8b0433dda0e"} -->

## UI

https://github.com/user-attachments/assets/fe47254d-4595-493b-9f1c-77bb99f6bcd2

