### PR TITLE
LPD-93194 Add accessible label to Manage Columns toggle switches

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/table/Head.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/table/Head.tsx
@@ -178,6 +178,11 @@ export function Head<T extends Record<string, any>>(
 
 												<Layout.ContentCol float="end">
 													<Toggle
+														aria-label={
+															collection.getItem(
+																item
+															).value
+														}
 														containerProps={{
 															style: {
 																marginBottom: 0,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93194

## What Is Being Fixed

The toggle switches in the Manage Columns dropdown of a Clay table render with no accessible label. Screen readers announce each toggle without naming the column it controls, so a user relying on assistive technology cannot tell which column a given switch shows or hides.

## How It Is Being Fixed

The table `Head` passes the column's value as the `aria-label` on each `Toggle` it renders in the Manage Columns dropdown, so the control is announced with the name of the column it governs.

## Why Are There No Tests?

The change adds a single static `aria-label` attribute with no logic. The accessibility behavior is already covered by `modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts`.

## PR Check

**pr-check: PASS** — tested on `eb53bfd634141dd9d50bb2971520d4db3a32a2a7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | BLOCKED — clay unit specs cannot run in this checkout (no babel config for the vendored clay packages); the change was exercised by the JS production build during Per-Module Compile |

<!-- pr-check {"result": "success", "sha": "eb53bfd634141dd9d50bb2971520d4db3a32a2a7"} -->