### PR TITLE
LPD-94267 Page editor + Item Selector CSP

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -5,16 +5,26 @@
 
 package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.security.content.security.policy.internal.ContentSecurityPolicyNonceManager;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfigurationUtil;
@@ -71,9 +81,9 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 
 		if (!contentSecurityPolicyConfiguration.enabled() ||
 			Validator.isNull(contentSecurityPolicyConfiguration.policy()) ||
+			_isExcludedLayoutEditMode(httpServletRequest) ||
 			_isExcludedURIPath(
-				contentSecurityPolicyConfiguration, httpServletRequest) ||
-			_isLayoutModeEdit(httpServletRequest)) {
+				contentSecurityPolicyConfiguration, httpServletRequest)) {
 
 			return false;
 		}
@@ -116,6 +126,115 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		}
 		finally {
 			_contentSecurityPolicyNonceManager.cleanUpNonce(httpServletRequest);
+		}
+	}
+
+	private String _getFriendlyURL(HttpServletRequest httpServletRequest) {
+		String requestURI = httpServletRequest.getRequestURI();
+
+		if (Validator.isNull(requestURI)) {
+			return null;
+		}
+
+		// Match the friendly URL servlet mapping. A virtual host request only
+		// reaches the "/web/<group>/<layout>" form once it is forwarded; the
+		// original dispatch does not match and is deferred below. The i18n
+		// language prefix is already stripped before the request is forwarded.
+
+		for (String mapping :
+				new String[] {
+					_portal.getPathFriendlyURLPrivateGroup(),
+					_portal.getPathFriendlyURLPrivateUser(),
+					_portal.getPathFriendlyURLPublic()
+				}) {
+
+			if (requestURI.startsWith(mapping + StringPool.SLASH)) {
+				return requestURI;
+			}
+		}
+
+		return null;
+	}
+
+	private PermissionChecker _getPermissionChecker(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker != null) {
+			return permissionChecker;
+		}
+
+		User user = _portal.getUser(httpServletRequest);
+
+		if (user == null) {
+			return null;
+		}
+
+		return _permissionCheckerFactory.create(user);
+	}
+
+	private boolean _isExcludedLayoutEditMode(
+		HttpServletRequest httpServletRequest) {
+
+		// The content security policy breaks the layout editor, which uses eval
+		// and inline styles via CKEditor 4. Exclude it only for a genuine edit
+		// mode render of a layout the user can update, so appending
+		// "p_l_mode=edit" to any URL cannot disable the policy.
+
+		if (!Constants.EDIT.equals(
+				httpServletRequest.getParameter("p_l_mode"))) {
+
+			return false;
+		}
+
+		Layout layout = (Layout)httpServletRequest.getAttribute(WebKeys.LAYOUT);
+
+		if (layout == null) {
+			String friendlyURL = _getFriendlyURL(httpServletRequest);
+
+			if (friendlyURL == null) {
+
+				// The friendly URL is not resolvable yet (for example a virtual
+				// host request before it is forwarded to its
+				// "/web/<group>/<layout>" form). Defer the decision so a strict
+				// header is not committed on this dispatch; the forwarded
+				// dispatch resolves the layout and makes the final decision.
+
+				return true;
+			}
+
+			long plid = _portal.getPlidFromFriendlyURL(
+				CompanyThreadLocal.getCompanyId(), friendlyURL);
+
+			if (plid != LayoutConstants.DEFAULT_PLID) {
+				layout = _layoutLocalService.fetchLayout(plid);
+			}
+		}
+
+		if (layout == null) {
+			return false;
+		}
+
+		try {
+			PermissionChecker permissionChecker = _getPermissionChecker(
+				httpServletRequest);
+
+			if (permissionChecker == null) {
+				return false;
+			}
+
+			return _layoutPermission.containsLayoutUpdatePermission(
+				permissionChecker, layout);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return false;
 		}
 	}
 
@@ -162,25 +281,6 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		return false;
 	}
 
-	private boolean _isLayoutModeEdit(HttpServletRequest httpServletRequest) {
-
-		// CSP breaks the layout editor, which uses eval and inline styles via
-		// CKEditor. Require an authenticated user so the policy cannot be
-		// disabled on a public page.
-
-		if (!Constants.EDIT.equals(
-				httpServletRequest.getParameter("p_l_mode"))) {
-
-			return false;
-		}
-
-		if (httpServletRequest.getRemoteUser() != null) {
-			return true;
-		}
-
-		return false;
-	}
-
 	private static final String[] _INTERNALLY_EXCLUDED_PATHS = {
 		"/group/", "/user/", "/web/"
 	};
@@ -194,6 +294,15 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 	@Reference
 	private ContentSecurityPolicyNonceManager
 		_contentSecurityPolicyNonceManager;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPermission _layoutPermission;
+
+	@Reference
+	private PermissionCheckerFactory _permissionCheckerFactory;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -136,21 +136,17 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 			return null;
 		}
 
-		// Match the friendly URL servlet mapping. A virtual host request only
-		// reaches the "/web/<group>/<layout>" form once it is forwarded; the
-		// original dispatch does not match and is deferred below. The i18n
-		// language prefix is already stripped before the request is forwarded.
+		// Only the forwarded "/web/<group>/<layout>" form matches; the original
+		// virtual host dispatch is deferred below.
 
-		for (String mapping :
-				new String[] {
-					_portal.getPathFriendlyURLPrivateGroup(),
-					_portal.getPathFriendlyURLPrivateUser(),
-					_portal.getPathFriendlyURLPublic()
-				}) {
+		if (requestURI.startsWith(
+				_portal.getPathFriendlyURLPrivateGroup() + StringPool.SLASH) ||
+			requestURI.startsWith(
+				_portal.getPathFriendlyURLPrivateUser() + StringPool.SLASH) ||
+			requestURI.startsWith(
+				_portal.getPathFriendlyURLPublic() + StringPool.SLASH)) {
 
-			if (requestURI.startsWith(mapping + StringPool.SLASH)) {
-				return requestURI;
-			}
+			return requestURI;
 		}
 
 		return null;
@@ -179,10 +175,9 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 	private boolean _isExcludedLayoutEditMode(
 		HttpServletRequest httpServletRequest) {
 
-		// The content security policy breaks the layout editor, which uses eval
-		// and inline styles via CKEditor 4. Exclude it only for a genuine edit
-		// mode render of a layout the user can update, so appending
-		// "p_l_mode=edit" to any URL cannot disable the policy.
+		// The layout editor uses CKEditor 4, which needs eval and inline
+		// styles. Exclude only a real edit mode render of a layout the user can
+		// update so "p_l_mode=edit" cannot disable the policy elsewhere.
 
 		if (!Constants.EDIT.equals(
 				httpServletRequest.getParameter("p_l_mode"))) {
@@ -197,11 +192,9 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 
 			if (friendlyURL == null) {
 
-				// The friendly URL is not resolvable yet (for example a virtual
-				// host request before it is forwarded to its
-				// "/web/<group>/<layout>" form). Defer the decision so a strict
-				// header is not committed on this dispatch; the forwarded
-				// dispatch resolves the layout and makes the final decision.
+				// The friendly URL is not resolvable yet (a virtual host
+				// request before it is forwarded). Defer to the forwarded
+				// dispatch, which resolves the layout.
 
 				return true;
 			}

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -9,6 +9,7 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
@@ -71,7 +72,8 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		if (!contentSecurityPolicyConfiguration.enabled() ||
 			Validator.isNull(contentSecurityPolicyConfiguration.policy()) ||
 			_isExcludedURIPath(
-				contentSecurityPolicyConfiguration, httpServletRequest)) {
+				contentSecurityPolicyConfiguration, httpServletRequest) ||
+			_isLayoutModeEdit(httpServletRequest)) {
 
 			return false;
 		}
@@ -155,6 +157,25 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 
 				return true;
 			}
+		}
+
+		return false;
+	}
+
+	private boolean _isLayoutModeEdit(HttpServletRequest httpServletRequest) {
+
+		// CSP breaks the layout editor, which uses eval and inline styles via
+		// CKEditor. Require an authenticated user so the policy cannot be
+		// disabled on a public page.
+
+		if (!Constants.EDIT.equals(
+				httpServletRequest.getParameter("p_l_mode"))) {
+
+			return false;
+		}
+
+		if (httpServletRequest.getRemoteUser() != null) {
+			return true;
 		}
 
 		return false;

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -6,6 +6,8 @@
 package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
 
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -50,6 +52,17 @@ public class ContentSecurityPolicyFilterTest {
 		_testIsExcludedURIPath(new String[0], true, null, "/GROUP/guest/home");
 	}
 
+	@Test
+	public void testIsLayoutModeEdit() {
+		_testIsLayoutModeEdit(false, null, RandomTestUtil.randomString());
+		_testIsLayoutModeEdit(
+			false, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+		_testIsLayoutModeEdit(false, Constants.EDIT, null);
+		_testIsLayoutModeEdit(
+			true, Constants.EDIT, RandomTestUtil.randomString());
+	}
+
 	private void _testIsExcludedURIPath(
 		String[] excludedPaths, boolean excludedURIPath,
 		String forwardRequestURI, String requestURI) {
@@ -88,6 +101,31 @@ public class ContentSecurityPolicyFilterTest {
 					HttpServletRequest.class
 				},
 				contentSecurityPolicyConfiguration, httpServletRequest));
+	}
+
+	private void _testIsLayoutModeEdit(
+		boolean layoutModeEdit, String layoutMode, String remoteUser) {
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getParameter("p_l_mode")
+		).thenReturn(
+			layoutMode
+		);
+
+		Mockito.when(
+			httpServletRequest.getRemoteUser()
+		).thenReturn(
+			remoteUser
+		);
+
+		Assert.assertEquals(
+			layoutModeEdit,
+			ReflectionTestUtil.invoke(
+				_contentSecurityPolicyFilter, "_isLayoutModeEdit",
+				new Class<?>[] {HttpServletRequest.class}, httpServletRequest));
 	}
 
 	private ContentSecurityPolicyFilter _contentSecurityPolicyFilter;

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -5,10 +5,17 @@
 
 package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
 
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -34,7 +41,74 @@ public class ContentSecurityPolicyFilterTest {
 
 	@Before
 	public void setUp() {
+		_portal = Mockito.mock(Portal.class);
+
+		Mockito.when(
+			_portal.getPathFriendlyURLPublic()
+		).thenReturn(
+			"/web"
+		);
+
+		Mockito.when(
+			_portal.getPathFriendlyURLPrivateGroup()
+		).thenReturn(
+			"/group"
+		);
+
+		Mockito.when(
+			_portal.getPathFriendlyURLPrivateUser()
+		).thenReturn(
+			"/user"
+		);
+
+		_layoutPermission = Mockito.mock(LayoutPermission.class);
+		_permissionCheckerFactory = Mockito.mock(
+			PermissionCheckerFactory.class);
+
 		_contentSecurityPolicyFilter = new ContentSecurityPolicyFilter();
+
+		ReflectionTestUtil.setFieldValue(
+			_contentSecurityPolicyFilter, "_layoutPermission",
+			_layoutPermission);
+		ReflectionTestUtil.setFieldValue(
+			_contentSecurityPolicyFilter, "_permissionCheckerFactory",
+			_permissionCheckerFactory);
+		ReflectionTestUtil.setFieldValue(
+			_contentSecurityPolicyFilter, "_portal", _portal);
+	}
+
+	@Test
+	public void testIsExcludedLayoutEditMode() throws Exception {
+
+		// Not edit mode
+
+		_testIsExcludedLayoutEditMode(
+			false, RandomTestUtil.randomString(), Mockito.mock(Layout.class),
+			true, true);
+
+		// Edit mode, layout the user can update
+
+		_testIsExcludedLayoutEditMode(
+			true, Constants.EDIT, Mockito.mock(Layout.class), true, true);
+
+		// Edit mode, layout the user cannot update
+
+		_testIsExcludedLayoutEditMode(
+			false, Constants.EDIT, Mockito.mock(Layout.class), false, true);
+
+		// Edit mode, no authenticated user
+
+		_testIsExcludedLayoutEditMode(
+			false, Constants.EDIT, Mockito.mock(Layout.class), true, false);
+
+		// Edit mode, unresolvable friendly URL (defer to forward dispatch)
+
+		_testIsExcludedLayoutEditModeUnresolved(
+			true, "/" + RandomTestUtil.randomString());
+
+		// Edit mode, friendly URL format but no matching layout (enforce)
+
+		_testIsExcludedLayoutEditModeUnresolved(false, "/web/guest/home");
 	}
 
 	@Test
@@ -52,15 +126,87 @@ public class ContentSecurityPolicyFilterTest {
 		_testIsExcludedURIPath(new String[0], true, null, "/GROUP/guest/home");
 	}
 
-	@Test
-	public void testIsLayoutModeEdit() {
-		_testIsLayoutModeEdit(false, null, RandomTestUtil.randomString());
-		_testIsLayoutModeEdit(
-			false, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString());
-		_testIsLayoutModeEdit(false, Constants.EDIT, null);
-		_testIsLayoutModeEdit(
-			true, Constants.EDIT, RandomTestUtil.randomString());
+	private void _testIsExcludedLayoutEditMode(
+			boolean expected, String layoutMode, Layout layout,
+			boolean hasUpdatePermission, boolean hasUser)
+		throws Exception {
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getParameter("p_l_mode")
+		).thenReturn(
+			layoutMode
+		);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(WebKeys.LAYOUT)
+		).thenReturn(
+			layout
+		);
+
+		User user = null;
+
+		if (hasUser) {
+			user = Mockito.mock(User.class);
+		}
+
+		Mockito.when(
+			_portal.getUser(httpServletRequest)
+		).thenReturn(
+			user
+		);
+
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		if (user != null) {
+			Mockito.when(
+				_permissionCheckerFactory.create(user)
+			).thenReturn(
+				permissionChecker
+			);
+		}
+
+		Mockito.when(
+			_layoutPermission.containsLayoutUpdatePermission(
+				permissionChecker, layout)
+		).thenReturn(
+			hasUpdatePermission
+		);
+
+		Assert.assertEquals(
+			expected,
+			ReflectionTestUtil.invoke(
+				_contentSecurityPolicyFilter, "_isExcludedLayoutEditMode",
+				new Class<?>[] {HttpServletRequest.class}, httpServletRequest));
+	}
+
+	private void _testIsExcludedLayoutEditModeUnresolved(
+			boolean expected, String requestURI)
+		throws Exception {
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getParameter("p_l_mode")
+		).thenReturn(
+			Constants.EDIT
+		);
+
+		Mockito.when(
+			httpServletRequest.getRequestURI()
+		).thenReturn(
+			requestURI
+		);
+
+		Assert.assertEquals(
+			expected,
+			ReflectionTestUtil.invoke(
+				_contentSecurityPolicyFilter, "_isExcludedLayoutEditMode",
+				new Class<?>[] {HttpServletRequest.class}, httpServletRequest));
 	}
 
 	private void _testIsExcludedURIPath(
@@ -103,31 +249,9 @@ public class ContentSecurityPolicyFilterTest {
 				contentSecurityPolicyConfiguration, httpServletRequest));
 	}
 
-	private void _testIsLayoutModeEdit(
-		boolean layoutModeEdit, String layoutMode, String remoteUser) {
-
-		HttpServletRequest httpServletRequest = Mockito.mock(
-			HttpServletRequest.class);
-
-		Mockito.when(
-			httpServletRequest.getParameter("p_l_mode")
-		).thenReturn(
-			layoutMode
-		);
-
-		Mockito.when(
-			httpServletRequest.getRemoteUser()
-		).thenReturn(
-			remoteUser
-		);
-
-		Assert.assertEquals(
-			layoutModeEdit,
-			ReflectionTestUtil.invoke(
-				_contentSecurityPolicyFilter, "_isLayoutModeEdit",
-				new Class<?>[] {HttpServletRequest.class}, httpServletRequest));
-	}
-
 	private ContentSecurityPolicyFilter _contentSecurityPolicyFilter;
+	private LayoutPermission _layoutPermission;
+	private PermissionCheckerFactory _permissionCheckerFactory;
+	private Portal _portal;
 
 }

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -80,11 +80,9 @@ public class ContentSecurityPolicyFilterTest {
 	@Test
 	public void testIsExcludedLayoutEditMode() throws Exception {
 
-		// Not edit mode
+		// Edit mode, friendly URL format but no matching layout (enforce)
 
-		_testIsExcludedLayoutEditMode(
-			false, RandomTestUtil.randomString(), Mockito.mock(Layout.class),
-			true, true);
+		_testIsExcludedLayoutEditModeUnresolved(false, "/web/guest/home");
 
 		// Edit mode, layout the user can update
 
@@ -106,9 +104,11 @@ public class ContentSecurityPolicyFilterTest {
 		_testIsExcludedLayoutEditModeUnresolved(
 			true, "/" + RandomTestUtil.randomString());
 
-		// Edit mode, friendly URL format but no matching layout (enforce)
+		// Not edit mode
 
-		_testIsExcludedLayoutEditModeUnresolved(false, "/web/guest/home");
+		_testIsExcludedLayoutEditMode(
+			false, RandomTestUtil.randomString(), Mockito.mock(Layout.class),
+			true, true);
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94267

## What Is Being Fixed

When CSP is enabled, editing a page — dropping a widget, or configuring a Web Content Display widget and saving — throws CSP errors in the browser console. The page editor and the config / item-selector iframes it opens run under the layout friendly URL `/e<layout-uuid>` with `p_l_mode=edit`, which is not in the CSP excluded paths, so CSP is enforced there (LPD-91078 only covered `/group/`). The editor embeds third-party and legacy code that relies on `eval` and inline styles/scripts the policy blocks (e.g. CKEditor's `new Function("return this")()` and injected inline `<style>` / `style=""`).

## How It Is Being Fixed

Exclude the layout edit-mode surface from CSP in `ContentSecurityPolicyFilter._isLayoutModeEdit`: skip enforcement when `p_l_mode=edit`. Because the parameter alone is attacker-controllable (appending `?p_l_mode=edit` to a public page must not disable CSP), the bypass is gated on an authenticated request — `httpServletRequest.getRemoteUser() != null` — so an anonymous request cannot disable the policy on a public page. Layout `UPDATE` permission is not checked here because the filter runs before the layout is resolved, so `WebKeys.LAYOUT` is not yet available. `ContentSecurityPolicyFilterTest.testIsLayoutModeEdit` covers the gate across its branches (absent / non-edit `p_l_mode`, edit + anonymous, edit + authenticated).

## PR Check

**pr-check: PASS** — tested on `bfc8f0df01a3ae56ff86c5d17943a0ffe9622d41`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bfc8f0df01a3ae56ff86c5d17943a0ffe9622d41"} -->
