### PR TITLE
LPD-95087 Fix FieldSelectModalPage locator

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/components/FieldSelectModalPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/components/FieldSelectModalPage.ts
@@ -46,7 +46,7 @@ export class FieldSelectModalPage {
 	}) {
 		const treeItem = dataId
 			? this.fieldSelectModalContainer.locator(
-					`.treeview-link[data-id$=",${dataId}"]`
+					`.treeview-link[data-id$="${dataId}"]`
 				)
 			: this.fieldSelectModalContainer.getByRole('treeitem', {
 					exact: true,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95087

## What Is Being Fixed

The field selection modal of the Data Set Manager visualization modes section matched the checked field with a `data-id` suffix selector that required a leading comma (`[data-id$=",${dataId}"]`). When a field's `data-id` does not carry that comma prefix, the locator fails to find the checked/selected field, so the Playwright test fails. Two earlier fixes were sent, but problems during merge reintroduced the failure.

## How It Is Being Fixed

The locator now matches the `data-id` suffix directly (`[data-id$="${dataId}"]`), dropping the spurious leading comma so it resolves the field regardless of the surrounding `data-id` structure.

## Why Are There No Tests?

This change fixes existing Playwright test infrastructure — a locator in the `FieldSelectModalPage` page object exercised by `visualizationModes.spec.ts`. No new test is warranted because the change repairs the test helper itself.

## PR Check

**pr-check: PASS** — tested on `455994b4895079a959f21bf8d30f1ecc7c8384c1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "455994b4895079a959f21bf8d30f1ecc7c8384c1"} -->
