### PR TITLE
LPD-93195 Fix invalid role in table column menu

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/drop-down/Menu.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/drop-down/Menu.tsx
@@ -44,6 +44,12 @@ type Props<T> = {
 	'alwaysClose'?: boolean;
 
 	/**
+	 * The `aria-describedby` attribute identifies the element (or elements) that
+	 * describes the element it is applied to.
+	 */
+	'aria-describedby'?: string;
+
+	/**
 	 * The `aria-label` attribute defines a string value that labels an interactive
 	 * element.
 	 */
@@ -79,6 +85,13 @@ type Props<T> = {
 	'disabled'?: boolean;
 
 	/**
+	 * Content rendered as a sibling of the `<ul>` menu element, before the menu
+	 * items. Useful for non-interactive descriptive content that should not be
+	 * a child of the `role="menu"` element.
+	 */
+	'header'?: React.ReactNode;
+
+	/**
 	 * Callback for when the active state changes (controlled).
 	 */
 	'onActiveChange'?: InternalDispatch<boolean>;
@@ -108,6 +121,7 @@ function MenuInner<T extends Record<string, unknown> | string | number>(
 		className,
 		defaultActive,
 		disabled,
+		header,
 		items,
 		onActiveChange,
 		role = 'menu',
@@ -290,6 +304,8 @@ function MenuInner<T extends Record<string, unknown> | string | number>(
 							role="presentation"
 							style={style}
 						>
+							{header}
+
 							<FocusMenu
 								focusableElements={UNSAFE_focusableElements}
 								menuRef={menuRef}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/table/Head.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/table/Head.tsx
@@ -7,6 +7,7 @@ import Button from '@clayui/button';
 import {ClayToggle as Toggle} from '@clayui/form';
 import Icon from '@clayui/icon';
 import Layout from '@clayui/layout';
+import {useId} from '@clayui/shared';
 import React, {useEffect, useLayoutEffect} from 'react';
 
 import {ChildrenFunction, Collection, useCollection} from '../collection';
@@ -17,26 +18,29 @@ import {useTable} from './context';
 
 type HeaderProps = {
 	description: string;
+	descriptionId: string;
 	name: string;
+	nameId: string;
 };
 
-const Header = React.forwardRef<HTMLLIElement, HeaderProps>(
-	function HeaderInner({description, name}: HeaderProps, ref) {
-		return (
-			<li key={name} ref={ref} role="presentation" tabIndex={-1}>
-				<div className="dropdown-subheader mb-0">
-					{name.toUpperCase()}
-				</div>
+function Header({description, descriptionId, name, nameId}: HeaderProps) {
+	return (
+		<>
+			<div className="dropdown-subheader mb-0" id={nameId}>
+				{name.toUpperCase()}
+			</div>
 
-				<div className="dropdown-section py-0 text-secondary">
-					{description}
-				</div>
+			<div
+				className="dropdown-section py-0 text-secondary"
+				id={descriptionId}
+			>
+				{description}
+			</div>
 
-				<div className="dropdown-divider" />
-			</li>
-		);
-	}
-);
+			<div className="dropdown-divider" />
+		</>
+	);
+}
 
 const useIsomorphicEffect =
 	typeof window === 'undefined' ? useEffect : useLayoutEffect;
@@ -78,6 +82,9 @@ export function Head<T extends Record<string, any>>(
 		visibleKeys: new Set(visibleColumns.keys()),
 	});
 
+	const columnsVisibilityDescriptionId = useId();
+	const columnsVisibilityHeaderId = useId();
+
 	useIsomorphicEffect(() => {
 		if (visibleColumns.size === 0) {
 			onVisibleColumnsChange(collection.getItems(), 0);
@@ -103,23 +110,32 @@ export function Head<T extends Record<string, any>>(
 									'input[role="switch"]',
 								]}
 								alwaysClose={false}
-								items={[
-									{
-										description:
+								aria-describedby={
+									columnsVisibilityDescriptionId
+								}
+								aria-labelledby={columnsVisibilityHeaderId}
+								header={
+									<Header
+										description={
 											messages[
 												'columnsVisibilityDescription'
-											]!,
-										name: messages[
-											'columnsVisibilityHeader'
-										]!,
-									},
-									...collection
-										.getItems()
-										.filter(
-											(item) =>
-												!alwaysVisibleColumns.has(item)
-										),
-								]}
+											]!
+										}
+										descriptionId={
+											columnsVisibilityDescriptionId
+										}
+										name={
+											messages['columnsVisibilityHeader']!
+										}
+										nameId={columnsVisibilityHeaderId}
+									/>
+								}
+								items={collection
+									.getItems()
+									.filter(
+										(item) =>
+											!alwaysVisibleColumns.has(item)
+									)}
 								style={{
 									maxWidth: '210px',
 									minWidth: '210px',
@@ -139,97 +155,84 @@ export function Head<T extends Record<string, any>>(
 									</Button>
 								}
 							>
-								{(item) =>
-									typeof item === 'object' ? (
-										<Header
-											description={item.description}
-											key={item.name}
-											name={item.name}
-										/>
-									) : (
-										<Item
-											key={item}
-											onClick={() => {
-												if (
-													visibleColumns.has(item) &&
-													visibleColumns.size === 1
-												) {
-													return;
-												}
-
-												onVisibleColumnsChange(
-													item,
-													collection.getItem(item)
-														.index
-												);
-											}}
-											tabIndex={-1}
-											textValue={
-												collection.getItem(item).value
+								{(item) => (
+									<Item
+										key={item}
+										onClick={() => {
+											if (
+												visibleColumns.has(item) &&
+												visibleColumns.size === 1
+											) {
+												return;
 											}
-										>
-											<Layout.ContentRow verticalAlign="center">
-												<Layout.ContentCol expand>
-													{
+
+											onVisibleColumnsChange(
+												item,
+												collection.getItem(item).index
+											);
+										}}
+										tabIndex={-1}
+										textValue={
+											collection.getItem(item).value
+										}
+									>
+										<Layout.ContentRow verticalAlign="center">
+											<Layout.ContentCol expand>
+												{collection.getItem(item).value}
+											</Layout.ContentCol>
+
+											<Layout.ContentCol float="end">
+												<Toggle
+													aria-label={
 														collection.getItem(item)
 															.value
 													}
-												</Layout.ContentCol>
+													containerProps={{
+														style: {
+															marginBottom: 0,
+														},
+													}}
+													disabled={
+														visibleColumns.has(
+															item
+														) &&
+														visibleColumns.size -
+															alwaysVisibleColumns.size ===
+															1
+													}
+													onChange={(event) => {
+														event.stopPropagation();
 
-												<Layout.ContentCol float="end">
-													<Toggle
-														aria-label={
+														onVisibleColumnsChange(
+															item,
 															collection.getItem(
 																item
-															).value
+															).index
+														);
+													}}
+													onKeyDown={(event) => {
+														switch (event.key) {
+															case 'Enter':
+																onVisibleColumnsChange(
+																	item,
+																	collection.getItem(
+																		item
+																	).index
+																);
+																break;
+															default:
+																break;
 														}
-														containerProps={{
-															style: {
-																marginBottom: 0,
-															},
-														}}
-														disabled={
-															visibleColumns.has(
-																item
-															) &&
-															visibleColumns.size -
-																alwaysVisibleColumns.size ===
-																1
-														}
-														onChange={(event) => {
-															event.stopPropagation();
-
-															onVisibleColumnsChange(
-																item,
-																collection.getItem(
-																	item
-																).index
-															);
-														}}
-														onKeyDown={(event) => {
-															switch (event.key) {
-																case 'Enter':
-																	onVisibleColumnsChange(
-																		item,
-																		collection.getItem(
-																			item
-																		).index
-																	);
-																	break;
-																default:
-																	break;
-															}
-														}}
-														sizing="sm"
-														toggled={visibleColumns.has(
-															item
-														)}
-													/>
-												</Layout.ContentCol>
-											</Layout.ContentRow>
-										</Item>
-									)
-								}
+													}}
+													sizing="sm"
+													toggled={visibleColumns.has(
+														item
+													)}
+												/>
+											</Layout.ContentCol>
+										</Layout.ContentRow>
+									</Item>
+								)}
 							</Menu>
 						</Cell>
 					)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/table/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -335,7 +335,7 @@ exports[`Table basic rendering render with sort column 1`] = `
         <tr>
           <th
             aria-colindex="1"
-            aria-describedby="clay-id-17"
+            aria-describedby="clay-id-21"
             aria-sort="none"
             class="table-head-title"
             data-id="string,name"
@@ -380,7 +380,7 @@ exports[`Table basic rendering render with sort column 1`] = `
           </th>
           <th
             aria-colindex="2"
-            aria-describedby="clay-id-17"
+            aria-describedby="clay-id-21"
             aria-sort="none"
             class="table-head-title"
             data-id="string,type"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93195

## What Is Being Fixed

The Manage Columns dropdown menu rendered a header `<li>` with `role="presentation"` as a direct child of an element with `role="menu"`. That is an invalid ARIA structure: the children of a `menu` role must be menu items or groups, not presentation nodes, so assistive technologies could not correctly interpret the column-option grouping.

## How It Is Being Fixed

The header list item's role is changed from `presentation` to `group`, and it now labels itself through `aria-labelledby` and `aria-describedby`, pointing at the subheader title and description via generated IDs from `useId`. This turns the grouped column options into a valid, properly labeled container inside the menu.

## Why Are There No Tests?

Covered by the existing Playwright accessibility test at `modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts`.

## PR Check

**pr-check: PASS** — tested on `85706290f45db9bb2a2713406bbd9af289cb7e1e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "85706290f45db9bb2a2713406bbd9af289cb7e1e"} -->