### PR TITLE
LPD-95249 Select the locale with a dispatched click event

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor5-sample-web/pages/InputLocalizedPage.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor5-sample-web/pages/InputLocalizedPage.ts
@@ -60,24 +60,20 @@ export class InputLocalizedPage {
 	 * verifies the language button reflects the new locale.
 	 *
 	 * The dropdown menu is a portal aligned to its trigger. When the trigger
-	 * sits low on the page the menu opens below the viewport fold, so clicking
-	 * an option forces a page scroll that realigns the menu; on a slow CI
-	 * machine the menu shifts in the gap between Playwright computing the click
-	 * point and dispatching the event, and the click lands off the option
-	 * without committing the selection. Scrolling the trigger up first lets the
-	 * menu open fully on-screen, so the option click needs no scroll and lands
-	 * cleanly. The open/click/verify flow is still retried as a unit as a
-	 * safety net.
+	 * sits low on the page the menu opens below the viewport fold (and clay
+	 * may flip it above the trigger), so a normal click forces Playwright to
+	 * scroll, which realigns the portal menu; the synthesized click then lands
+	 * off the moving option and never fires its onClick, leaving the locale
+	 * unchanged. Dispatching the click event directly on the option triggers
+	 * the same React handler without depending on the option's on-screen
+	 * position, so the selection commits regardless of where the menu opens.
+	 * The open/select/verify flow is retried as a unit as a safety net.
 	 */
 	async switchLanguage(
 		languageButton: Locator,
 		option: Locator,
 		expectedLanguageId: string
 	) {
-		await languageButton.evaluate((element) =>
-			element.scrollIntoView({block: 'start'})
-		);
-
 		await expect(async () => {
 			const expanded = await languageButton.getAttribute('aria-expanded');
 
@@ -85,7 +81,9 @@ export class InputLocalizedPage {
 				await languageButton.click({timeout: 1000});
 			}
 
-			await option.click({timeout: 1000});
+			await expect(option).toBeVisible({timeout: 1000});
+
+			await option.dispatchEvent('click');
 
 			await expect(languageButton).toContainText(expectedLanguageId, {
 				timeout: 1000,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95249

## What Is Being Fixed

The ckeditor5 input_localized Playwright test fails because selecting a language never commits. The content editor sits low on the page, so its language dropdown — a portal aligned to the trigger — opens below the viewport fold, and clay flips it above the trigger. A normal Playwright click on an option forces a page scroll that realigns the portal menu; the synthesized click lands off the moving option and never fires its onClick, so the locale stays unchanged, the dropdown stays open, and the test times out. A direct click event on the same option commits instantly, confirming the React handler is fine and the miss is purely positional.

## How It Is Being Fixed

InputLocalizedPage.switchLanguage now dispatches the click event directly on the option, which triggers the same handler without depending on the option's on-screen position. Verified against the failure: it turns a 100% failure rate (both unthrottled and under CPU throttling with a shortened viewport) into a 100% pass rate. This supersedes the scroll-into-view attempt from LPD-94734 (#5556), which Playwright's own click undid by re-scrolling.

## Why Are There No Tests?

This change modifies test code only. It stabilizes the existing input_localized.spec.ts Playwright test, which is itself the coverage; no product code changed, so no new test is added.

## PR Check

**pr-check: PASS** — tested on `32c6d8f59c39e9f94050aaa90e2e19302b9e636f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "32c6d8f59c39e9f94050aaa90e2e19302b9e636f"} -->
