### PR TITLE
LPD-93466 Skip view change when the requested view is already active

### DIFF
--- a/modules/test/playwright/tests/journal-web/main/pages/JournalPage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalPage.ts
@@ -199,10 +199,23 @@ export class JournalPage {
 	}
 
 	async changeView(viewName: string) {
+		const selectViewButton = this.page.getByLabel(
+			'Select View, Currently Selected: '
+		);
+
+		await expect(selectViewButton).toBeVisible();
+
+		const currentViewLabel =
+			await selectViewButton.getAttribute('aria-label');
+
+		if (currentViewLabel?.endsWith(`: ${viewName}`)) {
+			return;
+		}
+
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: this.page.getByRole('menuitem', {name: viewName}),
-			trigger: this.page.getByLabel('Select View, Currently Selected: '),
+			trigger: selectViewButton,
 		});
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93466

## What Is Being Fixed

Both tests in `frontend-taglib/main/tests/frontend-taglib/diff_version_comparator.spec.ts` timed out during setup and never reached the diff-version-comparator behavior under test. They failed in the shared `JournalPage.changeView('List')` step.

## How It Is Being Fixed

`changeView` clicked the requested view's menuitem unconditionally. The Web Content admin defaults to the List view (`displayStyle=descriptive`), and the currently-selected view's menuitem is rendered with `pointer-events: none`, so the click never became actionable and `clickAndExpectToBeVisible` retried until the 90s test timeout. `changeView` now reads the toolbar's "Select View, Currently Selected: X" label and returns early when the requested view is already active, only clicking through the dropdown when an actual switch is needed. This fixes every caller of the shared page object, not just this spec.

## Why Are There No Tests?

The change is confined to a shared Playwright page object (test infrastructure); no product code changed. It is verified by the existing `diff_version_comparator.spec.ts` tests, which now pass where they previously timed out.

## PR Check

**pr-check: PASS** — tested on `0f13b90c16dcea1b525408ad67b9a9a902cb4cb6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0f13b90c16dcea1b525408ad67b9a9a902cb4cb6"} -->
