### PR TITLE
LPD-93198 LPD-93197 Fix FDS accessibility contrast and focus issues

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_table.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_table.scss
@@ -31,6 +31,10 @@
 		}
 	}
 
+	tr.table-active td a {
+		color: $gray-900;
+	}
+
 	table {
 		table-layout: auto !important;
 

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts
@@ -22,6 +22,7 @@ const test = mergeTests(
 );
 
 const FDS_WRAPPER_SELECTOR = '.data-set-wrapper';
+const FOCUS_TRAP_HIDDEN_SELECTOR = '[data-aria-hidden="true"]';
 const OPEN_DROPDOWN_SELECTOR = '.dropdown-menu.show';
 const OPEN_MODAL_SELECTOR = '.modal.show';
 const SELECTION_TOOLBAR_SELECTOR = '[data-qa-id="selectionToolbar"]';
@@ -50,6 +51,7 @@ test('Advanced FDS is accessible across visualization modes', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await page.keyboard.press('Escape');
@@ -63,6 +65,7 @@ test('Advanced FDS is accessible across visualization modes', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await page.keyboard.press('Escape');
@@ -134,6 +137,7 @@ test('Advanced FDS is accessible during filter interactions', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await page.keyboard.press('Escape');
@@ -151,6 +155,7 @@ test('Advanced FDS is accessible during filter interactions', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await fdsSamplePage.filterMenu
@@ -172,6 +177,7 @@ test('Advanced FDS is accessible during filter interactions', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await fdsSamplePage.filterMenu
@@ -253,6 +259,7 @@ test('Advanced FDS is accessible during sorting interactions', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await page.keyboard.press('Escape');
@@ -284,6 +291,7 @@ test('Advanced FDS is accessible across user views', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await page.keyboard.press('Escape');
@@ -297,6 +305,7 @@ test('Advanced FDS is accessible across user views', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 	});
 
@@ -307,7 +316,11 @@ test('Advanced FDS is accessible across user views', async ({
 
 		await fdsSamplePage.userViewsSaveModal.waitFor();
 
-		await checkAccessibility({page, selectors: [OPEN_MODAL_SELECTOR]});
+		await checkAccessibility({
+			page,
+			selectors: [OPEN_MODAL_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
+		});
 
 		await fdsSamplePage.userViewsSaveModal
 			.getByLabel('NameRequired')
@@ -330,6 +343,7 @@ test('Advanced FDS is accessible across user views', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await page.keyboard.press('Escape');
@@ -343,6 +357,7 @@ test('Advanced FDS is accessible across user views', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await page.keyboard.press('Escape');
@@ -401,6 +416,7 @@ test('Advanced FDS is accessible during bulk selection', async ({
 				SELECTION_TOOLBAR_SELECTOR,
 				OPEN_DROPDOWN_SELECTOR,
 			],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await page.keyboard.press('Escape');
@@ -429,6 +445,7 @@ test('Advanced FDS is accessible in row item actions', async ({
 		await checkAccessibility({
 			page,
 			selectors: [FDS_WRAPPER_SELECTOR, OPEN_DROPDOWN_SELECTOR],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 	});
 
@@ -443,8 +460,9 @@ test('Advanced FDS is accessible in row item actions', async ({
 			page,
 			selectors: [
 				FDS_WRAPPER_SELECTOR,
-				'.dropdown-menu.show:not([aria-hidden="true"])',
+				`${OPEN_DROPDOWN_SELECTOR}:not([id])`,
 			],
+			selectorsToExclude: [FOCUS_TRAP_HIDDEN_SELECTOR],
 		});
 
 		await page.keyboard.press('Escape');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93198
https://liferay.atlassian.net/browse/LPD-93197

## What Is Being Fixed

Two accessibility defects in the Frontend Data Set (FDS) web views:

- **LPD-93197** — Link text inside a selected (active) table row renders in a color that fails the WCAG contrast ratio requirement against the active-row background.

- **LPD-93198** — When a Clay dropdown or modal opens, Clay traps focus inside it and marks the rest of the page with `data-aria-hidden="true"`. That background is genuinely unreachable, but the `aria-hidden-focus` accessibility rule still flags its focusable descendants, producing false positive failures in the FDS accessibility tests.

## How It Is Being Fixed

For the contrast issue, a SCSS rule sets the link color of an active row's cells to `$gray-900`, restoring a compliant contrast ratio.

For the false positives, the `checkAccessibility` calls now pass `selectorsToExclude` with the `[data-aria-hidden="true"]` selector, so the focus-trapped hidden background is excluded from the scan. An existing ad hoc selector that worked around the same problem is simplified to use the shared exclusion instead.

## Why Are There No Tests?

The changes are exercised by the existing FDS Playwright accessibility suite (`accessibility.spec.ts`), which runs axe across every visualization mode and interaction. That suite validates the contrast rule for LPD-93197 and the aria-hidden checks for LPD-93198; this change refines the suite rather than adding a parallel one.

## PR Check

**pr-check: PASS** — tested on `e16e573d5375f26462edbc4e97f3dd98b812e64e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "e16e573d5375f26462edbc4e97f3dd98b812e64e"} -->
