### PR TITLE
LPD-93196 Give dropdown menu tabindex 0 when active

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/Menu.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/Menu.tsx
@@ -225,6 +225,7 @@ const Menu = React.forwardRef<HTMLDivElement, IProps>(
 						})}
 						ref={menuRef}
 						role={role}
+						tabIndex={active ? 0 : undefined}
 					>
 						{children}
 					</div>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
@@ -24,6 +24,7 @@ exports[`ClayDropDown renders dropdown menu when clicked 1`] = `
         id="clay-dropdown-menu-2"
         role="presentation"
         style="left: -999px; top: -995px;"
+        tabindex="0"
       >
         <ul
           class="list-unstyled"
@@ -96,6 +97,7 @@ exports[`ClayDropDown renders with groups 1`] = `
         id="clay-dropdown-menu-7"
         role="presentation"
         style="left: -999px; top: -995px;"
+        tabindex="0"
       >
         <ul
           class="list-unstyled"
@@ -240,6 +242,7 @@ exports[`ClayDropDown renders with icons 1`] = `
         id="clay-dropdown-menu-6"
         role="presentation"
         style="left: -999px; top: -995px;"
+        tabindex="0"
       >
         <ul
           class="list-unstyled"
@@ -357,6 +360,7 @@ exports[`ClayDropDown renders with search input 1`] = `
         id="clay-dropdown-menu-5"
         role="presentation"
         style="left: -999px; top: -995px;"
+        tabindex="0"
       >
         <form
           class=""


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93196

## What Is Being Fixed

The dropdown menu container is a scrollable region, but it carried no
tabindex, so it was not keyboard-focusable. Keyboard-only users could
not move focus to the menu to scroll it, which is an accessibility
defect for long or overflowing dropdown menus.

## How It Is Being Fixed

The menu container is given `tabIndex={active ? 0 : undefined}` so that
the scrollable region becomes keyboard-focusable only while the menu is
open, and stays out of the tab order when it is closed. The
clay-drop-down Jest snapshots were regenerated to reflect the new
`tabindex="0"` attribute on the rendered menu container.

## Why Are There No Tests?

The keyboard-accessibility behavior is covered by the existing Playwright
accessibility suite at
modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts,
and the clay-drop-down Jest snapshots assert the rendered tabindex
attribute.

## PR Check

**pr-check: PASS** — tested on `ae994efdbb58b1805e9d3f10133379fac9e16226`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ae994efdbb58b1805e9d3f10133379fac9e16226"} -->
