### PR TITLE
LPD-95613 Do not load custom element resources without VIEW permission

### DIFF
--- a/modules/test/playwright/tests/client-extension-web/main/customElement.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/customElement.spec.ts
@@ -11,6 +11,7 @@ import {loginTest} from '../../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {liferayConfig} from '../../../liferay.config';
 import getRandomString from '../../../utils/getRandomString';
+import {performLoginViaApi, performLogout} from '../../../utils/performLogin';
 import {clientExtensionsPageTest} from './fixtures/clientExtensionsPageTest';
 import {editCustomElementPageTest} from './fixtures/editCustomElementPageTest';
 import {Column} from './pages/ClientExtensionsPage';
@@ -836,6 +837,98 @@ test(
 		});
 
 		await test.step('Clean up', async () => {
+			await clientExtensionsPage.deleteClientExtension(
+				clientExtensionName
+			);
+		});
+	}
+);
+
+testSample(
+	'Custom Element resources are not loaded for a guest without VIEW permission',
+	{tag: '@LPD-95613'},
+	async ({
+		clientExtensionsPage,
+		editCustomElementPage,
+		layout,
+		page,
+		pageEditorPage,
+	}) => {
+		const clientExtensionName = getRandomString();
+		const cssResourceName = `res-${getRandomString()}.css`;
+		const htmlElementName = `html-${getRandomString()}`;
+		const jsResourceName = `res-${getRandomString()}.js`;
+
+		await test.step('Create a Custom Element with CSS and JavaScript resources', async () => {
+			await editCustomElementPage.goto();
+
+			await editCustomElementPage.cssURLInput.fill(
+				`https://www.example.com/${cssResourceName}`
+			);
+			await editCustomElementPage.htmlElementNameInput.fill(
+				htmlElementName
+			);
+			await editCustomElementPage.javaScriptURLInput.fill(
+				`https://www.example.com/${jsResourceName}`
+			);
+			await editCustomElementPage.nameInput.fill(clientExtensionName);
+
+			await editCustomElementPage.publish(WaitAction.SUCCESS);
+		});
+
+		await test.step('Add the widget and remove VIEW permission for the Guest role', async () => {
+			await page.goto(`/web/guest${layout.friendlyURL}?p_l_mode=edit`);
+
+			await pageEditorPage.addWidget(
+				'Client Extensions',
+				clientExtensionName
+			);
+
+			const widgetId =
+				await pageEditorPage.getFragmentId(clientExtensionName);
+
+			await pageEditorPage.changeWidgetPermission(
+				widgetId,
+				'#guest_ACTION_VIEW',
+				false
+			);
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('Resources load for a user with VIEW permission', async () => {
+			await page.goto(`/web/guest${layout.friendlyURL}`);
+
+			await expect(page.locator(htmlElementName)).toBeAttached();
+			await expect(
+				page.locator(`script[src*="${jsResourceName}"]`)
+			).toBeAttached();
+			await expect(
+				page.locator(`link[href*="${cssResourceName}"]`)
+			).toBeAttached();
+		});
+
+		await test.step('Resources do not load for a guest without VIEW permission', async () => {
+			await performLogout(page);
+
+			await expect(async () => {
+				await page.goto(`/web/guest${layout.friendlyURL}`);
+
+				await expect(page.locator(htmlElementName)).toHaveCount(0);
+				await expect(
+					page.locator(`script[src*="${jsResourceName}"]`)
+				).toHaveCount(0);
+				await expect(
+					page.locator(`link[href*="${cssResourceName}"]`)
+				).toHaveCount(0);
+			}).toPass();
+		});
+
+		await test.step('Clean up', async () => {
+			await performLoginViaApi({page, screenName: 'test'});
+
+			await clientExtensionsPage.goto();
+
 			await clientExtensionsPage.deleteClientExtension(
 				clientExtensionName
 			);

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/render/PortletRenderUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/render/PortletRenderUtil.java
@@ -8,12 +8,16 @@ package com.liferay.portal.kernel.portlet.render;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesRegistryUtil;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -25,6 +29,8 @@ import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.PortletMode;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -53,6 +59,13 @@ public class PortletRenderUtil {
 	public static PortletRenderParts getPortletRenderParts(
 		HttpServletRequest httpServletRequest, String portletHTML,
 		Portlet portlet) {
+
+		if (!_hasAccessPermission(httpServletRequest, portlet)) {
+			return new PortletRenderParts(
+				Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList(), Collections.emptyList(), portletHTML,
+				!portlet.isAjaxable());
+		}
 
 		boolean portletOnLayout = false;
 
@@ -402,6 +415,39 @@ public class PortletRenderUtil {
 		}
 
 		return urls;
+	}
+
+	private static boolean _hasAccessPermission(
+		HttpServletRequest httpServletRequest, Portlet portlet) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (themeDisplay == null) {
+			return true;
+		}
+
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
+		Layout layout = themeDisplay.getLayout();
+
+		if ((permissionChecker == null) || (layout == null)) {
+			return true;
+		}
+
+		try {
+			return PortletPermissionUtil.hasAccessPermission(
+				permissionChecker, themeDisplay.getScopeGroupId(), layout,
+				portlet, PortletMode.VIEW);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return false;
+		}
 	}
 
 	private static boolean _isTokenized(String resourceURI) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95613

## What Is Being Fixed

A custom element client extension rendered its resources — the registered HTML element, its JavaScript URL, and its CSS URL — into the page for every visitor, even one without VIEW permission on the widget. A guest who had VIEW removed for a Custom Element widget still received its resources, leaking the extension's assets to users not entitled to see the widget.

## How It Is Being Fixed

`PortletRenderUtil.getPortletRenderParts` now verifies the current user's access permission for the portlet before assembling any render parts. It resolves the `ThemeDisplay`, permission checker, and layout from the request and calls `PortletPermissionUtil.hasAccessPermission` for the scope group, layout, and portlet in `VIEW` mode. When the user lacks permission, it returns empty render parts so no header/footer CSS or JavaScript and no resource markup are emitted; the existing portlet HTML is left untouched. The check is defensive: it returns true when no theme display, permission checker, or layout is available, and treats a `PortalException` as no access.

## PR Check

**pr-check: PASS** — tested on `3e19fe805472097b5ddedff7b296aa86c2d34104`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3e19fe805472097b5ddedff7b296aa86c2d34104"} -->
