### PR TITLE
LPD-65977 Add DocumentLinkSelector plugin for CKEditor 5

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/DocumentLinkSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/DocumentLinkSelector.ts
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Plugin} from '@ckeditor/ckeditor5-core/dist/index.js';
+import {Link, LinkUI} from '@ckeditor/ckeditor5-link/dist/index.js';
+import {ButtonView} from '@ckeditor/ckeditor5-ui/dist/index.js';
+import {openCMSFileSelectorModal} from '@liferay/frontend-js-item-selector-web';
+
+class DocumentLinkSelector extends Plugin {
+	static get requires() {
+		return [Link];
+	}
+
+	afterInit() {
+		const editor = this.editor;
+		const linkUI = editor.plugins.get(LinkUI) as any;
+
+		const getGroupId = () =>
+			Number(editor.config.get('groupId')) ||
+			Liferay.ThemeDisplay.getScopeGroupId();
+
+		const originalCreateFormView = linkUI._createFormView.bind(linkUI);
+
+		linkUI._createFormView = (...args: unknown[]) => {
+			const formView = originalCreateFormView(...args);
+
+			const selectDocumentButton = new ButtonView(editor.locale);
+
+			selectDocumentButton.set({
+				label: Liferay.Language.get('select-document'),
+				withText: true,
+			});
+
+			selectDocumentButton.on('execute', () => {
+				openCMSFileSelectorModal({
+					groupId: getGroupId(),
+					itemTypeLabel: Liferay.Language.get('document'),
+					onSelect: (items) => {
+						const href =
+							items[0]?.embedded?.file?.link?.href ||
+							items[0]?.value;
+
+						if (!href) {
+							return;
+						}
+
+						formView.urlInputView.fieldView.value = href;
+
+						if (formView.urlInputView.fieldView.element) {
+							formView.urlInputView.fieldView.element.value =
+								href;
+						}
+
+						editor.execute('link', href);
+
+						linkUI._closeFormView();
+					},
+				});
+			});
+
+			for (let i = 0; i < formView.children.length; i++) {
+				const rowView = formView.children.get(i) as any;
+
+				if (!rowView?.children) {
+					continue;
+				}
+
+				for (let j = 0; j < rowView.children.length; j++) {
+					if (rowView.children.get(j) === formView.urlInputView) {
+						rowView.children.add(selectDocumentButton, j + 1);
+
+						return formView;
+					}
+				}
+			}
+
+			return formView;
+		};
+	}
+}
+
+export default DocumentLinkSelector;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
@@ -49,6 +49,7 @@ import {WritingAssistant} from '@liferay/ai-hub-cell-js-components-web';
 import {sub} from 'frontend-js-web';
 
 import AICreator from '../plugins/AICreator';
+import DocumentLinkSelector from '../plugins/DocumentLinkSelector';
 import HeadlessItemSelector from '../plugins/HeadlessItemSelector';
 import ItemSelector from '../plugins/ItemSelector';
 import {EEditorConfigPreset, EEditorVariant} from './types';
@@ -129,6 +130,7 @@ const getDefaultEditorConfig = ({
 		AICreator,
 		Alignment,
 		BlockQuote,
+		DocumentLinkSelector,
 		Font,
 		Heading,
 		HeadlessItemSelector,

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getIcon.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getIcon.ts
@@ -4,8 +4,13 @@
  */
 
 const getIcon = ({symbol}: {symbol: string}): string => {
+	const spritemapUrl = new URL(Liferay.Icons.spritemap, window.location.href);
+
+	spritemapUrl.host = window.location.host;
+	spritemapUrl.protocol = window.location.protocol;
+
 	return `<svg xmlns="http://www.w3.org/2000/svg">
-		<use href="${Liferay.Icons.spritemap}#${symbol}" />
+		<use href="${spritemapUrl.toString()}#${symbol}" />
 	</svg>`;
 };
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-65977

## What Is Being Fixed

CKEditor 5's Link balloon had no way to browse and select documents from the DXP document library — users had to manually type or paste document URLs.

## How It Is Being Fixed

A new `DocumentLinkSelector` CKEditor 5 plugin intercepts the Link plugin's form view and injects a "Select Document" button next to the URL input. When clicked, it opens the CMS file selector modal; on selection it populates the URL input and executes the `link` command. The plugin is registered in `getDefaultEditorConfig.ts`. `getIcon.ts` is updated to normalize the spritemap URL host and protocol from `window.location` so the SVG icon reference resolves correctly regardless of how the page is served.

## Why Are There No Tests?

Tests will be added in a follow-up — this is a draft PR.

## PR Check

**pr-check: FAIL** — tested on `5ef9767e32e5c8b0ef82397af9f8602bf87d6de4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | FAIL |

Per-Module Compile timed out during the `ant compile install-portal-snapshots` setup step.

<!-- pr-check {"result": "failure", "sha": "5ef9767e32e5c8b0ef82397af9f8602bf87d6de4"} -->