### PR TITLE
LPD-75050 Validate user view name before saving

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -106,9 +106,7 @@ function SaveSnapshotModalComponent({
 		);
 
 		if (duplicated) {
-			return Liferay.Language.get(
-				'a-view-with-this-name-already-exists'
-			);
+			return Liferay.Language.get('a-view-with-this-name-already-exists');
 		}
 
 		return null;
@@ -419,8 +417,7 @@ const SnapshotsControls = () => {
 					closeModal={closeModal}
 					existingLabels={ownedSnapshotItems
 						.filter(
-							(item: ISnapshot) =>
-								item.erc !== activeSnapshot.erc
+							(item: ISnapshot) => item.erc !== activeSnapshot.erc
 						)
 						.map((item: ISnapshot) => item.label)}
 					initialLabel={initialLabel}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -76,25 +76,49 @@ const SnapshotsControlsTrigger = React.forwardRef(
 
 function SaveSnapshotModalComponent({
 	closeModal,
+	existingLabels,
 	initialLabel,
 	namespace,
 	onSave,
 	title,
 }: {
 	closeModal: () => void;
+	existingLabels: string[];
 	initialLabel: string;
 	namespace: string;
 	onSave: (label: string) => void;
 	title: string;
 }) {
 	const [label, setLabel] = useState(initialLabel);
-	const [nameValidationError, setNameValidationError] = useState(false);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	const trimmedLabel = label.trim();
+
+	const getValidationError = () => {
+		if (!trimmedLabel) {
+			return Liferay.Language.get('this-field-is-required');
+		}
+
+		const duplicated = existingLabels.some(
+			(existingLabel) =>
+				existingLabel.trim().toLowerCase() ===
+				trimmedLabel.toLowerCase()
+		);
+
+		if (duplicated) {
+			return Liferay.Language.get(
+				'a-view-with-this-name-already-exists'
+			);
+		}
+
+		return null;
+	};
 
 	const handleSave = () => {
-		const trimmedLabel = label.trim();
+		const validationError = getValidationError();
 
-		if (!trimmedLabel) {
-			setNameValidationError(true);
+		if (validationError) {
+			setErrorMessage(validationError);
 
 			return;
 		}
@@ -111,9 +135,7 @@ function SaveSnapshotModalComponent({
 			</ClayModal.Header>
 
 			<ClayModal.Body>
-				<ClayForm.Group
-					className={nameValidationError ? 'has-error' : ''}
-				>
+				<ClayForm.Group className={errorMessage ? 'has-error' : ''}>
 					<label htmlFor={`${namespace}labelInput`}>
 						{Liferay.Language.get('name')}
 
@@ -125,18 +147,18 @@ function SaveSnapshotModalComponent({
 						id={`${namespace}labelInput`}
 						onChange={(event) => {
 							setLabel(event.target.value);
-							setNameValidationError(false);
+							setErrorMessage(null);
 						}}
 						type="text"
 						value={label}
 					/>
 
-					{nameValidationError && (
+					{errorMessage && (
 						<ClayForm.FeedbackGroup>
 							<ClayForm.FeedbackItem>
 								<ClayForm.FeedbackIndicator symbol="exclamation-full" />
 
-								{Liferay.Language.get('this-field-is-required')}
+								{errorMessage}
 							</ClayForm.FeedbackItem>
 						</ClayForm.FeedbackGroup>
 					)}
@@ -153,7 +175,10 @@ function SaveSnapshotModalComponent({
 							{Liferay.Language.get('cancel')}
 						</ClayButton>
 
-						<ClayButton onClick={handleSave}>
+						<ClayButton
+							disabled={!trimmedLabel}
+							onClick={handleSave}
+						>
 							{Liferay.Language.get('save')}
 						</ClayButton>
 					</ClayButton.Group>
@@ -311,11 +336,16 @@ const SnapshotsControls = () => {
 			});
 	};
 
+	const ownedSnapshotItems = ownedSnapshots?.items ?? [];
+
 	const openSaveSnapshotModal = () => {
 		openModal({
 			contentComponent: ({closeModal}) => (
 				<SaveSnapshotModalComponent
 					closeModal={closeModal}
+					existingLabels={ownedSnapshotItems.map(
+						(item: ISnapshot) => item.label
+					)}
 					initialLabel={initialLabel}
 					namespace={namespace ?? ''}
 					onSave={(label) =>
@@ -387,6 +417,12 @@ const SnapshotsControls = () => {
 			contentComponent: ({closeModal}) => (
 				<SaveSnapshotModalComponent
 					closeModal={closeModal}
+					existingLabels={ownedSnapshotItems
+						.filter(
+							(item: ISnapshot) =>
+								item.erc !== activeSnapshot.erc
+						)
+						.map((item: ISnapshot) => item.label)}
 					initialLabel={initialLabel}
 					namespace={namespace ?? ''}
 					onSave={(label) =>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -1,11 +1,11 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 import {render, screen, waitFor} from '@testing-library/react';
 import {openModal} from 'frontend-js-components-web';
-import {fetch} from 'frontend-js-web';
+import fetch from 'jest-fetch-mock';
 import React from 'react';
 
 import '@testing-library/jest-dom';
@@ -21,31 +21,10 @@ jest.mock(
 );
 
 jest.mock('frontend-js-components-web', () => ({
-	...jest.requireActual('frontend-js-components-web'),
+	...(jest.requireActual('frontend-js-components-web') as object),
 	openModal: jest.fn(),
 	openToast: jest.fn(),
 }));
-
-jest.mock('frontend-js-web', () => ({
-	...jest.requireActual('frontend-js-web'),
-	fetch: jest.fn(() =>
-		Promise.resolve({
-			json: () => ({
-				externalReferenceCode: 'erc',
-				id: 1,
-				label: 'New View',
-				viewConfig: '{}',
-			}),
-			ok: true,
-		})
-	),
-}));
-
-global.Liferay = {
-	Language: {
-		get: (key: string) => key,
-	},
-} as any;
 
 const mockFDSContext = {
 	globalFDSState: {filters: []},
@@ -164,7 +143,6 @@ describe('SnapshotsControls view name validation', () => {
 	});
 
 	beforeEach(() => {
-		(fetch as jest.Mock).mockClear();
 		(openModal as jest.Mock).mockClear();
 	});
 
@@ -175,15 +153,11 @@ describe('SnapshotsControls view name validation', () => {
 				ownedViewsState({activeSnapshotERC: null})
 			);
 
-			expect(
-				screen.getByRole('button', {name: 'save'})
-			).toBeDisabled();
+			expect(screen.getByRole('button', {name: 'save'})).toBeDisabled();
 
 			await userEvent.type(screen.getByLabelText(/name/), '   ');
 
-			expect(
-				screen.getByRole('button', {name: 'save'})
-			).toBeDisabled();
+			expect(screen.getByRole('button', {name: 'save'})).toBeDisabled();
 		});
 
 		it('blocks saving and warns when the name matches an existing view', async () => {
@@ -235,6 +209,15 @@ describe('SnapshotsControls view name validation', () => {
 				'A Brand New View'
 			);
 
+			fetch.mockResponseOnce(
+				JSON.stringify({
+					externalReferenceCode: 'erc',
+					id: 1,
+					label: 'New View',
+					viewConfig: '{}',
+				})
+			);
+
 			await userEvent.click(screen.getByRole('button', {name: 'save'}));
 
 			expect(
@@ -248,6 +231,15 @@ describe('SnapshotsControls view name validation', () => {
 	describe('"Rename View"', () => {
 		it('allows keeping the current name unchanged', async () => {
 			await renderModalFor('rename-view', ownedViewsState());
+
+			fetch.mockResponseOnce(
+				JSON.stringify({
+					externalReferenceCode: 'erc',
+					id: 1,
+					label: 'New View',
+					viewConfig: '{}',
+				})
+			);
 
 			await userEvent.click(screen.getByRole('button', {name: 'save'}));
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
+import {openModal} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import React from 'react';
 
 import '@testing-library/jest-dom';
@@ -17,6 +19,27 @@ jest.mock(
 	'../../../../src/main/resources/META-INF/resources/management_bar/controls/snapshots/shareSnapshotAction',
 	() => jest.fn()
 );
+
+jest.mock('frontend-js-components-web', () => ({
+	...jest.requireActual('frontend-js-components-web'),
+	openModal: jest.fn(),
+	openToast: jest.fn(),
+}));
+
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	fetch: jest.fn(() =>
+		Promise.resolve({
+			json: () => ({
+				externalReferenceCode: 'erc',
+				id: 1,
+				label: 'New View',
+				viewConfig: '{}',
+			}),
+			ok: true,
+		})
+	),
+}));
 
 global.Liferay = {
 	Language: {
@@ -105,6 +128,150 @@ describe('SnapshotsControls action gating', () => {
 			expect(screen.queryByText('rename-view')).not.toBeInTheDocument();
 			expect(screen.queryByText('share-view')).not.toBeInTheDocument();
 			expect(screen.queryByText('delete-view')).not.toBeInTheDocument();
+		});
+	});
+});
+
+describe('SnapshotsControls view name validation', () => {
+	const secondSnapshot = {erc: 'second-erc', id: 3, label: 'Second View'};
+
+	const renderModalFor = async (actionLabel: string, viewsState: any) => {
+		renderSnapshotsControls(viewsState);
+
+		await openActionsDropdown();
+
+		await userEvent.click(await screen.findByText(actionLabel));
+
+		const {contentComponent} = (openModal as jest.Mock).mock.calls.at(
+			-1
+		)[0];
+
+		render(contentComponent({closeModal: jest.fn()}));
+	};
+
+	const ownedViewsState = (overrides: any = {}) => ({
+		activeSnapshotERC: ownedSnapshot.erc,
+		activeView: null,
+		defaultSnapshot: {},
+		paginationDelta: null,
+		snapshotUpdated: false,
+		snapshots: [
+			{headerVisible: false, items: [ownedSnapshot, secondSnapshot]},
+		],
+		sorts: [],
+		visibleFieldNames: {},
+		...overrides,
+	});
+
+	beforeEach(() => {
+		(fetch as jest.Mock).mockClear();
+		(openModal as jest.Mock).mockClear();
+	});
+
+	describe('"Save View As"', () => {
+		it('disables "Save" while the name is empty or only whitespace', async () => {
+			await renderModalFor(
+				'save-view-as',
+				ownedViewsState({activeSnapshotERC: null})
+			);
+
+			expect(
+				screen.getByRole('button', {name: 'save'})
+			).toBeDisabled();
+
+			await userEvent.type(screen.getByLabelText(/name/), '   ');
+
+			expect(
+				screen.getByRole('button', {name: 'save'})
+			).toBeDisabled();
+		});
+
+		it('blocks saving and warns when the name matches an existing view', async () => {
+			await renderModalFor(
+				'save-view-as',
+				ownedViewsState({activeSnapshotERC: null})
+			);
+
+			await userEvent.type(
+				screen.getByLabelText(/name/),
+				ownedSnapshot.label
+			);
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			expect(
+				screen.getByText('a-view-with-this-name-already-exists')
+			).toBeInTheDocument();
+			expect(fetch).not.toHaveBeenCalled();
+		});
+
+		it('treats names that differ only in casing as duplicates', async () => {
+			await renderModalFor(
+				'save-view-as',
+				ownedViewsState({activeSnapshotERC: null})
+			);
+
+			await userEvent.type(
+				screen.getByLabelText(/name/),
+				ownedSnapshot.label.toUpperCase()
+			);
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			expect(
+				screen.getByText('a-view-with-this-name-already-exists')
+			).toBeInTheDocument();
+			expect(fetch).not.toHaveBeenCalled();
+		});
+
+		it('sends the form for a valid, unique name', async () => {
+			await renderModalFor(
+				'save-view-as',
+				ownedViewsState({activeSnapshotERC: null})
+			);
+
+			await userEvent.type(
+				screen.getByLabelText(/name/),
+				'A Brand New View'
+			);
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			expect(
+				screen.queryByText('a-view-with-this-name-already-exists')
+			).not.toBeInTheDocument();
+
+			await waitFor(() => expect(fetch).toHaveBeenCalled());
+		});
+	});
+
+	describe('"Rename View"', () => {
+		it('allows keeping the current name unchanged', async () => {
+			await renderModalFor('rename-view', ownedViewsState());
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			expect(
+				screen.queryByText('a-view-with-this-name-already-exists')
+			).not.toBeInTheDocument();
+
+			await waitFor(() => expect(fetch).toHaveBeenCalled());
+		});
+
+		it('blocks renaming to another existing view name', async () => {
+			await renderModalFor('rename-view', ownedViewsState());
+
+			const nameInput = screen.getByLabelText(/name/);
+
+			await userEvent.clear(nameInput);
+			await userEvent.type(nameInput, secondSnapshot.label);
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			expect(
+				screen.getByText('a-view-with-this-name-already-exists')
+			).toBeInTheDocument();
+			expect(fetch).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -131,6 +131,7 @@ a-user-may-be-authenticated-by-cas-and-not-yet-exist-in-the-portal=A user may be
 a-user-with-that-openid-already-exists=A user with that OpenID already exists.
 a-value-needs-to-be-added-or-selected-in-the-blank-field=A value needs to be added or selected in the blank field.
 a-variant-needs-to-be-created=A variant needs to be created.
+a-view-with-this-name-already-exists=A view with this name already exists.
 a-virus-was-detected-in-the-file=A virus was detected in the file.
 a-web-content-has-expired=A web content has expired.
 a-webdav-password-has-already-been-generated-and-will-be-expired-if-a-new-one-is-generated=A WebDAV password has already been generated and will be expired if a new one is generated.

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/userViews.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/userViews.spec.ts
@@ -308,6 +308,55 @@ test(
 			page.keyboard.press('Escape');
 		});
 
+		await test.step('Cannot save a view with a blank or duplicate name', async () => {
+			await dataSetFragmentPage.userViewsActionsButton.click();
+
+			await userViewsActionsDropdown
+				.filter({has: page.getByRole('menu')})
+				.waitFor();
+
+			await userViewsActionsDropdown
+				.getByRole('menuitem', {name: 'Save View As...'})
+				.click();
+
+			await expect(
+				dataSetFragmentPage.userViewsSaveModal
+			).toBeInViewport();
+
+			const nameInput =
+				dataSetFragmentPage.userViewsSaveModal.getByLabel(
+					'NameRequired'
+				);
+			const saveButton = dataSetFragmentPage.userViewsSaveModal.getByRole(
+				'button',
+				{name: 'Save'}
+			);
+
+			await nameInput.fill('   ');
+
+			await expect(saveButton).toBeDisabled();
+
+			await nameInput.fill(userView1Name.toUpperCase());
+
+			await expect(saveButton).toBeEnabled();
+
+			await saveButton.click();
+
+			await expect(
+				dataSetFragmentPage.userViewsSaveModal.getByText(
+					'A view with this name already exists.'
+				)
+			).toBeVisible();
+
+			await dataSetFragmentPage.userViewsSaveModal
+				.getByRole('button', {name: 'Cancel'})
+				.click();
+
+			await expect(
+				dataSetFragmentPage.userViewsSaveModal
+			).not.toBeInViewport();
+		});
+
 		await test.step('Confirm that changes in an user view does not affect Default View', async () => {
 			await expect(
 				dataSetFragmentPage.userViewsSelectorButton


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75050

## Goal

When saving or renaming a user view (snapshot) in a Frontend Data Set, the entered name was not validated against the views the user already owns. A view could be created or renamed to a name that duplicates an existing owned view, and an empty or whitespace-only name was accepted.

## Detail

The "Save View As" and "Rename View" modals now validate the name before submitting. The Save button stays disabled while the name is empty or only whitespace, and on save the name is compared case-insensitively against the labels of the user's owned views; a duplicate is rejected with "A view with this name already exists." Rename excludes the active view from that check so keeping the current name is still allowed. Coverage was added at two layers: jest unit tests for the validation logic — aligned with the shared jest fetch and Liferay mocks rather than re-stubbing them — and a Playwright step that exercises the blank and duplicate-name flow end to end.

## UI

<img width="667" height="340" alt="image" src="https://github.com/user-attachments/assets/32d3ba2e-d790-44ec-b223-64545b23411e" />

## PR Check

**pr-check: PASS** — tested on `5968b13a2cc5dbcc78a9210e05bfabe5d5dc65df`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5968b13a2cc5dbcc78a9210e05bfabe5d5dc65df"} -->
