### PR TITLE
LPD-95363 Fix flaky locale switch in client extension name tests

### DIFF
--- a/modules/test/playwright/tests/client-extension-web/main/customElement.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/customElement.spec.ts
@@ -282,9 +282,9 @@ test('Check that Name field can be translated', async ({
 	const defaultTranslationName = getRandomString();
 	const ptTranslationName = getRandomString();
 
-	await editCustomElementPage.nameInput.fill(defaultTranslationName);
+	await editCustomElementPage.fillName('en_US', defaultTranslationName);
 	await editCustomElementPage.changeNameLanguage('pt_BR');
-	await editCustomElementPage.nameInput.fill(ptTranslationName);
+	await editCustomElementPage.fillName('pt_BR', ptTranslationName);
 
 	await test.step('Check expectations', async () => {
 		await editCustomElementPage.changeNameLanguage('en_US');

--- a/modules/test/playwright/tests/client-extension-web/main/fdsCellRenderer.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/fdsCellRenderer.spec.ts
@@ -44,7 +44,8 @@ test(
 		await editFDSCellRendererPage.goto();
 
 		await editFDSCellRendererPage.changeNameLanguage('es_ES');
-		await editFDSCellRendererPage.nameInput.fill(
+		await editFDSCellRendererPage.fillName(
+			'es_ES',
 			'Cambiar formato de fecha'
 		);
 		await editFDSCellRendererPage.changeNameLanguage('en_US');

--- a/modules/test/playwright/tests/client-extension-web/main/js.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/js.spec.ts
@@ -488,7 +488,7 @@ test('JS client extension can be created with name translations while having a l
 			page.getByLabel('Current translation is English', {exact: false})
 		).toBeVisible();
 
-		await editJSClientExtensionsPage.nameInput.fill(englishName);
+		await editJSClientExtensionsPage.fillName('en_US', englishName);
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,
@@ -505,7 +505,7 @@ test('JS client extension can be created with name translations while having a l
 			page.getByLabel('Current translation is Spanish', {exact: false})
 		).toBeVisible();
 
-		await editJSClientExtensionsPage.nameInput.fill(spanishName);
+		await editJSClientExtensionsPage.fillName('es_ES', spanishName);
 
 		await editJSClientExtensionsPage.javaScriptURLInput.fill(
 			'https://www.example.com/script.js'

--- a/modules/test/playwright/tests/client-extension-web/main/pages/EditClientExtensionsPage.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/pages/EditClientExtensionsPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import POM from '../../../../utils/POM';
 import {waitForInputLocalized} from '../../../../utils/waitFor';
@@ -105,6 +105,14 @@ export class EditClientExtensionsPage extends POM {
 		await this.page
 			.locator(`#_${this.portletName}_namePaletteContentBox`)
 			.waitFor({state: 'hidden'});
+	}
+
+	async fillName(languageId: string, name: string) {
+		await this.nameInput.fill(name);
+
+		await expect(
+			this.page.locator(`#_${this.portletName}_name_${languageId}`)
+		).toHaveValue(name);
 	}
 
 	async publish(waitAction: WaitAction) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95363

## What Is Being Fixed

Three Playwright tests in client-extension-web assert that a localized
"Name" value survives switching locales (fdsCellRenderer, customElement,
and js). Two were failing and the third had the same latent race: after
typing a translation, the value came back empty once the locale was
switched and switched back.

## How It Is Being Fixed

The liferay-ui:input-localized widget persists typed text into its hidden
per-language field through a 100ms-debounced input handler, and switching
locales does not flush that pending edit. The tests filled the name and
switched locale immediately, racing the debounce, so the typed value was
never stored. A new fillName helper on EditClientExtensionsPage fills the
field and then waits (auto-waiting, no fixed sleep) for the value to land
in the hidden per-language input before the test proceeds. All three
fill-then-switch sites now use it.

## Why Are There No Tests?

This PR only modifies existing Playwright tests; it changes no product
code, so there is nothing new to cover. The change hardens the tests
themselves, verified by running the three affected specs (all pass,
including 3 repeats each of the two originally failing tests).

## PR Check

**pr-check: PASS** — tested on `4002815879565b2a9a367b1edae53600e0b8e420`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "4002815879565b2a9a367b1edae53600e0b8e420"} -->
