### PR TITLE
LPD-95690 Update renamed client extension reference in Playwright test envs

### DIFF
--- a/modules/test/playwright/tests/client-extension-web/main/env/client-extensions.list
+++ b/modules/test/playwright/tests/client-extension-web/main/env/client-extensions.list
@@ -3,7 +3,7 @@ liferay-sample-custom-element-2
 liferay-sample-custom-element-3
 liferay-sample-custom-element-4
 liferay-sample-custom-element-5
-liferay-sample-editor-config-contributor
+liferay-sample-editor-config-contributor-1
 liferay-sample-etc-frontend
 liferay-sample-global-css-1
 liferay-sample-global-css-2

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/env/client-extensions.list
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/env/client-extensions.list
@@ -1,1 +1,1 @@
-liferay-sample-editor-config-contributor
+liferay-sample-editor-config-contributor-1

--- a/modules/test/playwright/tests/layout-content-page-editor-web/fragments/env/client-extensions.list
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/fragments/env/client-extensions.list
@@ -1,1 +1,1 @@
-liferay-sample-editor-config-contributor
+liferay-sample-editor-config-contributor-1


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95690

## What Is Being Fixed

A Playwright test failure surfaced in client-extension-web/main/editorConfigContributor.spec.ts. The sample client extension `liferay-sample-editor-config-contributor` was renamed to `liferay-sample-editor-config-contributor-1` as part of LPD-89734, but the Playwright environment `client-extensions.list` files still referenced the old name, so the extension was no longer deployed for those test runs.

## How It Is Being Fixed

Updated the stale reference to the new name in the three affected `client-extensions.list` env files (client-extension-web/main, frontend-editor-ckeditor-web/main, and layout-content-page-editor-web/fragments).

## Why Are There No Tests?

This change only updates Playwright test environment configuration to match a client extension rename from LPD-89734. It is test-infrastructure maintenance that keeps the existing tests running; no production code changed and no new test is warranted.

## PR Check

**pr-check: PASS** — tested on `04f68882e0bba60027a8d4fda9cfe924ce685d61`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "04f68882e0bba60027a8d4fda9cfe924ce685d61"} -->
