### PR TITLE
LPD-95740 Fix CKEditor 5 support in liferay-sample-editor-config-contributor-1 broken by LPD-89734

### DIFF
--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-1/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-1/src/index.ts
@@ -34,6 +34,15 @@ const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
 		}
 	}
 
+	// CKEditor 5
+
+	if (config.editorType === 'ckeditor5') {
+		return {
+			...config,
+			toolbar: ['accessibilityHelp', '|', 'undo', 'redo'],
+		};
+	}
+
 	// CKEditor
 
 	const toolbar: string | [string[]] = config.toolbar;


### PR DESCRIPTION
## What

LPD-89734 renamed `liferay-sample-editor-config-contributor` to `liferay-sample-editor-config-contributor-1` and explicitly removed its CKEditor 5 branch. This broke two `@LPD-54262` Playwright tests in `layout-content-page-editor-web.fragments`:

- `fragments.spec.ts` > Editor config contributor client extension is applied (CKEditor 5 path): broken by both the stale list name and the missing CKEditor 5 branch, which caused fall-through to the CKEditor 4 handler and wiped the editor toolbar
- `fragmentsWithCKEditor4.spec.ts` > Editor config contributor client extension is applied with CKEditor 4 (AlloyEditor path): broken only by the stale list name

## How

- Restore the CKEditor 5 toolbar-replace block in `liferay-sample-editor-config-contributor-1/src/index.ts`, using a short toolbar starting with `accessibilityHelp` (matching the original approach in the now-deleted `liferay-sample-editor-config-contributor`)
- Update three `env/client-extensions.list` files (`layout-content-page-editor-web/fragments`, `client-extension-web/main`, `frontend-editor-ckeditor-web/main`) to reference the renamed CX