### PR TITLE
LPD-94564 Cache AC segments and persist audiences in a cookie

### DIFF
--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/FrontendJSAudiencesWebServlet.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/FrontendJSAudiencesWebServlet.java
@@ -158,8 +158,10 @@ public class FrontendJSAudiencesWebServlet extends HttpServlet {
 			return Long.valueOf(plid);
 		}
 		catch (NumberFormatException numberFormatException) {
-			_log.error(
-				"Unable to get plid from " + plid, numberFormatException);
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to get plid from " + plid, numberFormatException);
+			}
 
 			return null;
 		}

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/attributes/segments.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/attributes/segments.ts
@@ -3,24 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-declare const Analytics: any;
-
-export async function getSegments(): Promise<Set<string>> {
-	if (typeof Analytics === 'undefined') {
-		throw new Error(
-			`Unable to use 'segments' attribute because 'Analytics' global object is missing`
-		);
-	}
-
-	const set: Set<string> = new Set();
-
-	for (const segment of await Analytics.segment.getBatchSegmentExternalReferenceCodes()) {
-		set.add(segment);
-	}
-
-	for (const segment of await Analytics.segment.getRealTimeSegmentExternalReferenceCodes()) {
-		set.add(segment);
-	}
-
-	return set;
+export function getSegments(acSegments: Set<string>): Set<string> {
+	return acSegments;
 }

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/check.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/check.ts
@@ -12,7 +12,6 @@ import type {
 	Conjunction,
 	LeafRule,
 	Operator,
-	RetentionType,
 	Rule,
 	RuleGroup,
 } from '../index';
@@ -59,8 +58,6 @@ const OPERATOR_VALUE_TYPES: {[operator in Operator]: string[]} = {
 	not_includes: ['string'],
 };
 
-const RETENTION_TYPES: RetentionType[] = ['BROWSER', 'PAGE', 'TAB'];
-
 export function check(audiencesDefinition: AudiencesDefinition) {
 	const what = 'Audiences definition';
 
@@ -89,18 +86,13 @@ function checkAudience(audience: Audience, index: number) {
 	const what = `Audience '${audience?.id ?? `#${index + 1}`}'`;
 
 	checkObject(audience, what);
-	checkKeys(audience, ['conjunction', 'id', 'retentionType', 'rules'], what);
+	checkKeys(audience, ['conjunction', 'id', 'rules'], what);
 	checkOneOf(
 		audience.conjunction,
 		CONJUNCTIONS,
 		`${what} field 'conjunction'`
 	);
 	checkString(audience.id, `${what} field 'id'`);
-	checkOneOf(
-		audience.retentionType,
-		RETENTION_TYPES,
-		`${what} field 'retentionType'`
-	);
 	checkRules(audience.rules, `${what} field 'rules'`);
 }
 

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/index.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/index.ts
@@ -40,6 +40,8 @@ import type {
 	Rule,
 } from '../index';
 
+declare const Analytics: any;
+
 export interface AudienceMatch {
 	id: string;
 	retentionType: RetentionType;
@@ -53,6 +55,7 @@ interface OperatorImpl {
 
 export class Detection {
 	private _audiencesDefinition: AudiencesDefinition;
+	private _acSegments: Set<string> | undefined;
 	private _uaParser: UAParser;
 
 	constructor(audiencesDefinition: AudiencesDefinition) {
@@ -83,6 +86,30 @@ export class Detection {
 		}
 
 		return matches;
+	}
+
+	private async _getAcSegments() {
+		if (this._acSegments === undefined) {
+			if (typeof Analytics === 'undefined') {
+				throw new Error(
+					`Unable to get Analytics Cloud segments because 'Analytics' global object is missing`
+				);
+			}
+
+			const set: Set<string> = new Set();
+
+			for (const segment of await Analytics.segment.getBatchSegmentExternalReferenceCodes()) {
+				set.add(segment);
+			}
+
+			for (const segment of await Analytics.segment.getRealTimeSegmentExternalReferenceCodes()) {
+				set.add(segment);
+			}
+
+			this._acSegments = set;
+		}
+
+		return this._acSegments;
 	}
 
 	private async _getAttribute(attr: Attribute): Promise<AttributeValue> {
@@ -120,7 +147,7 @@ export class Detection {
 			return getRequestParameters();
 		}
 		else if (attr === 'segments') {
-			return getSegments();
+			return getSegments(await this._getAcSegments());
 		}
 		else if (attr === 'timezone') {
 			return getTimezone();

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/index.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/index.ts
@@ -33,19 +33,14 @@ import {notIncludes} from './operators/not_includes';
 
 import type {
 	Attribute,
+	AudienceId,
 	AudiencesDefinition,
 	Conjunction,
 	Operator,
-	RetentionType,
 	Rule,
 } from '../index';
 
 declare const Analytics: any;
-
-export interface AudienceMatch {
-	id: string;
-	retentionType: RetentionType;
-}
 
 type AttributeValue = Set<string> | boolean | number | string;
 
@@ -65,23 +60,20 @@ export class Detection {
 		this._uaParser = new UAParser(navigator.userAgent);
 	}
 
-	async run(): Promise<AudienceMatch[]> {
+	async run(): Promise<AudienceId[]> {
 		const matches = [];
 
 		for (const audience of this._audiencesDefinition.audiences) {
-			const {conjunction, id, retentionType, rules} = audience;
+			const {conjunction, id, rules} = audience;
 
 			log(`Checking rules for audience '${id}'...`);
 
 			const matched = await this._evaluateGroup(conjunction, rules);
 
 			if (matched) {
-				log(`Matched ${retentionType} audience: ${id}`);
+				log(`Matched audience: ${id}`);
 
-				matches.push({
-					id,
-					retentionType,
-				});
+				matches.push(id);
 			}
 		}
 

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/implementation.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/implementation.ts
@@ -7,19 +7,19 @@ import {Detection} from './detection';
 import {log} from './log';
 import {store} from './store';
 
-import type {AudiencesDefinition, Handler, RetentionType} from './index';
+import type {AudienceId, AudiencesDefinition, Handler} from './index';
 
 interface HandlersMap {
-	[audienceId: string]: Handler[];
+	[audienceId: AudienceId]: Handler[];
 }
 
 const handlers: HandlersMap = {};
 
-export function clear(retentionType?: RetentionType): void {
-	store.clear(retentionType);
+export function clear(): void {
+	store.clear();
 }
 
-export function get(): Set<string> {
+export function get(): Set<AudienceId> {
 	return store.getAudienceIds();
 }
 
@@ -70,41 +70,16 @@ export async function runDetection(
 		);
 	}
 
-	const browserAudienceIds = store.getBrowserAudienceIds();
-	const pageAudienceIds = store.getPageAudienceIds();
-	const tabAudienceIds = store.getTabAudienceIds();
+	const audienceIds = store.getAudienceIds();
 
 	for (const match of matches) {
-		switch (match.retentionType) {
-			case 'BROWSER': {
-				browserAudienceIds.add(match.id);
-				break;
-			}
-
-			case 'PAGE': {
-				pageAudienceIds.add(match.id);
-				break;
-			}
-
-			case 'TAB': {
-				tabAudienceIds.add(match.id);
-				break;
-			}
-
-			default: {
-				throw new Error(
-					`Unsupported retention type '${match.retentionType}' for audience '${match.id}'`
-				);
-			}
-		}
+		audienceIds.add(match);
 	}
 
-	store.setBrowserAudienceIds(browserAudienceIds);
-	store.setPageAudienceIds(pageAudienceIds);
-	store.setTabAudienceIds(tabAudienceIds);
+	store.setAudienceIds(audienceIds);
 }
 
-export function on(audienceId: string, handler: Handler): void {
+export function on(audienceId: AudienceId, handler: Handler): void {
 	log(
 		`Adding handler '${handler.name ?? 'anonymous'}' for audience '${audienceId}'`
 	);

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/index.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/index.ts
@@ -20,14 +20,13 @@ export interface AudiencesDefinition {
 
 export interface Audience {
 	conjunction: Conjunction;
-	id: string;
-	retentionType: RetentionType;
+	id: AudienceId;
 	rules: Rule[];
 }
 
-export type Conjunction = 'AND' | 'OR';
+export type AudienceId = string;
 
-export type RetentionType = 'BROWSER' | 'PAGE' | 'TAB';
+export type Conjunction = 'AND' | 'OR';
 
 export type Rule = LeafRule | RuleGroup;
 
@@ -81,9 +80,9 @@ export interface Handler {
 }
 
 export interface AudiencesAPI {
-	clear(retentionType?: RetentionType): void;
-	get(): Set<string>;
-	on(audienceId: string, handler: Handler): void;
+	clear(): void;
+	get(): Set<AudienceId>;
+	on(audienceId: AudienceId, handler: Handler): void;
 	runDetection(audiencesDefinitionURL: string): Promise<void>;
 	runHandlers(): Promise<void>;
 	setLogEnabled(enabled: boolean): void;

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/store.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/store.ts
@@ -3,97 +3,44 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {RetentionType} from './index';
 import {log} from './log';
 
-const STORAGE_KEY = 'com.liferay.frontend.js.audiences.web';
-const STORAGE_SEPARATOR = '|';
+import type {AudienceId} from './index';
+
+const STORAGE_KEY = 'com.liferay.frontend.js.audiences';
+const STORAGE_MAX_AGE = 365 * 24 * 60 * 60;
+const STORAGE_SEPARATOR = '\n';
 
 class Store {
-	private pageAudienceIds: Set<string> = new Set();
+	clear(): void {
+		log(`Clearing audiences`);
 
-	clear(retentionType?: RetentionType): void {
-		log(`Clearing audiences for scope: ${retentionType ?? 'ALL'}`);
-
-		switch (retentionType) {
-			case 'BROWSER':
-				localStorage.removeItem(STORAGE_KEY);
-				break;
-
-			case 'PAGE':
-				this.pageAudienceIds = new Set();
-				break;
-
-			case 'TAB':
-				sessionStorage.removeItem(STORAGE_KEY);
-				break;
-
-			default:
-				localStorage.removeItem(STORAGE_KEY);
-				this.pageAudienceIds = new Set();
-				sessionStorage.removeItem(STORAGE_KEY);
-				break;
-		}
+		document.cookie = `${STORAGE_KEY}=; path=/; max-age=0`;
 	}
 
-	getAudienceIds(): Set<string> {
-		const set: Set<string> = new Set();
+	getAudienceIds(): Set<AudienceId> {
+		const value = this._getCookie();
 
-		for (const audienceId of this.getBrowserAudienceIds()) {
-			set.add(audienceId);
-		}
-
-		for (const audienceId of this.getPageAudienceIds()) {
-			set.add(audienceId);
-		}
-
-		for (const audienceId of this.getTabAudienceIds()) {
-			set.add(audienceId);
-		}
-
-		return set;
-	}
-
-	getBrowserAudienceIds(): Set<string> {
-		const storageItem = localStorage.getItem(STORAGE_KEY);
-
-		if (!storageItem) {
+		if (!value) {
 			return new Set();
 		}
 
-		return new Set(storageItem.split(STORAGE_SEPARATOR));
+		return new Set(decodeURIComponent(value).split(STORAGE_SEPARATOR));
 	}
 
-	getPageAudienceIds(): Set<string> {
-		return this.pageAudienceIds;
-	}
-
-	getTabAudienceIds(): Set<string> {
-		const storageItem = sessionStorage.getItem(STORAGE_KEY);
-
-		if (!storageItem) {
-			return new Set();
-		}
-
-		return new Set(storageItem.split(STORAGE_SEPARATOR));
-	}
-
-	setBrowserAudienceIds(audienceIds: Set<string>) {
-		localStorage.setItem(
-			STORAGE_KEY,
+	setAudienceIds(audienceIds: Set<AudienceId>): void {
+		const value = encodeURIComponent(
 			[...audienceIds].join(STORAGE_SEPARATOR)
 		);
+
+		document.cookie = `${STORAGE_KEY}=${value}; path=/; max-age=${STORAGE_MAX_AGE}`;
 	}
 
-	setPageAudienceIds(audienceIds: Set<string>) {
-		this.pageAudienceIds = audienceIds;
-	}
-
-	setTabAudienceIds(audienceIds: Set<string>) {
-		sessionStorage.setItem(
-			STORAGE_KEY,
-			[...audienceIds].join(STORAGE_SEPARATOR)
-		);
+	private _getCookie(): string | undefined {
+		return document.cookie
+			.split('; ')
+			.find((item) => item.startsWith(`${STORAGE_KEY}=`))
+			?.slice(STORAGE_KEY.length + 1);
 	}
 }
 

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/store.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/store.ts
@@ -25,7 +25,17 @@ class Store {
 			return new Set();
 		}
 
-		return new Set(decodeURIComponent(value).split(STORAGE_SEPARATOR));
+		try {
+			return new Set(decodeURIComponent(value).split(STORAGE_SEPARATOR));
+		}
+		catch (error) {
+			log(
+				`Invalid audiences cookie found: '${value}'`,
+				`(reason: ${error})`
+			);
+
+			return new Set();
+		}
 	}
 
 	setAudienceIds(audienceIds: Set<AudienceId>): void {

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/com/liferay/frontend/js/audiences/web/internal/util/dependencies/bootstrap.js.tpl
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/com/liferay/frontend/js/audiences/web/internal/util/dependencies/bootstrap.js.tpl
@@ -4,7 +4,7 @@ const {audiences} = await import(`${BASE_URL}o/frontend-js-audiences-web/__lifer
 
 audiences.setLogEnabled([$ENABLE_LOG$]);
 
-audiences.clear('PAGE');
+audiences.clear();
 await audiences.runDetection(`${BASE_URL}o/audiences/definition.([$AUDIENCES_DEFINITION_HASH$]).json`);
 
 await import(`${BASE_URL}o/audiences/[$PLID$]/variations.([$ELEMENT_VARIATIONS_HASH$]).js`);

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/attributes.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/attributes.test.ts
@@ -32,8 +32,6 @@ describe('attributes', () => {
 		delete (document as any).cookie;
 		delete (document as any).referrer;
 
-		delete (global as any).Analytics;
-
 		delete (navigator as any).userAgent;
 
 		window.history.replaceState({}, '', '/');
@@ -65,18 +63,6 @@ describe('attributes', () => {
 		Object.defineProperty(document, 'referrer', {
 			configurable: true,
 			value: 'https://www.wikipedia.org/',
-		});
-
-		Object.defineProperty(global, 'Analytics', {
-			configurable: true,
-			value: {
-				segment: {
-					getBatchSegmentExternalReferenceCodes: () =>
-						Promise.resolve(['SEGMENT_BATCH']),
-					getRealTimeSegmentExternalReferenceCodes: () =>
-						Promise.resolve(['SEGMENT_REAL_TIME']),
-				},
-			},
 		});
 
 		Object.defineProperty(navigator, 'userAgent', {
@@ -247,7 +233,9 @@ describe('attributes', () => {
 
 	describe('attribute segments', () => {
 		it('works and returns a Set<string>', async () => {
-			const value = await getSegments();
+			const value = getSegments(
+				new Set(['SEGMENT_BATCH', 'SEGMENT_REAL_TIME'])
+			);
 
 			expect(value).toBeInstanceOf(Set);
 			expect(value).toEqual(

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/check.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/check.test.ts
@@ -26,7 +26,6 @@ function audience(overrides: {[key: string]: any} = {}): any {
 	return {
 		conjunction: 'AND',
 		id: 'the_audience',
-		retentionType: 'PAGE',
 		rules: [leafRule()],
 		...overrides,
 	};
@@ -202,19 +201,6 @@ describe('check', () => {
 			expect(() =>
 				check(audiencesDefinition({audiences: [audience({id: 123})]}))
 			).toThrow("field 'id' must be a string");
-		});
-
-		it('rejects an invalid retentionType', () => {
-			expect(() =>
-				check(
-					audiencesDefinition({
-						audiences: [audience({retentionType: 'FOREVER'})],
-					})
-				)
-			).toThrow(
-				"Audience 'the_audience' field 'retentionType' must be one of: " +
-					"'BROWSER', 'PAGE', 'TAB'"
-			);
 		});
 	});
 

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/detection.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/detection.test.ts
@@ -21,7 +21,6 @@ function mockAudiencesDefinition(conjunction: Conjunction, rules: Rule[]) {
 			{
 				conjunction,
 				id: 'the_audience',
-				retentionType: 'BROWSER',
 				rules,
 			},
 		],
@@ -59,7 +58,10 @@ describe('detection', () => {
 
 		jest.restoreAllMocks();
 
-		delete (document as any).cookie;
+		for (const item of document.cookie.split(';')) {
+			document.cookie = `${item.split('=')[0].trim()}=; path=/; max-age=0`;
+		}
+
 		delete (document as any).referrer;
 
 		delete (global as any).Analytics;
@@ -89,10 +91,9 @@ describe('detection', () => {
 			'resolvedOptions'
 		).mockReturnValue({timeZone: 'America/New_York'} as any);
 
-		Object.defineProperty(document, 'cookie', {
-			configurable: true,
-			value: 'REMEMBER_ME=true; JSESSIONID=ba8e4d1c',
-		});
+		document.cookie = 'REMEMBER_ME=true';
+		document.cookie = 'JSESSIONID=ba8e4d1c';
+
 		Object.defineProperty(document, 'referrer', {
 			configurable: true,
 			value: 'https://www.wikipedia.org/',

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/implementation.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/implementation.test.ts
@@ -19,7 +19,7 @@ describe('implementation', () => {
 
 			// Store audiences in reverse order so that we really test the registration is honored
 
-			store.setPageAudienceIds(new Set(audienceIds.reverse()));
+			store.setAudienceIds(new Set(audienceIds.reverse()));
 
 			for (const audienceId of audienceIds) {
 				audiences.on(audienceId, () => {
@@ -36,7 +36,7 @@ describe('implementation', () => {
 		it('clears the registered handlers after running', async () => {
 			let runCount = 0;
 
-			store.setPageAudienceIds(new Set(['a']));
+			store.setAudienceIds(new Set(['a']));
 
 			audiences.on('a', () => {
 				runCount += 1;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94564
https://liferay.atlassian.net/browse/LPD-94796

## What Is Being Fixed

The Audiences detection script recomputed Analytics Cloud segments every time a rule referenced the `segments` attribute, repeating two Analytics API calls on each evaluation. Separately, detected audiences were split across three retention scopes (browser, page, tab) and kept in `localStorage`/`sessionStorage`, so the matched audiences never reached the server and the page-scoped ones were lost on browser restart.

## How It Is Being Fixed

Analytics Cloud segments are now fetched once and memoized in the `Detection` object: `_getAcSegments` caches the combined batch and real-time segment external reference codes on first use, and `getSegments` returns the cached set, so later attribute evaluations reuse it.

The retention-type model is removed entirely. The `retentionType` field is dropped from the audiences definition and its validation, and audiences are no longer classified as BROWSER, PAGE, or TAB. All detected audience ids are now written to a single long-lived cookie instead of web storage, so they travel to the server automatically on each request and persist across browser restarts. The store collapses to a cookie read/write pair, the public API loses its `retentionType` parameters, and the bootstrap template clears audiences unconditionally before running detection.

## PR Check

**pr-check: PASS** — tested on `02001bf08b7f367b1dc8b90f47d54dd4f8105f28`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Module Registration | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "02001bf08b7f367b1dc8b90f47d54dd4f8105f28"} -->
