### PR TITLE
LPD-95945 Provide alt for card images set via setItemComponentProps

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -266,13 +266,24 @@ const Card = forwardRef<HTMLDivElement, any>(
 			title: getLocalizedValue(item, title)?.value || '',
 		};
 
+		const finalProps = {
+			...props,
+			...(activeView.setItemComponentProps?.({item, props}) ?? {}),
+		};
+
+		// Ensure card images remain accessible even when a consumer overrides
+		// imgProps through setItemComponentProps without providing an alt
+
+		if (finalProps.imgProps && !finalProps.imgProps.alt) {
+			finalProps.imgProps = {
+				...finalProps.imgProps,
+				alt: accessibleName,
+			};
+		}
+
 		return (
 			<div ref={ref}>
-				<ClayCardWithInfo
-					{...props}
-					{...(activeView.setItemComponentProps?.({item, props}) ??
-						{})}
-				/>
+				<ClayCardWithInfo {...finalProps} />
 			</div>
 		);
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95945

## What Is Being Fixed

The Playwright accessibility spec `frontend-data-set-web/main/tests/advanced/accessibility.spec.ts` failed on the Cards visualization mode: a card image rendered without an accessible name. The earlier fix (LPD-93191) taught `imagePropsTransformer` to fall back to the card's accessible name when no `alt` is present, but that fallback only covered the default `imgProps`. The FDS API lets a consumer replace component props through `setItemComponentProps`, and the card spreads that result over the computed props. When a consumer returns its own `imgProps` without an `alt` — as the Advanced sample does for the `Sample1` card — it overrides the alt-bearing props and leaves the image with no accessible name.

## How It Is Being Fixed

In `Cards.tsx` the merge of the default props and the `setItemComponentProps` result is now computed into a single `finalProps` object, and the accessible-name fallback runs on that merged result instead of only on the default `imgProps`. If the resulting `imgProps` still has no `alt`, the card's accessible name is applied. This guarantees an accessible image regardless of whether `imgProps` originates from the default transformer or from a consumer's `setItemComponentProps`, mirroring the existing fallback already in `imagePropsTransformer`.

## Why Are There No Tests?

LPD-95945 is a "fix the test" task: the existing accessibility Playwright spec is the coverage and now passes (deployed and verified locally). The image `alt` behavior is additionally exercised by the existing `imagePropsTransformer` Jest spec.

## PR Check

**pr-check: PASS** — tested on `ba7506f475b0e19628fda1cd7faf475fe378b5c4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ba7506f475b0e19628fda1cd7faf475fe378b5c4"} -->
