### PR TITLE
LPD-94210 Prevent the share people input from clearing on comma

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/share_modal_content/ShareModalContent.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/share_modal_content/ShareModalContent.tsx
@@ -497,6 +497,7 @@ export default function ShareModalContent({
 							</div>
 
 							<ClayMultiSelect
+								allowsCustomLabel={false}
 								id="collaboratorAutocomplete"
 								items={[]}
 								loadingState={autocompleteNetworkStatus}

--- a/modules/apps/frontend-js/frontend-js-components-web/test/share_modal_content/ShareModalContent.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/share_modal_content/ShareModalContent.test.tsx
@@ -8,6 +8,7 @@ import '@testing-library/jest-dom';
 // eslint-disable-next-line
 import {checkAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
 import {act, fireEvent, render, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import ShareModalContent from '../../src/main/resources/META-INF/resources/share_modal_content/ShareModalContent';
@@ -244,6 +245,22 @@ describe('ShareModalContent', () => {
 		await waitFor(() => {
 			expect(getByRole('listbox')).toBeInTheDocument();
 		});
+	});
+
+	it('keeps the typed value in the autocomplete input when a special character is entered', async () => {
+		const user = userEvent.setup({
+			advanceTimers: jest.advanceTimersByTime,
+		});
+
+		const {container} = renderComponent();
+
+		const input = container.querySelector<HTMLInputElement>(
+			'input#collaboratorAutocomplete'
+		)!;
+
+		await user.type(input, 'Test3,');
+
+		expect(input).toHaveValue('Test3,');
 	});
 
 	it('calls submission when share is clicked', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94210

## What Is Being Fixed

In the Share dialog, typing text in the "Add people" field and then pressing the comma key wiped the whole input. The user lost everything they had typed instead of either keeping the comma in the field or, at worst, just not being able to add that entry as a collaborator.

## How It Is Being Fixed

The field is a `ClayMultiSelect` in the shared `ShareModalContent` component (`frontend-js-components-web`). Its `allowsCustomLabel` prop defaults to `true`, so Clay treats the comma and Enter as delimiters: it strips the comma as you type and commits the typed text as a custom label, clearing the input. Since collaborators here are only ever added by selecting an autocomplete suggestion, that committed text is discarded and nothing is added, leaving an empty field.

The fix passes `allowsCustomLabel={false}` to that `ClayMultiSelect`. The comma now stays in the field, and if it does not match an autocomplete suggestion, no collaborator is simply added. Because this is the shared component, the fix covers both consumers that use it: the CMS share and the Frontend Data Set "User Views" share, which had the same bug.

A Jest unit test was added to `ShareModalContent.test.tsx` that types text followed by a comma into the collaborator input and asserts the value is preserved. It fails without the fix and passes with it. No existing Playwright share tests are affected, since they all add collaborators through the autocomplete dropdown rather than by typing a comma or pressing Enter.

## PR Check

**pr-check: PASS** — tested on `1a4e883e7e41b39a0cac3450c28a8d15bc896fab`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1a4e883e7e41b39a0cac3450c28a8d15bc896fab"} -->
