### PR TITLE
LPD-74823 Keep the unsaved changes mark when renaming a user view

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/viewsReducer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/viewsReducer.ts
@@ -146,7 +146,6 @@ const viewsActions: TViewsActions = {
 
 		return {
 			...state,
-			snapshotUpdated: false,
 			snapshots: updatedSnapshots,
 		};
 	},

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/userViews.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/userViews.spec.ts
@@ -137,7 +137,7 @@ test(
 
 test(
 	'Can create, edit and delete User Views',
-	{tag: '@LPD-10683'},
+	{tag: ['@LPD-10683', '@LPD-74823']},
 	async ({dataSetFragmentPage, dataSetManagerApiHelpers, layout, page}) => {
 		let userViewsActionsDropdown: Locator;
 		let userViewsDropdown: Locator;
@@ -390,6 +390,16 @@ test(
 
 			await expect(dataSetFragmentPage.cardsWrapper).toBeInViewport();
 
+			await dataSetFragmentPage.changeVisualizationMode('Table');
+
+			await dataSetFragmentPage.table.container.waitFor({
+				state: 'visible',
+			});
+
+			await expect(
+				dataSetFragmentPage.userViewsSelectorButton
+			).toHaveText(`${userView1Name}${userView1Name} Updated`);
+
 			await dataSetFragmentPage.userViewsActionsButton.click();
 
 			await userViewsActionsDropdown
@@ -418,10 +428,12 @@ test(
 				.click();
 
 			await waitForAlert(page, 'Success:View was renamed successfully.');
+		});
 
+		await test.step('Renaming a view keeps its unsaved changes mark', async () => {
 			await expect(
 				dataSetFragmentPage.userViewsSelectorButton
-			).toHaveText(userView2Name);
+			).toHaveText(`${userView2Name}${userView2Name} Updated`);
 		});
 
 		await test.step('Can delete a user view', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-74823

## What Is Being Fixed

When a User View in a Frontend Data Set had unsaved changes — shown by the "*" next to its name — renaming the view through the kebab menu cleared that mark, even though the other unsaved view settings (delta, sorting, columns) were still pending.

## How It Is Being Fixed

The RENAME_ACTIVE_SNAPSHOT reducer action was hard-setting snapshotUpdated to false. Renaming only persists the view's label through a single PATCH, so the reducer now preserves the existing snapshotUpdated value rather than clearing it: a view with pending changes keeps its "*", and a clean view stays clean. The "Can create, edit and delete User Views" Playwright test now makes an unsaved change before renaming and asserts the mark survives.

## PR Check

**pr-check: PASS** — tested on `e79e15d24f38bb172bc8f0a90ba8d3251dd97c45`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e79e15d24f38bb172bc8f0a90ba8d3251dd97c45"} -->
