### PR TITLE
LPD-93231 Google Maps Search Not Properly Handling Map Marker/Zoom

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -164,10 +164,7 @@ export function useGeolocation({
 		if (mapRef.current) {
 			onChangeRef.current?.removeListener();
 
-			onChangeRef.current = mapRef.current.on(
-				'positionChange',
-				onChange
-			);
+			onChangeRef.current = mapRef.current.on('positionChange', onChange);
 		}
 	}, [onChange]);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -96,6 +96,7 @@ export function useGeolocation({
 	viewMode,
 }) {
 	const mapRef = useRef(null);
+	const onChangeRef = useRef(null);
 
 	useEffect(() => {
 		if (!disabled || viewMode) {
@@ -120,9 +121,12 @@ export function useGeolocation({
 					`#map_${instanceId}`
 				);
 
-				mapRef.current.removeAllListeners('positionChange');
+				onChangeRef.current?.removeListener();
 
-				mapRef.current.on('positionChange', onChange);
+				onChangeRef.current = mapRef.current.on(
+					'positionChange',
+					onChange
+				);
 
 				if (value) {
 					mapRef.current.setCenter(parseJSONValue(value));
@@ -158,9 +162,12 @@ export function useGeolocation({
 
 	useEffect(() => {
 		if (mapRef.current) {
-			mapRef.current.removeAllListeners('positionChange');
+			onChangeRef.current?.removeListener();
 
-			mapRef.current.on('positionChange', onChange);
+			onChangeRef.current = mapRef.current.on(
+				'positionChange',
+				onChange
+			);
 		}
 	}, [onChange]);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -96,7 +96,7 @@ export function useGeolocation({
 	viewMode,
 }) {
 	const mapRef = useRef(null);
-	const onChangeRef = useRef(null);
+	const onPositionChangeRef = useRef(null);
 
 	useEffect(() => {
 		if (!disabled || viewMode) {
@@ -121,9 +121,9 @@ export function useGeolocation({
 					`#map_${instanceId}`
 				);
 
-				onChangeRef.current?.removeListener();
+				onPositionChangeRef.current?.removeListener();
 
-				onChangeRef.current = mapRef.current.on(
+				onPositionChangeRef.current = mapRef.current.on(
 					'positionChange',
 					onChange
 				);
@@ -162,10 +162,18 @@ export function useGeolocation({
 
 	useEffect(() => {
 		if (mapRef.current) {
-			onChangeRef.current?.removeListener();
+			onPositionChangeRef.current?.removeListener();
 
-			onChangeRef.current = mapRef.current.on('positionChange', onChange);
+			onPositionChangeRef.current = mapRef.current.on(
+				'positionChange',
+				onChange
+			);
 		}
+
+		return () => {
+			onPositionChangeRef.current?.removeListener();
+			onPositionChangeRef.current = null;
+		};
 	}, [onChange]);
 
 	useEffect(() => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {MapOpenStreetMap} from '@liferay/map-openstreetmap';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -60,6 +61,8 @@ jest.mock('@liferay/map-openstreetmap', () => ({
 			}),
 			on: jest.fn((eventName, callback) => {
 				mockInstance._listeners[eventName] = callback;
+
+				return {removeListener: jest.fn()};
 			}),
 			removeAllListeners: jest.fn(),
 			setCenter: jest.fn(),
@@ -132,5 +135,40 @@ describe('Geolocation', () => {
 
 		expect(await screen.findAllByText('pt_BR Address')).toBeTruthy();
 		expect(screen.queryAllByText('en_US Address')).toHaveLength(0);
+	});
+
+	it('removes only the listener held in useGeolocation and not any other listeners', () => {
+		const renderGeolocation = () => (
+			<ConfigProvider value={{defaultLanguageId: 'en_US'}}>
+				<FormProvider
+					initialState={{
+						editingLanguageId: 'en_US',
+						pages: [],
+					}}
+					reducers={[languageReducer]}
+				>
+					<PageProvider value={{pageIndex: 0}}>
+						<GeolocationWrapper />
+					</PageProvider>
+				</FormProvider>
+			</ConfigProvider>
+		);
+
+		const {rerender} = render(renderGeolocation());
+
+		const {results} = MapOpenStreetMap.mock;
+
+		const mapInstance = results[results.length - 1].value;
+
+		const {results: onResults} = mapInstance.on.mock;
+
+		const previousListener = onResults[onResults.length - 1].value;
+
+		rerender(renderGeolocation());
+
+		const currentListener = onResults[onResults.length - 1].value;
+
+		expect(previousListener.removeListener).toHaveBeenCalledTimes(1);
+		expect(currentListener.removeListener).not.toHaveBeenCalled();
 	});
 });

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
@@ -62,9 +62,12 @@ jest.mock('@liferay/map-openstreetmap', () => ({
 			on: jest.fn((eventName, callback) => {
 				mockInstance._listeners[eventName] = callback;
 
-				return {removeListener: jest.fn()};
+				return {
+					removeListener: jest.fn(() => {
+						delete mockInstance._listeners[eventName];
+					}),
+				};
 			}),
-			removeAllListeners: jest.fn(),
 			setCenter: jest.fn(),
 		};
 

--- a/modules/apps/map/map-google-maps/package.json
+++ b/modules/apps/map/map-google-maps/package.json
@@ -9,7 +9,8 @@
 	"scripts": {
 		"build": "node-scripts build",
 		"checkFormat": "node-scripts format --check",
-		"format": "node-scripts format"
+		"format": "node-scripts format",
+		"test": "node-scripts test"
 	},
 	"version": "5.0.48"
 }

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsSearch.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsSearch.js
@@ -94,6 +94,7 @@ class GoogleMapsSearch extends EventEmitter {
 						lat: geolocation.lat(),
 						lng: geolocation.lng(),
 					},
+					viewport: place.geometry.viewport || null,
 				},
 			});
 		}

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.js
@@ -12,6 +12,13 @@ import GoogleMapsMarker from './GoogleMapsMarker';
 import GoogleMapsSearch from './GoogleMapsSearch';
 
 /**
+ * Zoom level applied when a selected Place result lacks a recommended viewport.
+ * @see https://developers.google.com/maps/documentation/javascript/examples/place-autocomplete-map
+ * @type {number}
+ */
+const FALLBACK_ZOOM = 17;
+
+/**
  * MapGoogleMaps
  * @review
  */
@@ -66,6 +73,26 @@ class MapGoogleMaps extends MapBase {
 		}
 
 		return map;
+	}
+
+	/**
+	 * @inheritDoc
+	 * @review
+	 */
+	_handleSearchButtonClicked({position}) {
+		super._handleSearchButtonClicked({position});
+
+		if (!this._map) {
+			return;
+		}
+
+		if (position.viewport) {
+			this._map.fitBounds(position.viewport);
+		}
+		else {
+			this._map.setCenter(position.location);
+			this._map.setZoom(FALLBACK_ZOOM);
+		}
 	}
 
 	/**

--- a/modules/apps/map/map-google-maps/test/liferay/MapGoogleMaps.js
+++ b/modules/apps/map/map-google-maps/test/liferay/MapGoogleMaps.js
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import MapGoogleMaps from '../../src/main/resources/META-INF/resources/js/MapGoogleMaps';
+
+describe('MapGoogleMaps', () => {
+	const getLocation = () => ({lat: Math.random(), lng: Math.random()});
+
+	const getMap = () => ({
+		controls: {},
+		data: {setStyle() {}},
+		fitBounds: jest.fn(),
+		setCenter: jest.fn(),
+		setZoom: jest.fn(),
+	});
+
+	let map;
+	let mapImpl;
+
+	class MapImpl extends MapGoogleMaps {
+		_createMap() {
+			return getMap();
+		}
+	}
+
+	beforeEach(() => {
+		global.google = {
+			maps: {
+				Geocoder: jest.fn(),
+				event: {addListener: jest.fn()},
+			},
+		};
+
+		mapImpl = new MapImpl();
+
+		map = getMap();
+
+		mapImpl._map = map;
+	});
+
+	describe('_handleSearchButtonClicked()', () => {
+		it('updates the instance position', () => {
+			const position = {location: getLocation()};
+
+			mapImpl._handleSearchButtonClicked({position});
+
+			expect(mapImpl.position).toBe(position);
+		});
+
+		it('fits the map to the viewport when the position has one', () => {
+			const position = {location: getLocation(), viewport: {name: 'box'}};
+
+			mapImpl._handleSearchButtonClicked({position});
+
+			expect(map.fitBounds).toHaveBeenCalledTimes(1);
+			expect(map.fitBounds.mock.calls[0][0]).toBe(position.viewport);
+		});
+
+		it('does not set a fallback zoom when the position has a viewport', () => {
+			const position = {location: getLocation(), viewport: {name: 'box'}};
+
+			mapImpl._handleSearchButtonClicked({position});
+
+			expect(map.setZoom).not.toHaveBeenCalled();
+		});
+
+		it('centers the map and applies the fallback zoom when the position has no viewport', () => {
+			const position = {location: getLocation()};
+
+			mapImpl._handleSearchButtonClicked({position});
+
+			expect(map.setCenter.mock.calls[0][0]).toBe(position.location);
+			expect(map.setZoom).toHaveBeenCalledTimes(1);
+			expect(map.setZoom.mock.calls[0][0]).toBe(17);
+		});
+	});
+});


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-93231
Follow up: https://github.com/liferay-frontend/liferay-portal/pull/5571

<h1>Google Maps Search Not Properly Handling Map Marker/Zoom</h1>

This PR addresses 2 issues:

1. When searching for a location, the marker is not repositioned. This is due to useGeolocation removing MapBase's positionChange listener and is fixed by making sure useGeolocation only removes its own listener.
2. The map is currently not recentered after searching with the Google Maps provider. This is fixed by using the bounds provided by Google for the geocoded result.