### PR TITLE
LPD-96282 Fix snapshot sharing interpreter test on a seeded database

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
@@ -6,7 +6,6 @@
 package com.liferay.frontend.data.set.internal.sharing.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.frontend.data.set.test.util.FrontendDataSetTestUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -63,9 +62,6 @@ public class DataSetSnapshotSharingEntryInterpreterTest {
 
 	@Before
 	public void setUp() throws Exception {
-		FrontendDataSetTestUtil.initialize(
-			DataSetSnapshotSharingEntryInterpreterTest.class);
-
 		_objectDefinition =
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96282

## What Is Being Fixed

DataSetSnapshotSharingEntryInterpreterTest fails in CI on a database where the L_DATA_SET system object definitions already exist. Its setUp called FrontendDataSetTestUtil.initialize, which re-ran the LPS-164563-gated object definition batch import a second time. Because L_DATA_SET was already seeded, the re-import tried to create a duplicate object definition and tripped the LPS-135983 root model resource guard (portlet ...ObjectDefinitionsPortlet_T9Q0 cannot be assigned to two root model resources), which aborted the import under ON_ERROR_FAIL and failed the test in setUp.

## How It Is Being Fixed

The L_DATA_SET object definitions, including L_DATA_SET_SNAPSHOT, are already seeded by the feature-flag-gated batch import that runs when LPS-164563 is enabled, which the test already enables via @FeatureFlags. The explicit initialize call was therefore redundant and only introduced the conflicting second import. Removing it lets the test rely on the seeding the feature flags already perform.

## Why Are There No Tests?

The change is itself a test fix: it repairs the existing failing integration test DataSetSnapshotSharingEntryInterpreterTest and adds no new behavior that would warrant additional coverage.

## PR Check

**pr-check: PASS** — tested on `9cd583069ada5402e4598906efcad05101da694f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "9cd583069ada5402e4598906efcad05101da694f"} -->
