### PR TITLE
LPD-96120 Fix Balloon Editor toolbar test after AI Creator removal

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/balloon.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/balloon.spec.ts
@@ -53,7 +53,7 @@ test(
 			'Image',
 			'Video',
 			'Horizontal line',
-			'Text alignment'
+			'Text alignment',
 		];
 
 		const controls = await balloonPage.toolbar

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/balloon.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/balloon.spec.ts
@@ -53,8 +53,7 @@ test(
 			'Image',
 			'Video',
 			'Horizontal line',
-			'Text alignment',
-			'AI Creator',
+			'Text alignment'
 		];
 
 		const controls = await balloonPage.toolbar


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96120

## What Is Being Fixed

The Playwright test in balloon.spec.ts asserted that the Balloon Editor toolbar exposes an "AI Creator" control. After LPD-92713, the AI Creator button is no longer shown by default in the Balloon Editor, so the expected-controls list no longer matched what the toolbar renders and the test failed.

## How It Is Being Fixed

The "AI Creator" entry is removed from the list of expected toolbar controls so the assertion reflects the editor's current default behavior.

## Why Are There No Tests?

The sole change in this PR is a fix to an existing Playwright test; it adjusts test expectations rather than production code, so no additional test coverage applies.

## PR Check

**pr-check: PASS** — tested on `91b952721e649fe743d989c08e61a3f43b9bc8c7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "91b952721e649fe743d989c08e61a3f43b9bc8c7"} -->
