### PR TITLE
LPD-96500 Align user views test with the new name validation

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/userViews.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/userViews.spec.ts
@@ -118,7 +118,7 @@ test(
 			await expect(fdsSamplePage.table.headerCells).toHaveCount(11);
 		});
 
-		await test.step('Can not change a user view name if no name is provided', async () => {
+		await test.step('Can not rename a user view to a blank or duplicate name', async () => {
 			await fdsSamplePage.userViewsSelectorButton.click();
 
 			await fdsSamplePage.dropdownMenu.waitFor();
@@ -141,17 +141,26 @@ test(
 
 			await expect(fdsSamplePage.userViewsRenameModal).toBeInViewport();
 
-			await fdsSamplePage.userViewsRenameModal
-				.getByLabel('NameRequired')
-				.fill('');
+			const nameInput =
+				fdsSamplePage.userViewsRenameModal.getByLabel('NameRequired');
+			const saveButton = fdsSamplePage.userViewsRenameModal.getByRole(
+				'button',
+				{name: 'Save'}
+			);
 
-			await fdsSamplePage.userViewsRenameModal
-				.getByRole('button', {name: 'Save'})
-				.click();
+			await nameInput.fill('   ');
+
+			await expect(saveButton).toBeDisabled();
+
+			await nameInput.fill(userView1Name);
+
+			await expect(saveButton).toBeEnabled();
+
+			await saveButton.click();
 
 			await expect(
 				fdsSamplePage.userViewsRenameModal.getByText(
-					'This field is required.'
+					'A view with this name already exists.'
 				)
 			).toBeVisible();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96500

## What Is Being Fixed

LPD-75050 added name validation to the FDS User View save/rename modal: the Save button is now disabled while the name is empty or whitespace, and a duplicate name produces "A view with this name already exists." This broke the `frontend-data-set-web` `userViews.spec.ts` test, whose "no name provided" step cleared the field, clicked Save, and asserted "This field is required." — a path that no longer exists, so the click stalls on the now-disabled button.

## How It Is Being Fixed

The affected step is rewritten to match the new behavior, mirroring the coverage already added to the sibling `frontend-data-set-fragment-web` spec: a blank/whitespace name asserts the Save button is disabled, then an existing view name asserts the button re-enables and that saving surfaces the duplicate-name error.

## PR Check

**pr-check: PASS** — tested on `e87395f3629ab40941f72406c4f62c43c657b18b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "e87395f3629ab40941f72406c4f62c43c657b18b"} -->
