### PR TITLE
LPD-96651 Fix Dynamic Actions test broken by menu toggle behavior

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/dynamic_actions/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/dynamic_actions/actions.spec.ts
@@ -178,6 +178,8 @@ test('Dynamic Actions', async ({
 		await expect(
 			fdsSamplePage.dropdownMenu.getByRole('menuitem')
 		).toHaveText(['Approve', 'Reject']);
+
+		await page.keyboard.press('Escape');
 	});
 
 	await test.step('Can Reject the pending task with a comment', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96651

## What Is Being Fixed

The "Dynamic Actions" Playwright test in
frontend-data-set-web/main/tests/dynamic_actions/actions.spec.ts started
failing with a timeout while waiting for the "Reject" menu item inside the
item actions dropdown.

The test regressed after LPD-93937 ("Close the FDS item actions menu when
its trigger is clicked"), which corrected the dropdown's onActiveChange
handler to honor Clay's active state instead of a stale-closure toggle. The
"Check that the pending task has workflow actions" step opens the actions
menu and asserts its items, but leaves it open. The next step's
clickItemAction then clicks the same trigger again. Before the fix that
re-click left the menu open, so the item was clickable; after the fix the
re-click correctly closes the menu, so the item never appears and the click
times out.

## How It Is Being Fixed

The test now closes the actions menu with Escape after asserting its
contents, so the subsequent clickItemAction reopens it from a closed state
and finds the "Reject" item. This aligns the test with the corrected,
intended dropdown behavior instead of relying on the previous bug.

## Why Are There No Tests?

This change is itself a fix to an existing Playwright test and touches no
product code, so no additional test coverage is warranted.

## PR Check

**pr-check: PASS** — tested on `648ca06563186a3b5429c212c868991ee205a82f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "648ca06563186a3b5429c212c868991ee205a82f"} -->
