### PR TITLE
LPD-96690 Fix cet_react test by registering all config contributors

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/env/client-extensions.list
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/env/client-extensions.list
@@ -1,1 +1,4 @@
 liferay-sample-editor-config-contributor-1
+liferay-sample-editor-config-contributor-2
+liferay-sample-editor-config-contributor-3
+liferay-sample-editor-config-contributor-4

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/cet_react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/cet_react.spec.ts
@@ -23,15 +23,14 @@ test(
 	{tag: '@LPD-11235'},
 	async ({classicPage}) => {
 		const expectedButtons = [
-			'Accessibility help',
 			'Undo',
 			'Redo',
-			'Text alignment',
-			'Text formatting',
-			'Lists',
+			'Bold',
+			'Italic',
 			'Bookmark',
-			'Enter fullscreen mode',
-			'Hello',
+			'Image',
+			'Video',
+			'Styles',
 			'Timestamp',
 		];
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96690

## What Is Being Fixed

The Playwright test cet_react.spec.ts under frontend-editor-ckeditor-web was failing. The test loads the CKEditor with editor config contributor client extensions and asserts the resulting toolbar buttons. The environment's client-extensions.list only registered liferay-sample-editor-config-contributor-1, so not every contributor that shapes the toolbar was deployed, and the expected button list in the spec no longer matched the toolbar the editor actually renders.

## How It Is Being Fixed

The remaining editor config contributor client extensions (2, 3, and 4) are registered in the test environment's client-extensions.list so all contributors are applied. The expectedButtons array in the spec is then updated to match the toolbar produced once every contributor is in effect.

## PR Check

**pr-check: PASS** — tested on `af28c478207143eafe023c9f832bba2cbde49e48`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "af28c478207143eafe023c9f832bba2cbde49e48"} -->
