### PR TITLE
LPD-96709 Apply the CSP nonce to markup injected via createContextualFragment

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelMetricsView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelMetricsView.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {setCSPNonce} from 'frontend-js-web';
 import React, {useEffect, useRef} from 'react';
 
 import Sidebar from './Sidebar';
@@ -11,7 +12,9 @@ const SidebarPanelMetricsView = ({html}) => {
 	const elementRef = useRef();
 
 	useEffect(() => {
-		const fragment = document.createRange().createContextualFragment(html);
+		const fragment = document
+			.createRange()
+			.createContextualFragment(setCSPNonce(html));
 
 		elementRef.current.innerHTML = '';
 

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/modal/components/Modal.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/modal/components/Modal.tsx
@@ -7,7 +7,7 @@ import ClayButton from '@clayui/button';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import classNames from 'classnames';
-import {navigate} from 'frontend-js-web';
+import {navigate, setCSPNonce} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import Iframe, {IframeOnOpen} from './Iframe';
@@ -228,7 +228,7 @@ export default function Modal({
 			if (html) {
 				const fragment = document
 					.createRange()
-					.createContextualFragment(html);
+					.createContextualFragment(setCSPNonce(html));
 
 				if (bodyRef.current) {
 					bodyRef.current.innerHTML = '';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/index.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/index.js
@@ -112,6 +112,7 @@ import runScriptsInElement from './util/run_scripts_in_element.es';
 import selectFolder from './util/select_folder';
 import {getSessionValue, setSessionValue} from './util/session.es';
 import sessionStorage from './util/session_storage';
+import setCSPNonce from './util/set_csp_nonce';
 import showCapsLock from './util/show_caps_lock';
 import sub from './util/sub';
 import toCharCode from './util/to_char_code.es';
@@ -333,6 +334,7 @@ Liferay.Util.openWindow = openWindow;
 Liferay.Util.openInDialog = openInDialog;
 Liferay.Util.removeEntitySelection = removeEntitySelection;
 Liferay.Util.selectFolder = selectFolder;
+Liferay.Util.setCSPNonce = setCSPNonce;
 Liferay.Util.setPortletConfigurationIconAction =
 	setPortletConfigurationIconAction;
 Liferay.Util.showCapsLock = showCapsLock;
@@ -440,6 +442,7 @@ Liferay.__INTERNALS = {
 	runScriptsInElement,
 	selectFolder,
 	sessionStorage,
+	setCSPNonce,
 	setCookie,
 	setFormValues,
 	setSessionValue,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/portlet.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/portlet.es.js
@@ -7,6 +7,7 @@ import fetch from '../util/fetch.es';
 import objectToFormData from '../util/form/object_to_form_data.es';
 import getPortletId from '../util/get_portlet_id';
 import createPortletURL from '../util/portlet_url/create_portlet_url.es';
+import setCSPNonce from '../util/set_csp_nonce';
 import register from './register.es';
 
 /**
@@ -102,6 +103,8 @@ export function minimizePortlet(portletSelector, trigger, options) {
 						)
 							.then((response) => response.text())
 							.then((response) => {
+								response = setCSPNonce(response);
+
 								const range = document.createRange();
 
 								range.selectNode(portlet);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -6,6 +6,7 @@
 import EventEmitter from './events/EventEmitter';
 import throttle from './throttle.es';
 import fetch from './util/fetch.es';
+import setCSPNonce from './util/set_csp_nonce';
 
 const SCRIPT_URL = document.currentScript.src;
 
@@ -454,6 +455,8 @@ SideNavigation.prototype = {
 					return response.text();
 				})
 				.then((text) => {
+					text = setCSPNonce(text);
+
 					const range = document.createRange();
 
 					range.selectNode(sidebar);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/set_csp_nonce.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/set_csp_nonce.js
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/**
+ * Rewrites the nonce of every inline `<script>`/`<style>` in the given markup
+ * to the nonce bound to the current document (`Liferay.CSP.nonce`).
+ *
+ * Markup fetched over AJAX carries the nonce of its own response. When
+ * per-request nonces are in effect (for example when SPA is disabled) that
+ * nonce does not match the one bound to the current document, so injecting the
+ * markup (for example through `Range.createContextualFragment`, which evaluates
+ * scripts and applies styles) is blocked by the Content Security Policy.
+ * Rewriting the nonces to the document nonce keeps the injected content valid.
+ *
+ * @param {string} html The markup to rewrite.
+ * @return {string} The markup with its inline script/style nonces rewritten.
+ */
+export default function setCSPNonce(html) {
+	if (
+		typeof html !== 'string' ||
+		!window.Liferay ||
+		!Liferay.CSP ||
+		!Liferay.CSP.nonce
+	) {
+		return html;
+	}
+
+	return html.replace(
+		/(<(?:script|style)\b[^>]*\bnonce=")[^"]*(")/gi,
+		`$1${Liferay.CSP.nonce}$2`
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.d.ts
@@ -777,6 +777,9 @@ export function sub(
 /* Returns the stored value of a cookie, undefined if not present */
 export function getCookie(name: string, type: TYPE_VALUES): string | undefined;
 
+/* Rewrites the inline script/style nonces in the given markup to the document nonce */
+export function setCSPNonce(html: string): string;
+
 /* Sets a cookie of a specific type if user has consented */
 export function setCookie(
 	name: string,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.js
@@ -64,6 +64,7 @@ export const {
 	runScriptsInElement,
 	selectFolder,
 	sessionStorage,
+	setCSPNonce,
 	setCookie,
 	setFormValues,
 	setSessionValue,

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LookAndFeelThemeEdit.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LookAndFeelThemeEdit.js
@@ -4,7 +4,7 @@
  */
 
 import {openSelectionModal} from 'frontend-js-components-web';
-import {fetch, objectToFormData} from 'frontend-js-web';
+import {fetch, objectToFormData, setCSPNonce} from 'frontend-js-web';
 
 export default function ({
 	changeThemeButtonId,
@@ -49,6 +49,8 @@ export default function ({
 					})
 						.then((response) => response.text())
 						.then((response) => {
+							response = setCSPNonce(response);
+
 							const range = document.createRange();
 							const fragment =
 								range.createContextualFragment(response);

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
@@ -329,6 +329,8 @@ if (portletTitleBasedNavigation) {
 					);
 
 					if (messageContainer) {
+						response = Liferay.Util.setCSPNonce(response);
+
 						messageContainer.appendChild(
 							document
 								.createRange()

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.js
@@ -6,7 +6,13 @@
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {openToast} from 'frontend-js-components-web';
-import {fetch, objectToFormData, setSessionValue, sub} from 'frontend-js-web';
+import {
+	fetch,
+	objectToFormData,
+	setCSPNonce,
+	setSessionValue,
+	sub,
+} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
@@ -99,6 +105,8 @@ function LayoutFinder({
 					);
 
 					sidebar.innerHTML = '';
+
+					productMenuContent = setCSPNonce(productMenuContent);
 
 					const range = document.createRange();
 					range.selectNode(sidebar);

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.js
@@ -9,7 +9,7 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import {openToast} from 'frontend-js-components-web';
-import {fetch, navigate, setSessionValue} from 'frontend-js-web';
+import {fetch, navigate, setCSPNonce, setSessionValue} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
@@ -43,6 +43,8 @@ function PageTypeSelector({
 						);
 
 						sidebar.innerHTML = '';
+
+						productMenuContent = setCSPNonce(productMenuContent);
 
 						const range = document.createRange();
 						range.selectNode(sidebar);

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -135,6 +135,8 @@ SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDis
 
 						sidebar.innerHTML = '';
 
+						response = Liferay.Util.setCSPNonce(response);
+
 						var range = document.createRange();
 						range.selectNode(sidebar);
 

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/js/index.js
@@ -4,7 +4,7 @@
  */
 
 import {openModal} from 'frontend-js-components-web';
-import {addParams, fetch, navigate} from 'frontend-js-web';
+import {addParams, fetch, navigate, setCSPNonce} from 'frontend-js-web';
 
 export function signInButtonPropsTransformer({
 	additionalProps: {redirect: initialRedirect, signInURL},
@@ -20,6 +20,8 @@ export function signInButtonPropsTransformer({
 	const updateModalContent = (html) => {
 		const modalBody = document.querySelector('.liferay-modal-body');
 		if (modalBody) {
+			html = setCSPNonce(html);
+
 			const fragment = document
 				.createRange()
 				.createContextualFragment(html);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96709
### What Is Being Fixed

AJAX-fetched portlet markup is injected into the page via `Range.createContextualFragment`, which evaluates its inline `<script>` and applies its inline `<style>`. That markup carries the nonce of **its own response**. When per-request nonces are in effect (for example when SPA is disabled), that nonce does not match the nonce bound to the current document, so the Content Security Policy blocks every injected script and style.

Symptom: opening the Product Menu sidenav (and similar flows) throws a burst of `Executing inline script violates ... script-src 'self' 'nonce-...'` and `Applying inline style violates ...` errors, and the injected content fails to initialize. (Console stacks misattribute the frames to `get_lexicon_icon.js` — a combo/source-map artifact; the real path is `toggle → toggleSimpleSidenav → showSimpleSidenav → _loadUrl`.)

### How It Is Being Fixed

Add a shared `Liferay.Util.setCSPNonce(html)` helper (`frontend-js-web/.../liferay/util/set_csp_nonce.js`) that rewrites the inline `<script>`/`<style>` nonces in the fetched markup to the current document nonce (`Liferay.CSP.nonce`), and call it immediately before each `createContextualFragment` injection.

Wired into `frontend-js-web` via `liferay/index.js` (global `Liferay.Util` + `Liferay.__INTERNALS`) and re-exported from the package entry `main/index.js` so `import {setCSPNonce} from 'frontend-js-web'` resolves.

Call sites updated (8):
- `frontend-js-web`: `side_navigation.es.js`, `portlet/portlet.es.js`
- `product-navigation-product-menu-web`: `LayoutFinder.js`, `PageTypeSelector.js`
- `layout-admin-web`: `LookAndFeelThemeEdit.js`
- `product-navigation-user-personal-bar-web`: `index.js` (sign-in modal)
- `message-boards-web`: `view_message_content.jsp`, `product-navigation-site-administration`: `site_administration_body.jsp` (via the `Liferay.Util.setCSPNonce` global)

### Tests

Verified manually with CSP enabled and **SPA disabled** (the per-request-nonce condition): Product Menu sidenav, Pages tree, Back-to-Menu, and the sign-in modal all inject with scripts carrying the document nonce and **zero** inline-script/style CSP violations (was 5 script + 1 style). Injected `<script>` nonces confirmed equal to the document nonce.

pr-check: Source Format, JSP Compile (message-boards-web, site-administration), Per-Module Compile (6 modules), and JavaScript Unit Test (frontend-js-web 527 tests / 7 snapshots, layout-admin-web 26 tests) all pass.

### Note for reviewers

`createContextualFragment` does honor a matching nonce; the bug is purely the mismatch between the fetched response's nonce and the document's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
