### PR TITLE
LPD-75911 Add search to the User Views dropdown

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -13,7 +13,7 @@ import {
 	openModal,
 	openToast,
 } from 'frontend-js-components-web';
-import {debounce, fetch, sub} from 'frontend-js-web';
+import {cancelDebounce, debounce, fetch, sub} from 'frontend-js-web';
 import React, {Ref, useContext, useMemo, useRef, useState} from 'react';
 
 import FrontendDataSetContext from '../../../FrontendDataSetContext';
@@ -223,6 +223,8 @@ const SnapshotsControls = () => {
 	);
 
 	const clearSearch = () => {
+		cancelDebounce(debouncedSetSearchTerm);
+
 		setSearchTerm('');
 		setDebouncedSearchTerm('');
 	};
@@ -605,45 +607,41 @@ const SnapshotsControls = () => {
 
 					{hasSearchResults ? (
 						<ClayDropDown.ItemList>
-							{filteredPickerItems.map(
-								(group: ISnapshots, index: number) => (
-									<ClayDropDown.Group
-										header={
-											group.headerVisible
-												? group.label
-												: undefined
-										}
-										key={index}
-									>
-										{group.items.map(
-											(snapshot: ISnapshot) => (
-												<ClayDropDown.Item
-													active={
-														snapshot.erc ===
-														activeSnapshot.erc
-													}
-													key={snapshot.erc}
-													onClick={() =>
-														onSnapshotChange({
-															defaultSnapshot,
-															snapshots,
-															value: snapshot.erc,
-														})
-													}
-													symbolRight={
-														snapshot.erc ===
-														activeSnapshot.erc
-															? 'check'
-															: undefined
-													}
-												>
-													{snapshot.label}
-												</ClayDropDown.Item>
-											)
-										)}
-									</ClayDropDown.Group>
-								)
-							)}
+							{filteredPickerItems.map((group: ISnapshots) => (
+								<ClayDropDown.Group
+									header={
+										group.headerVisible
+											? group.label
+											: undefined
+									}
+									key={group.label || 'default'}
+								>
+									{group.items.map((snapshot: ISnapshot) => (
+										<ClayDropDown.Item
+											active={
+												snapshot.erc ===
+												activeSnapshot.erc
+											}
+											key={snapshot.erc}
+											onClick={() =>
+												onSnapshotChange({
+													defaultSnapshot,
+													snapshots,
+													value: snapshot.erc,
+												})
+											}
+											symbolRight={
+												snapshot.erc ===
+												activeSnapshot.erc
+													? 'check'
+													: undefined
+											}
+										>
+											{snapshot.label}
+										</ClayDropDown.Item>
+									))}
+								</ClayDropDown.Group>
+							))}
 						</ClayDropDown.ItemList>
 					) : (
 						<ClayDropDown.Caption>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -4,7 +4,6 @@
  */
 
 import ClayButton from '@clayui/button';
-import {Option, Picker} from '@clayui/core';
 import ClayDropDown from '@clayui/drop-down';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
@@ -14,8 +13,8 @@ import {
 	openModal,
 	openToast,
 } from 'frontend-js-components-web';
-import {fetch, sub} from 'frontend-js-web';
-import React, {Ref, useContext, useState} from 'react';
+import {debounce, fetch, sub} from 'frontend-js-web';
+import React, {Ref, useContext, useMemo, useRef, useState} from 'react';
 
 import FrontendDataSetContext from '../../../FrontendDataSetContext';
 import {DEFAULT_FETCH_HEADERS} from '../../../constants';
@@ -25,6 +24,8 @@ import {EViewsActionTypes} from '../../../views/viewsReducer';
 import shareSnapshotAction from './shareSnapshotAction';
 
 const DEFAULT_VIEW_ID = 'DEFAULT_VIEW';
+
+const SEARCH_DEBOUNCE_DELAY = 300;
 
 const RequiredMark = () => (
 	<>
@@ -210,6 +211,26 @@ const SnapshotsControls = () => {
 	] = useContext(ViewsContext);
 
 	const [actionsDropdownActive, setActionsDropdownActive] = useState(false);
+	const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
+	const [searchTerm, setSearchTerm] = useState('');
+	const [viewsDropdownActive, setViewsDropdownActive] = useState(false);
+
+	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	const debouncedSetSearchTerm = useMemo(
+		() => debounce(setDebouncedSearchTerm, SEARCH_DEBOUNCE_DELAY),
+		[]
+	);
+
+	const clearSearch = () => {
+		setSearchTerm('');
+		setDebouncedSearchTerm('');
+	};
+
+	const updateSearch = (value: string) => {
+		setSearchTerm(value);
+		debouncedSetSearchTerm(value);
+	};
 
 	const defaultSnapshotItem = {
 		erc: DEFAULT_VIEW_ID,
@@ -244,6 +265,19 @@ const SnapshotsControls = () => {
 		},
 		...visibleHeaderSnapshots,
 	];
+
+	const normalizedSearchTerm = debouncedSearchTerm.trim().toLowerCase();
+
+	const filteredPickerItems = pickerItems
+		.map((group: ISnapshots) => ({
+			...group,
+			items: group.items.filter((item: ISnapshot) =>
+				item.label.toLowerCase().includes(normalizedSearchTerm)
+			),
+		}))
+		.filter((group: ISnapshots) => !!group.items.length);
+
+	const hasSearchResults = !!filteredPickerItems.length;
 
 	const activeSnapshotLabel = activeSnapshot.label ?? '';
 	const initialLabel =
@@ -504,45 +538,119 @@ const SnapshotsControls = () => {
 	return (
 		<>
 			<ManagementToolbar.Item>
-				<Picker
-					as={SnapshotsControlsTrigger}
-					items={pickerItems}
-					messages={{
-						itemDescribedby: Liferay.Language.get(
-							'you-are-currently-on-a-text-element,-inside-of-a-list-box'
-						),
-						itemSelected: Liferay.Language.get('x-selected'),
-						scrollToBottomAriaLabel:
-							Liferay.Language.get('scroll-to-bottom'),
-						scrollToTopAriaLabel:
-							Liferay.Language.get('scroll-to-top'),
+				<ClayDropDown
+					active={viewsDropdownActive}
+					closeOnClick
+					hasRightSymbols
+					menuWidth="shrink"
+					onActiveChange={(active: boolean) => {
+						setViewsDropdownActive(active);
+
+						if (!active) {
+							clearSearch();
+						}
 					}}
-					onSelectionChange={(value) => {
-						onSnapshotChange({defaultSnapshot, snapshots, value});
-					}}
-					selectedKey={activeSnapshot.erc}
-					snapshotUpdated={snapshotUpdated}
-					triggerLabel={
-						activeSnapshotERC
-							? activeSnapshot.label
-							: Liferay.Language.get('default-view')
+					trigger={
+						<SnapshotsControlsTrigger
+							snapshotUpdated={snapshotUpdated}
+							triggerLabel={
+								activeSnapshotERC
+									? activeSnapshot.label
+									: Liferay.Language.get('default-view')
+							}
+						/>
 					}
 				>
-					{(group: ISnapshots) => (
-						<ClayDropDown.Group
-							header={
-								group.headerVisible ? group.label : undefined
-							}
-							items={group.items}
-						>
-							{(snapshot: ISnapshot) => (
-								<Option key={snapshot.erc}>
-									{snapshot.label}
-								</Option>
+					<div className="dropdown-section">
+						<ClayInput.Group small>
+							<ClayInput.GroupItem className="input-group-item-focusable">
+								<ClayInput
+									aria-label={Liferay.Language.get('search')}
+									insetAfter
+									onChange={(event) =>
+										updateSearch(event.target.value)
+									}
+									placeholder={Liferay.Language.get('search')}
+									ref={searchInputRef}
+									type="text"
+									value={searchTerm}
+								/>
+
+								<ClayInput.GroupInsetItem after tag="span">
+									{searchTerm ? (
+										<ClayButton
+											aria-label={Liferay.Language.get(
+												'clear'
+											)}
+											displayType="unstyled"
+											onClick={() => {
+												clearSearch();
+
+												searchInputRef.current?.focus();
+											}}
+											title={Liferay.Language.get(
+												'clear'
+											)}
+											type="button"
+										>
+											<ClayIcon symbol="times" />
+										</ClayButton>
+									) : (
+										<ClayIcon symbol="search" />
+									)}
+								</ClayInput.GroupInsetItem>
+							</ClayInput.GroupItem>
+						</ClayInput.Group>
+					</div>
+
+					{hasSearchResults ? (
+						<ClayDropDown.ItemList>
+							{filteredPickerItems.map(
+								(group: ISnapshots, index: number) => (
+									<ClayDropDown.Group
+										header={
+											group.headerVisible
+												? group.label
+												: undefined
+										}
+										key={index}
+									>
+										{group.items.map(
+											(snapshot: ISnapshot) => (
+												<ClayDropDown.Item
+													active={
+														snapshot.erc ===
+														activeSnapshot.erc
+													}
+													key={snapshot.erc}
+													onClick={() =>
+														onSnapshotChange({
+															defaultSnapshot,
+															snapshots,
+															value: snapshot.erc,
+														})
+													}
+													symbolRight={
+														snapshot.erc ===
+														activeSnapshot.erc
+															? 'check'
+															: undefined
+													}
+												>
+													{snapshot.label}
+												</ClayDropDown.Item>
+											)
+										)}
+									</ClayDropDown.Group>
+								)
 							)}
-						</ClayDropDown.Group>
+						</ClayDropDown.ItemList>
+					) : (
+						<ClayDropDown.Caption>
+							{Liferay.Language.get('no-results-found')}
+						</ClayDropDown.Caption>
 					)}
-				</Picker>
+				</ClayDropDown>
 			</ManagementToolbar.Item>
 
 			<ManagementToolbar.Item>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {render, screen, waitFor} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {openModal} from 'frontend-js-components-web';
 import fetch from 'jest-fetch-mock';
 import React from 'react';
@@ -51,6 +51,13 @@ const openActionsDropdown = async () => {
 		screen.getByRole('button', {name: 'show-view-actions'})
 	);
 };
+
+const openViewsDropdown = async () => {
+	await userEvent.click(screen.getByRole('button', {name: 'views'}));
+};
+
+const getViewLabels = () =>
+	screen.queryAllByRole('menuitem').map((item) => item.textContent);
 
 describe('SnapshotsControls action gating', () => {
 	describe('when the active snapshot is owned by the current user', () => {
@@ -265,5 +272,130 @@ describe('SnapshotsControls view name validation', () => {
 			).toBeInTheDocument();
 			expect(fetch).not.toHaveBeenCalled();
 		});
+	});
+});
+
+describe('SnapshotsControls views search', () => {
+	beforeEach(() => {
+		renderSnapshotsControls({
+			activeSnapshotERC: null,
+			activeView: null,
+			defaultSnapshot: {},
+			paginationDelta: null,
+			snapshotUpdated: false,
+			snapshots: [
+				{
+					headerVisible: false,
+					items: [
+						{erc: 'erc-1', id: 1, label: 'Active Orders'},
+						{erc: 'erc-2', id: 2, label: 'Archived Orders'},
+						{erc: 'erc-3', id: 3, label: 'Pending Invoices'},
+					],
+				},
+				{
+					headerVisible: true,
+					items: [{erc: 'erc-4', id: 4, label: 'Team Orders'}],
+					label: 'shared-with-me',
+				},
+			],
+			sorts: [],
+			visibleFieldNames: {},
+		});
+	});
+
+	const searchViews = async (query: string) =>
+		fireEvent.change(await screen.findByPlaceholderText('search'), {
+			target: {value: query},
+		});
+
+	it('shows a search input inside the views dropdown', async () => {
+		await openViewsDropdown();
+
+		expect(
+			await screen.findByPlaceholderText('search')
+		).toBeInTheDocument();
+	});
+
+	it('filters the views in real time as the user types', async () => {
+		await openViewsDropdown();
+
+		await searchViews('archived');
+
+		await waitFor(() =>
+			expect(getViewLabels()).toEqual(['Archived Orders'])
+		);
+	});
+
+	it('matches views case-insensitively', async () => {
+		await openViewsDropdown();
+
+		await searchViews('PENDING');
+
+		await waitFor(() =>
+			expect(getViewLabels()).toEqual(['Pending Invoices'])
+		);
+	});
+
+	it('filters across all sections, including shared views', async () => {
+		await openViewsDropdown();
+
+		await searchViews('orders');
+
+		await waitFor(() =>
+			expect(getViewLabels()).toEqual([
+				'Active Orders',
+				'Archived Orders',
+				'Team Orders',
+			])
+		);
+	});
+
+	it('communicates an empty state when no view matches', async () => {
+		await openViewsDropdown();
+
+		await searchViews('nonexistent');
+
+		await waitFor(() =>
+			expect(screen.queryAllByRole('menuitem')).toHaveLength(0)
+		);
+		expect(screen.getByText('no-results-found')).toBeInTheDocument();
+	});
+
+	it('shows a clear button only once a search term is typed', async () => {
+		await openViewsDropdown();
+
+		await screen.findByPlaceholderText('search');
+
+		expect(
+			screen.queryByRole('button', {name: 'clear'})
+		).not.toBeInTheDocument();
+
+		await searchViews('arch');
+
+		expect(
+			await screen.findByRole('button', {name: 'clear'})
+		).toBeInTheDocument();
+	});
+
+	it('restores the full list when the clear button is clicked', async () => {
+		await openViewsDropdown();
+
+		await searchViews('archived');
+
+		await waitFor(() =>
+			expect(getViewLabels()).toEqual(['Archived Orders'])
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'clear'}));
+
+		await waitFor(() =>
+			expect(getViewLabels()).toEqual([
+				'default-view',
+				'Active Orders',
+				'Archived Orders',
+				'Pending Invoices',
+				'Team Orders',
+			])
+		);
 	});
 });

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {openModal} from 'frontend-js-components-web';
 import fetch from 'jest-fetch-mock';
 import React from 'react';
@@ -397,5 +397,34 @@ describe('SnapshotsControls views search', () => {
 				'Team Orders',
 			])
 		);
+	});
+
+	it('does not re-filter when cleared before the debounce elapses', async () => {
+		await openViewsDropdown();
+
+		const searchInput = await screen.findByPlaceholderText('search');
+
+		jest.useFakeTimers();
+
+		try {
+			fireEvent.change(searchInput, {target: {value: 'archived'}});
+
+			fireEvent.click(screen.getByRole('button', {name: 'clear'}));
+
+			act(() => {
+				jest.advanceTimersByTime(1000);
+			});
+
+			expect(getViewLabels()).toEqual([
+				'default-view',
+				'Active Orders',
+				'Archived Orders',
+				'Pending Invoices',
+				'Team Orders',
+			]);
+		}
+		finally {
+			jest.useRealTimers();
+		}
 	});
 });

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/userViews.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/userViews.spec.ts
@@ -303,7 +303,9 @@ test(
 			).toHaveText(userView1Name);
 			await dataSetFragmentPage.userViewsSelectorButton.click();
 
-			await expect(userViewsDropdown.getByRole('option')).toHaveCount(2);
+			await expect(userViewsDropdown.getByRole('menuitem')).toHaveCount(
+				2
+			);
 
 			page.keyboard.press('Escape');
 		});
@@ -368,7 +370,7 @@ test(
 			await userViewsDropdown.waitFor();
 
 			await userViewsDropdown
-				.getByRole('option', {name: 'Default View'})
+				.getByRole('menuitem', {name: 'Default View'})
 				.click();
 
 			await expect(dataSetFragmentPage.table.headerCells).toHaveCount(6);
@@ -380,7 +382,7 @@ test(
 			await userViewsDropdown.waitFor();
 
 			await userViewsDropdown
-				.getByRole('option', {name: userView1Name})
+				.getByRole('menuitem', {name: userView1Name})
 				.click();
 
 			await dataSetFragmentPage.changeVisualizationMode('Cards');
@@ -416,7 +418,7 @@ test(
 			await dataSetFragmentPage.userViewsSelectorButton.click();
 
 			await userViewsDropdown
-				.getByRole('option', {name: 'Default View'})
+				.getByRole('menuitem', {name: 'Default View'})
 				.click();
 
 			await dataSetFragmentPage.table.container.waitFor({
@@ -430,7 +432,7 @@ test(
 			await dataSetFragmentPage.userViewsSelectorButton.click();
 
 			await userViewsDropdown
-				.getByRole('option', {name: userView1Name})
+				.getByRole('menuitem', {name: userView1Name})
 				.click();
 
 			await dataSetFragmentPage.cardsWrapper.waitFor({
@@ -514,8 +516,134 @@ test(
 			await userViewsDropdown.waitFor();
 
 			await expect(
-				userViewsDropdown.getByRole('option', {name: userView2Name})
+				userViewsDropdown.getByRole('menuitem', {name: userView2Name})
 			).not.toBeVisible();
+		});
+	}
+);
+
+test(
+	'Can search the User Views dropdown to filter the list',
+	{tag: '@LPD-75911'},
+	async ({dataSetFragmentPage, dataSetManagerApiHelpers, layout, page}) => {
+		await test.step('Enable User Views (snapshots)', async () => {
+			await dataSetManagerApiHelpers.updateDataSet({
+				erc: dataSetERC,
+				snapshotsEnabled: true,
+			});
+		});
+
+		await test.step('Configure Data Set fragment on the page', async () => {
+			await dataSetFragmentPage.configureDataSetFragment({
+				dataSetLabel,
+				layout,
+			});
+		});
+
+		await test.step('Seed several user views via the API', async () => {
+			for (const snapshotName of [
+				'Active Orders',
+				'Archived Orders',
+				'Pending Invoices',
+			]) {
+				await dataSetManagerApiHelpers.createDataSetSnapshot({
+					dataSetERC,
+					snapshotName,
+				});
+			}
+		});
+
+		await test.step('Reload so the seeded views are listed', async () => {
+			await dataSetFragmentPage.goToPage({layout});
+
+			await page
+				.locator('.data-set-content-wrapper')
+				.waitFor({state: 'visible'});
+		});
+
+		await dataSetFragmentPage.userViewsSelectorButton.click();
+
+		const userViewsDropdownId =
+			await dataSetFragmentPage.userViewsSelectorButton.getAttribute(
+				'aria-controls'
+			);
+		const userViewsDropdown = page.locator(`#${userViewsDropdownId}`);
+
+		await userViewsDropdown.waitFor();
+
+		const searchInput = userViewsDropdown.getByPlaceholder('Search');
+
+		// "Default View" plus the three seeded views
+
+		const allViewsCount = 4;
+
+		await test.step('The full list and the search input are shown initially', async () => {
+			await expect(searchInput).toBeVisible();
+			await expect(userViewsDropdown.getByRole('menuitem')).toHaveCount(
+				allViewsCount
+			);
+		});
+
+		await test.step('Typing filters the list in real time', async () => {
+			await searchInput.fill('orders');
+
+			await expect(userViewsDropdown.getByRole('menuitem')).toHaveCount(
+				2
+			);
+			await expect(
+				userViewsDropdown.getByRole('menuitem', {name: 'Active Orders'})
+			).toBeVisible();
+			await expect(
+				userViewsDropdown.getByRole('menuitem', {
+					name: 'Archived Orders',
+				})
+			).toBeVisible();
+		});
+
+		await test.step('The search is case-insensitive', async () => {
+			await searchInput.fill('INVOICES');
+
+			await expect(userViewsDropdown.getByRole('menuitem')).toHaveCount(
+				1
+			);
+			await expect(
+				userViewsDropdown.getByRole('menuitem', {
+					name: 'Pending Invoices',
+				})
+			).toBeVisible();
+		});
+
+		await test.step('The Default View is filtered along with the rest', async () => {
+			await searchInput.fill('default');
+
+			await expect(userViewsDropdown.getByRole('menuitem')).toHaveCount(
+				1
+			);
+			await expect(
+				userViewsDropdown.getByRole('menuitem', {name: 'Default View'})
+			).toBeVisible();
+		});
+
+		await test.step('An empty state is shown when nothing matches', async () => {
+			await searchInput.fill('nonexistent view name');
+
+			await expect(userViewsDropdown.getByRole('menuitem')).toHaveCount(
+				0
+			);
+			await expect(
+				userViewsDropdown.getByText('No Results Found')
+			).toBeVisible();
+		});
+
+		await test.step('Clearing the search restores the full list', async () => {
+			await userViewsDropdown
+				.getByRole('button', {name: 'Clear'})
+				.click();
+
+			await expect(searchInput).toHaveValue('');
+			await expect(userViewsDropdown.getByRole('menuitem')).toHaveCount(
+				allViewsCount
+			);
 		});
 	}
 );
@@ -578,7 +706,7 @@ test(
 
 			await page
 				.locator(`#${userViewsDropdownId}`)
-				.getByRole('option', {name: snapshotName})
+				.getByRole('menuitem', {name: snapshotName})
 				.click();
 		});
 
@@ -804,14 +932,16 @@ test(
 			).toBeVisible();
 
 			await expect(
-				userViewsDropdown.getByRole('option', {
+				userViewsDropdown.getByRole('menuitem', {
 					name: sharedSnapshotName,
 				})
 			).toBeVisible();
 		});
 
 		await test.step('Selecting the shared view makes it the active view', async () => {
-			await page.getByRole('option', {name: sharedSnapshotName}).click();
+			await page
+				.getByRole('menuitem', {name: sharedSnapshotName})
+				.click();
 
 			await expect(
 				dataSetFragmentPage.userViewsSelectorButton

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/userViews.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/userViews.spec.ts
@@ -84,7 +84,7 @@ test(
 			await fdsSamplePage.userViewsSelectorButton.click();
 
 			expect(
-				await fdsSamplePage.dropdownMenu.getByRole('option').count()
+				await fdsSamplePage.dropdownMenu.getByRole('menuitem').count()
 			).toBeGreaterThanOrEqual(3);
 		});
 
@@ -112,7 +112,7 @@ test(
 			await fdsSamplePage.userViewsSelectorButton.click();
 
 			await fdsSamplePage.dropdownMenu
-				.getByRole('option', {name: 'Default View'})
+				.getByRole('menuitem', {name: 'Default View'})
 				.click();
 
 			await expect(fdsSamplePage.table.headerCells).toHaveCount(11);
@@ -124,7 +124,7 @@ test(
 			await fdsSamplePage.dropdownMenu.waitFor();
 
 			await fdsSamplePage.dropdownMenu
-				.getByRole('option', {name: userView2Name})
+				.getByRole('menuitem', {name: userView2Name})
 				.click();
 
 			await fdsSamplePage.userViewsActionsButton.click();
@@ -173,7 +173,7 @@ test(
 			await fdsSamplePage.userViewsSelectorButton.click();
 
 			await fdsSamplePage.dropdownMenu
-				.getByRole('option', {name: userView2Name})
+				.getByRole('menuitem', {name: userView2Name})
 				.click();
 
 			await fdsSamplePage.userViewsActionsButton.click();
@@ -205,7 +205,7 @@ test(
 			await fdsSamplePage.userViewsSelectorButton.click();
 
 			await fdsSamplePage.dropdownMenu
-				.getByRole('option', {name: userView1Name})
+				.getByRole('menuitem', {name: userView1Name})
 				.click();
 
 			await fdsSamplePage.userViewsActionsButton.click();
@@ -227,13 +227,13 @@ test(
 			await fdsSamplePage.userViewsSelectorButton.click();
 
 			await expect(
-				fdsSamplePage.dropdownMenu.getByRole('option', {
+				fdsSamplePage.dropdownMenu.getByRole('menuitem', {
 					name: userView1Name,
 				})
 			).not.toBeVisible();
 
 			await fdsSamplePage.dropdownMenu
-				.getByRole('option', {name: newUserViewName})
+				.getByRole('menuitem', {name: newUserViewName})
 				.click();
 
 			await fdsSamplePage.userViewsActionsButton.click();
@@ -251,7 +251,7 @@ test(
 			await fdsSamplePage.userViewsSelectorButton.click();
 
 			await expect(
-				fdsSamplePage.dropdownMenu.getByRole('option', {
+				fdsSamplePage.dropdownMenu.getByRole('menuitem', {
 					name: newUserViewName,
 				})
 			).not.toBeVisible();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75911

## What Is Being Fixed

The User Views dropdown in Frontend Data Sets listed every saved view with no way to filter, so finding a specific view became hard as the number of saved views grew.

## How It Is Being Fixed

The views dropdown is migrated from Picker to ClayDropDown so it can host a search input alongside the list. The input filters the views in real time, case-insensitively, across all sections (default view, own views, shared views), shows an empty state when nothing matches, and offers a clear (×) button that restores the full list. The existing User Views Playwright specs are updated for the resulting markup change (view items moved from role "option" to role "menuitem"), and a dedicated Playwright test covers the new search behavior end to end.

## PR Check

**pr-check: PASS** — tested on `021959238a1e2b2c2563843af091444267db61ba`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "021959238a1e2b2c2563843af091444267db61ba"} -->
