### PR TITLE
LPD-97021 Avoid invalid aria-selected on user views dropdown items

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -616,30 +616,39 @@ const SnapshotsControls = () => {
 									}
 									key={group.label || 'default'}
 								>
-									{group.items.map((snapshot: ISnapshot) => (
-										<ClayDropDown.Item
-											active={
-												snapshot.erc ===
-												activeSnapshot.erc
-											}
-											key={snapshot.erc}
-											onClick={() =>
-												onSnapshotChange({
-													defaultSnapshot,
-													snapshots,
-													value: snapshot.erc,
-												})
-											}
-											symbolRight={
-												snapshot.erc ===
-												activeSnapshot.erc
-													? 'check'
-													: undefined
-											}
-										>
-											{snapshot.label}
-										</ClayDropDown.Item>
-									))}
+									{group.items.map((snapshot: ISnapshot) => {
+										const isActiveSnapshot =
+											snapshot.erc === activeSnapshot.erc;
+
+										return (
+											<ClayDropDown.Item
+												aria-current={
+													isActiveSnapshot ||
+													undefined
+												}
+												className={
+													isActiveSnapshot
+														? 'active'
+														: undefined
+												}
+												key={snapshot.erc}
+												onClick={() =>
+													onSnapshotChange({
+														defaultSnapshot,
+														snapshots,
+														value: snapshot.erc,
+													})
+												}
+												symbolRight={
+													isActiveSnapshot
+														? 'check'
+														: undefined
+												}
+											>
+												{snapshot.label}
+											</ClayDropDown.Item>
+										);
+									})}
 								</ClayDropDown.Group>
 							))}
 						</ClayDropDown.ItemList>

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts
@@ -9,6 +9,7 @@ import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../../fixtures/loginTest';
 import {checkAccessibility} from '../../../../../utils/checkAccessibility';
+import getRandomString from '../../../../../utils/getRandomString';
 import {EFDSVisualizationMode, waitForFDS} from '../../../../../utils/waitFor';
 import {fdsSamplePageTest} from '../../fixtures/fdsSamplePageTest';
 
@@ -283,6 +284,8 @@ test('Advanced FDS is accessible across user views', async ({
 	fdsSamplePage,
 	page,
 }) => {
+	const userViewName = getRandomString();
+
 	await test.step('Open user views menu', async () => {
 		await fdsSamplePage.userViewsSelectorButton.click();
 
@@ -324,7 +327,7 @@ test('Advanced FDS is accessible across user views', async ({
 
 		await fdsSamplePage.userViewsSaveModal
 			.getByLabel('NameRequired')
-			.fill('Accessibility View');
+			.fill(userViewName);
 
 		await fdsSamplePage.userViewsSaveModal
 			.getByRole('button', {name: 'Save'})
@@ -361,6 +364,24 @@ test('Advanced FDS is accessible across user views', async ({
 		});
 
 		await page.keyboard.press('Escape');
+	});
+
+	// Delete the saved view so it does not linger for the next run. User
+	// views are persisted per user and are not removed with the isolated
+	// site.
+
+	await test.step('Delete the saved view', async () => {
+		await fdsSamplePage.userViewsActionsButton.click();
+
+		await fdsSamplePage.dropdownMenu
+			.getByRole('menuitem', {name: 'Delete View'})
+			.click();
+
+		await fdsSamplePage.userViewsDeleteAlert
+			.getByRole('button', {name: 'Delete'})
+			.click();
+
+		await fdsSamplePage.userViewsDeleteAlert.waitFor({state: 'hidden'});
 	});
 });
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97021

## What Is Being Fixed

The Frontend Data Set user views selector was moved from a Picker to a ClayDropDown to add search support. ClayDropDown renders each item's active state as `aria-selected` on a `role="menuitem"` element, which is not a supported ARIA attribute for that role, so axe flagged the dropdown as inaccessible whenever it was opened — even with only the default view present.

The user views accessibility test also failed for a second, unrelated reason: it saved a view under a hardcoded name and never deleted it, and because user views are persisted per user (not wiped by the isolated site fixture), every run after the first hit the "a view with this name already exists" validation and timed out.

## How It Is Being Fixed

The active view is now conveyed with `aria-current` — valid on any role — instead of `aria-selected`, while the visual highlight is preserved through the `active` class and the existing check icon. The accessibility test now generates a unique view name and deletes the view it creates at the end of the run, matching the conventions already used by the functional user views test.

## Why Are There No Tests?

The accessibility fix is guarded by the existing `accessibility.spec.ts` user views test, which asserts there are no axe violations when the dropdown is open; that test previously flagged the `aria-selected` regression and now passes. The component is additionally covered by the existing `SnapshotsControls` Jest suite. No new test is added because the repaired accessibility test already exercises the fix.

## PR Check

**pr-check: PASS** — tested on `697e1fa87d5b20601bdee471db3635a6dff91064`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "697e1fa87d5b20601bdee471db3635a6dff91064"} -->
