### PR TITLE
LPD-97059 Fix system data sets test broken by ClayDropDown migration

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/systemDataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/systemDataSets.spec.ts
@@ -721,7 +721,7 @@ test(
 
 			await userViewsDropdown.waitFor();
 
-			const userViewMenuItem = userViewsDropdown.getByRole('option', {
+			const userViewMenuItem = userViewsDropdown.getByRole('menuitem', {
 				name: userView1Name,
 			});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97059

## What Is Being Fixed

The Playwright test "Deleting a System Data Set does not remove custom views" in systemDataSets.spec.ts started failing. It timed out waiting for the user view to appear in the Views dropdown, matched by `getByRole('option', ...)`.

## How It Is Being Fixed

The failure was introduced by LPD-75911, which added search to the user view dropdown by migrating the Views selector in SnapshotsControls from Clay's Picker to ClayDropDown. Picker renders its entries with `role="option"`, while ClayDropDown renders them with `role="menuitem"`, so the existing locator no longer matched. The fix updates the locator to query `getByRole('menuitem', ...)`, matching the new ClayDropDown semantics — consistent with the sibling actions dropdown in the same test, which already uses `menuitem`.

## Why Are There No Tests?

This change is itself a fix to an existing Playwright test. It restores the test's coverage of the delete-system-data-set flow after an unrelated UI migration broke its locator; no new test is warranted.

## PR Check

**pr-check: PASS** — tested on `0b33e98329078f653d4247dd44c37225583f9cc0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "0b33e98329078f653d4247dd44c37225583f9cc0"} -->
