### PR TITLE
LPD-96049 Update TranslationAdminSelector snapshot for Clay tabindex

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/__snapshots__/TranslationAdminSelector.js.snap
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/__snapshots__/TranslationAdminSelector.js.snap
@@ -415,6 +415,7 @@ exports[`TranslationAdminSelector renders an open dropdown with the list of acti
   id="clay-dropdown-menu-1"
   role="presentation"
   style="left: -999px; top: -995px;"
+  tabindex="0"
 >
   <ul
     class="list-unstyled"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96049

## What Is Being Fixed

The `TranslationAdminSelector` Jest test "renders an open dropdown with the list of active languages and manage translation option" was failing in `:apps:frontend-js:frontend-js-components-web:packageRunTest`. The stored snapshot no longer matched the rendered output.

## How It Is Being Fixed

A newer `@clayui/drop-down` version renders the admin-mode dropdown menu container with a `tabindex="0"` attribute (a focus-management/accessibility change). The committed snapshot predated this, so the rendered `.dropdown-menu` element diverged from the stored one by that single attribute. Regenerating the snapshot realigns it with the current Clay output. No component source changed; this is the same class of maintenance update as the earlier "Clay dropdown type=button" snapshot refresh.

## Why Are There No Tests?

This change only regenerates an existing Jest snapshot to match an upstream Clay dependency update. There is no production code change to cover, and the affected test itself is what the snapshot update fixes.

## PR Check

**pr-check: PASS** — tested on `0a3f2a38d921a035c035849f07fa370955dbae1f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "0a3f2a38d921a035c035849f07fa370955dbae1f"} -->
