### PR TITLE
LPD-97415 Exclude disabled cards from the clay accessibility axe scan

### DIFF
--- a/modules/test/playwright/tests/frontend-taglib-clay/main/accessibility.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/main/accessibility.spec.ts
@@ -34,7 +34,10 @@ test('When accessing all clay sample portlet tabs, then verifies that the compon
 				selectors: [
 					'.portlet-body > .lfr-tooltip-scope > .tab-content > .tab-pane.active',
 				],
-				selectorsToExclude: ['span[role="gridcell"].label-item-expand'],
+				selectorsToExclude: [
+					'span[role="gridcell"].label-item-expand',
+					'.card.disabled',
+				],
 			});
 		});
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97415

## What Is Being Fixed

The Playwright test `accessibility.spec.ts` in `frontend-taglib-clay` started
failing with WCAG color-contrast violations flagged on the disabled sample
cards (14 nodes). The card revamp in LPD-88758 gave disabled cards an
`opacity` of 0.4 in the atlas theme, which composites their already-muted text
over the white page background. axe reads the resulting effective foreground
as low-contrast and reports it as a serious violation.

## How It Is Being Fixed

The dimming is intentional and consistent with every other disabled Clay
component (buttons, forms, dropdowns, navigation bars all use
`$component-disabled-opacity`), and it is WCAG-compliant: SC 1.4.3 exempts
inactive user interface components from the contrast minimum. Rather than
change the styling, the test now excludes `.card.disabled` from the axe scan,
following the existing `selectorsToExclude` pattern. Every disabled Clay card
carries both the `card` and `disabled` classes, so the single selector covers
all card types and their low-contrast descendants.

## Why Are There No Tests?

This change only modifies an existing Playwright test; there is no product code
change to cover. The updated spec was run locally and passes.

## PR Check

**pr-check: PASS** — tested on `01f69a50219e616286ccbe59c35c1fa64d8cc5d9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "01f69a50219e616286ccbe59c35c1fa64d8cc5d9"} -->
