### PR TITLE
LPD-97422 Fix button order in toolbar

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react.spec.ts
@@ -38,8 +38,8 @@ test(
 				'Bookmark',
 				'Image',
 				'Video',
-				'Timestamp',
 				'Styles',
+				'Timestamp',
 			];
 
 			const availableButtons =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97422

## What Is Being Fixed

The Playwright test `react.spec.ts > Editor configuration is applied` began failing because the expected CKEditor 5 toolbar button order no longer matched what the toolbar renders. The test asserted `Timestamp` before `Styles`, but the toolbar renders `Styles` before `Timestamp`, so the exact-order `toEqual` comparison failed.

## How It Is Being Fixed

Reorder the `expectedButtons` array so `Styles` precedes `Timestamp`, matching the order the toolbar actually renders. There is no product code change — only the test expectation is corrected.

## Why Are There No Tests?

The change is itself a correction to an existing Playwright test; there is no product code change to cover.

## PR Check

**pr-check: PASS** — tested on `f8b1757718cf5665fd29fc2da3604a8d0209fd46`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "f8b1757718cf5665fd29fc2da3604a8d0209fd46"} -->
