### PR TITLE
LPD-97579 Provision the Data Set snapshot definition only when absent

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
@@ -63,13 +63,20 @@ public class DataSetSnapshotSharingEntryInterpreterTest {
 
 	@Before
 	public void setUp() throws Exception {
-		FrontendDataSetTestUtil.initialize(
-			DataSetSnapshotSharingEntryInterpreterTest.class);
-
 		_objectDefinition =
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
 					"L_DATA_SET_SNAPSHOT", TestPropsValues.getCompanyId());
+
+		if (_objectDefinition == null) {
+			FrontendDataSetTestUtil.initialize(
+				DataSetSnapshotSharingEntryInterpreterTest.class);
+
+			_objectDefinition =
+				_objectDefinitionLocalService.
+					fetchObjectDefinitionByExternalReferenceCode(
+						"L_DATA_SET_SNAPSHOT", TestPropsValues.getCompanyId());
+		}
 
 		Assert.assertNotNull(_objectDefinition);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97579

## What Is Being Fixed

DataSetSnapshotSharingEntryInterpreterTest fails in setUp on a seeded (multi-company) database with a ResourceActionsException: the ObjectDefinitionsPortlet_T9Q0 portlet is assigned two root model resources (LPS-135983). The setUp unconditionally called FrontendDataSetTestUtil.initialize, which re-runs the multiCompany batch import of the Data Set object definitions. When those definitions are already seeded by the LPS-164563 feature-flag-gated import, the redundant re-import re-deploys L_DATA_SET for a second company, and the two companies' definitions collide on the shared, company-independent portlet name during permission population. This reintroduced the failure that LPD-96282 had removed, because LPD-96577 re-added the initialize call to fix a clean-database case where the definition was not provisioned.

## How It Is Being Fixed

setUp now fetches the L_DATA_SET_SNAPSHOT object definition first and only calls FrontendDataSetTestUtil.initialize when it is absent, then re-fetches. On a seeded database the definition already exists, so the redundant import is skipped and the root model resource conflict no longer occurs; on a clean database the definition is provisioned as before. This reconciles the two prior fixes (LPD-96282 and LPD-96577) so the test passes regardless of database state.

## Why Are There No Tests?

This change modifies the setUp of an existing integration test; the test it repairs is the coverage.

## PR Check

**pr-check: PASS** — tested on `5a77b53ac6afe7590b3be30fe6f6a1c11998da45`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5a77b53ac6afe7590b3be30fe6f6a1c11998da45"} -->
