### PR TITLE
LPD-97708 Wait for keyboard movement to start before committing it

### DIFF
--- a/modules/test/playwright/tests/client-extension-web/main/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/editorConfigContributor.spec.ts
@@ -185,6 +185,14 @@ test('Check client extension does not apply to new instances @LPD-63018', async 
 
 		await virtualInstancePage.keyboard.press('Enter');
 
+		// Wait for the keyboard movement to start before committing it
+
+		await expect(
+			virtualInstancePage.locator(
+				'.page-editor__keyboard-movement-preview__content'
+			)
+		).toBeVisible();
+
 		await virtualInstancePage.keyboard.press('Enter');
 
 		await virtualInstancePage


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97708

## What Is Being Fixed

The Playwright test "Check client extension does not apply to new instances @LPD-63018" (`editorConfigContributor.spec.ts`) times out intermittently. It adds the "CKEditor 4 Sample" widget through the page editor's keyboard-placement flow, pressing Enter to pick the widget up and Enter again to drop it. The two presses fired back to back, so the committing Enter raced the asynchronous setup of the KeyboardMovementManager and was dropped. The widget stayed picked up, its header never rendered, and the test hung until the timeout.

## How It Is Being Fixed

After the Enter that starts the keyboard movement, the test now waits for the movement preview (`.page-editor__keyboard-movement-preview__content`) to be visible before pressing Enter to commit, mirroring the pattern already used in `sidebar.spec.ts`. The widget is reliably dropped, its header renders, and the test proceeds.

## Why Are There No Tests?

This change only adds synchronization to an existing Playwright test; it touches no product code, so there is nothing new to cover.

## PR Check

**pr-check: PASS** — tested on `ad74cfd8465ea2a63137beb45a0279771f8b58aa`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "ad74cfd8465ea2a63137beb45a0279771f8b58aa"} -->
