### PR TITLE
LPD-92439 Fix the language client extension deployment test

### DIFF
--- a/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
+++ b/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
@@ -81,6 +81,15 @@ export class LanguageOverridePage {
 		}
 	}
 
+	async assertLanguageKeyHasNoOverrideForLocale(
+		key: string,
+		languageId: string
+	) {
+		await expect(
+			this.page.getByRole('link', {name: key})
+		).not.toContainText(languageId.replace('-', '_'));
+	}
+
 	async assertLanguageKeyNotInListView(key: string) {
 		await expect(this.page.getByRole('link', {name: key})).toBeHidden();
 	}

--- a/modules/test/playwright/tests/client-extension-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/client-extension-web/main/env/portal-ext.properties
@@ -1,4 +1,29 @@
 terms.of.use.required=false
+
+locales.enabled=\
+    ar_SA,\
+    ca_ES,\
+    zh_CN,\
+    nl_NL,\
+    nl_BE,\
+    en_US,\
+    fi_FI,\
+    fr_FR,\
+    fr_BE,\
+    fr_CH,\
+    de_DE,\
+    de_AT,\
+    de_CH,\
+    hu_HU,\
+    ja_JP,\
+    pt_BR,\
+    pt_PT,\
+    es_ES,\
+    es_AR,\
+    es_CO,\
+    es_MX,\
+    sv_SE
+
 passwords.default.policy.change.required=false
 setup.wizard.enabled=false
 feature.flag.LPD-34594=true

--- a/modules/test/playwright/tests/client-extension-web/main/language.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/language.spec.ts
@@ -48,6 +48,10 @@ testSample.describe('Samples', () => {
 				value: '¿Le gusta comer pizza con anchoas?',
 			},
 			{
+				languageId: 'es-ES',
+				value: '¿Le gusta comer pizza con anchoas?',
+			},
+			{
 				languageId: 'es-MX',
 				value: '¿Le gusta comer pizza con anchoas?',
 			},
@@ -127,10 +131,19 @@ testSample.describe('Samples', () => {
 			);
 
 			await testSample.step(
-				'Check that a translation with (Automatic Copy) was not imported',
+				'Check that a translation for a disabled locale was not imported',
 				async () => {
-					await languageOverridePage.assertLanguageKeyTranslationIsEmpty(
-						'es-ES'
+					await languageOverridePage.goto();
+
+					await languageOverridePage.changeFilter('Any Language');
+
+					await languageOverridePage.searchLanguageKey(
+						EXPECTED_LANGUAGE_KEY.key
+					);
+
+					await languageOverridePage.assertLanguageKeyHasNoOverrideForLocale(
+						EXPECTED_LANGUAGE_KEY.key,
+						'th-TH'
 					);
 				}
 			);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92439

## What Is Being Fixed

The Playwright test "Assert that the language client extension is deployed" was failing, and failing differently across environments. Its assertions depended on the instance's enabled-locale configuration, which the project never pinned, so the imported override set and the editor's rendered inputs varied. Its second step also relied on an "(Automatic Copy)" es_ES translation that LPS-77699 replaced with a real translation, so that check no longer held.

## How It Is Being Fixed

Pin the enabled locales in the project environment so the language client extension imports a deterministic override set. The locales are ordered so each language's default-country locale (de_DE, fr_FR, nl_NL, es_ES) precedes its variants, which makes the bare Language_<language>.properties files resolve to it; routing Language_es.properties to es_ES in particular keeps the distinct es_AR/es_CO/es_MX translations from colliding on a shared override. The expected translation list is updated to include es_ES accordingly. The second step no longer relies on the removed "(Automatic Copy)" marker; it now asserts that a translation for a disabled locale (th-TH) is not imported, a stable property of the import rules, backed by a new assertLanguageKeyHasNoOverrideForLocale helper on the page object.

## Why Are There No Tests?

This change only repairs an existing Playwright test and its environment configuration; there is no product code change to cover with additional tests.

## PR Check

**pr-check: PASS** — tested on `ee2f52eea1d6676cb75e7baa618988e04587dd9b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "ee2f52eea1d6676cb75e7baa618988e04587dd9b"} -->
