### PR TITLE
LPD-95091 Enable the Find and Replace plugin in CKEditor 5

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
@@ -13,6 +13,7 @@ import {
 import {BlockQuote} from '@ckeditor/ckeditor5-block-quote/dist/index.js';
 import {EditorConfig} from '@ckeditor/ckeditor5-core/dist/index.js';
 import {Essentials} from '@ckeditor/ckeditor5-essentials/dist/index.js';
+import {FindAndReplace} from '@ckeditor/ckeditor5-find-and-replace/dist/index.js';
 import {Font} from '@ckeditor/ckeditor5-font/dist/index.js';
 import {Heading} from '@ckeditor/ckeditor5-heading/dist/index.js';
 import {HorizontalLine} from '@ckeditor/ckeditor5-horizontal-line/dist/index.js';
@@ -131,6 +132,7 @@ const getDefaultEditorConfig = ({
 		...basicPlugins,
 		Alignment,
 		BlockQuote,
+		FindAndReplace,
 		Font,
 		Heading,
 		HeadlessItemSelector,
@@ -170,6 +172,7 @@ const getDefaultEditorConfig = ({
 		'|',
 		'undo',
 		'redo',
+		'findAndReplace',
 		'|',
 		'style',
 		'|',

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
@@ -42,6 +42,7 @@ test(
 				'Accessibility help',
 				'Undo',
 				'Redo',
+				'Find and replace',
 				'Styles',
 				'Normal',
 				'Bold',

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
@@ -399,3 +399,16 @@ test(
 		});
 	}
 );
+
+test(
+	'Find and Replace button is shown in the toolbar',
+	{tag: '@LPD-95091'},
+	async ({classicPage}) => {
+		await expect(
+			classicPage.toolbar.container.getByRole('button', {
+				exact: true,
+				name: 'Find and replace',
+			})
+		).toBeVisible();
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95091

## What Is Being Fixed

The advanced Classic toolbar in CKEditor 5 has no way to find and replace text, forcing users to scroll through long content and manually locate each occurrence to make bulk edits.

## How It Is Being Fixed

Registers the community `FindAndReplace` plugin — already part of the base `ckeditor5` package, with no license restriction — into the advanced preset's plugin list and toolbar, right after Undo/Redo. The existing Playwright test asserting the full toolbar control list is updated to include the new button, and a new test asserts the button is visible.

## PR Check

**pr-check: PASS** — tested on `ce34abb5086093050a0185110d58fd12722c79a7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "ce34abb5086093050a0185110d58fd12722c79a7"} -->
