### PR TITLE
LPD-97562 Apply element variations on every SPA navigation

### DIFF
--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/FrontendJSAudiencesWebServlet.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/FrontendJSAudiencesWebServlet.java
@@ -61,20 +61,10 @@ public class FrontendJSAudiencesWebServlet extends HttpServlet {
 		String hash = null;
 
 		if ((parts.length == 2) && parts[1].startsWith("bootstrap.")) {
-			Long plid = _getPlid(httpServletRequest.getParameter("plid"));
-
-			if (plid == null) {
-				httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
-
-				return;
-			}
-
 			content = BootstrapJavaScriptUtil.getContent(
 				httpServletRequest.getParameter("audiencesDefinitionHash"),
-				httpServletRequest.getParameter("elementVariationsHash"),
 				Boolean.parseBoolean(
-					httpServletRequest.getParameter("enableLog")),
-				plid);
+					httpServletRequest.getParameter("enableLog")));
 			contentType = ContentTypes.APPLICATION_JAVASCRIPT;
 			hash = BootstrapJavaScriptUtil.getHash();
 		}

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/taglib/FrontendJSAudiencesWebTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/taglib/FrontendJSAudiencesWebTopHeadDynamicInclude.java
@@ -11,6 +11,7 @@ import com.liferay.frontend.js.audiences.ElementVariations;
 import com.liferay.frontend.js.audiences.ElementVariationsProvider;
 import com.liferay.frontend.js.audiences.web.internal.configuration.FrontendJSAudiencesConfiguration;
 import com.liferay.frontend.js.audiences.web.internal.util.BootstrapJavaScriptUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -69,6 +70,19 @@ public class FrontendJSAudiencesWebTopHeadDynamicInclude
 			return;
 		}
 
+		FrontendJSAudiencesConfiguration frontendJSAudiencesConfiguration;
+
+		try {
+			frontendJSAudiencesConfiguration =
+				_configurationProvider.getCompanyConfiguration(
+					FrontendJSAudiencesConfiguration.class, companyId);
+		}
+		catch (ConfigurationException configurationException) {
+			throw new IOException(configurationException);
+		}
+
+		PrintWriter printWriter = httpServletResponse.getWriter();
+
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
@@ -77,11 +91,13 @@ public class FrontendJSAudiencesWebTopHeadDynamicInclude
 			_elementVariationsProvider.getElementVariations(
 				themeDisplay.getPlid());
 
-		if (elementVariations == null) {
-			return;
+		if (elementVariations != null) {
+			printWriter.print("<meta content=\"");
+			printWriter.print(themeDisplay.getPlid());
+			printWriter.print(StringPool.COLON);
+			printWriter.print(elementVariations.getHash());
+			printWriter.print("\" name=\"audiences-variations\">");
 		}
-
-		PrintWriter printWriter = httpServletResponse.getWriter();
 
 		printWriter.print(
 			"<script data-senna-track=\"permanent\" id=\"audiencesBootstrap\"");
@@ -103,25 +119,8 @@ public class FrontendJSAudiencesWebTopHeadDynamicInclude
 		printWriter.print(BootstrapJavaScriptUtil.getHash());
 		printWriter.print(").js?audiencesDefinitionHash=");
 		printWriter.print(audiencesDefinition.getHash());
-		printWriter.print("&elementVariationsHash=");
-		printWriter.print(elementVariations.getHash());
 		printWriter.print("&enableLog=");
-
-		FrontendJSAudiencesConfiguration frontendJSAudiencesConfiguration;
-
-		try {
-			frontendJSAudiencesConfiguration =
-				_configurationProvider.getCompanyConfiguration(
-					FrontendJSAudiencesConfiguration.class, companyId);
-		}
-		catch (ConfigurationException configurationException) {
-			throw new IOException(configurationException);
-		}
-
 		printWriter.print(frontendJSAudiencesConfiguration.enableLog());
-
-		printWriter.print("&plid=");
-		printWriter.print(themeDisplay.getPlid());
 		printWriter.print("\" type=\"module\"></script>");
 	}
 

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/taglib/FrontendJSAudiencesWebTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/taglib/FrontendJSAudiencesWebTopHeadDynamicInclude.java
@@ -83,7 +83,8 @@ public class FrontendJSAudiencesWebTopHeadDynamicInclude
 
 		PrintWriter printWriter = httpServletResponse.getWriter();
 
-		printWriter.print("<script data-senna-track=\"temporary\"");
+		printWriter.print(
+			"<script data-senna-track=\"permanent\" id=\"audiencesBootstrap\"");
 		printWriter.print(
 			ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
 				httpServletRequest));

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/util/BootstrapJavaScriptUtil.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/util/BootstrapJavaScriptUtil.java
@@ -20,18 +20,13 @@ import java.io.InputStream;
 public class BootstrapJavaScriptUtil {
 
 	public static String getContent(
-		String audiencesDefinitionHash, String elementVariationsHash,
-		boolean enableLog, long plid) {
+		String audiencesDefinitionHash, boolean enableLog) {
 
 		return StringUtil.replace(
 			_TPL_BOOTSTRAP_JS,
-			new String[] {
-				"[$AUDIENCES_DEFINITION_HASH$]", "[$ELEMENT_VARIATIONS_HASH$]",
-				"[$ENABLE_LOG$]", "[$PLID$]"
-			},
+			new String[] {"[$AUDIENCES_DEFINITION_HASH$]", "[$ENABLE_LOG$]"},
 			new Object[] {
-				HtmlUtil.escapeJS(audiencesDefinitionHash),
-				HtmlUtil.escapeJS(elementVariationsHash), enableLog, plid
+				HtmlUtil.escapeJS(audiencesDefinitionHash), enableLog
 			});
 	}
 

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/implementation.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/implementation.ts
@@ -117,10 +117,6 @@ export async function runHandlers(): Promise<void> {
 			}
 		}
 	}
-
-	for (const key of Object.keys(handlers)) {
-		delete handlers[key];
-	}
 }
 
 export function setLogEnabled(enabled: boolean) {

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/implementation.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/implementation.ts
@@ -19,6 +19,12 @@ export function clear(): void {
 	store.clear();
 }
 
+export function clearHandlers(): void {
+	for (const audienceId of Object.keys(handlers)) {
+		delete handlers[audienceId];
+	}
+}
+
 export function get(): Set<AudienceId> {
 	return store.getAudienceIds();
 }

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/index.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/index.ts
@@ -5,6 +5,7 @@
 
 import {
 	clear,
+	clearHandlers,
 	get,
 	on,
 	runDetection,
@@ -81,6 +82,7 @@ export interface Handler {
 
 export interface AudiencesAPI {
 	clear(): void;
+	clearHandlers(): void;
 	get(): Set<AudienceId>;
 	on(audienceId: AudienceId, handler: Handler): void;
 	runDetection(audiencesDefinitionURL: string): Promise<void>;
@@ -90,6 +92,7 @@ export interface AudiencesAPI {
 
 export const audiences: AudiencesAPI = {
 	clear,
+	clearHandlers,
 	get,
 	on,
 	runDetection,

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/com/liferay/frontend/js/audiences/web/internal/util/dependencies/bootstrap.js.tpl
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/com/liferay/frontend/js/audiences/web/internal/util/dependencies/bootstrap.js.tpl
@@ -4,27 +4,36 @@ const {audiences} = await import(`${BASE_URL}o/frontend-js-audiences-web/__lifer
 
 audiences.setLogEnabled([$ENABLE_LOG$]);
 
-// Register the element variation handlers once. ES modules are evaluated at
-// most once per document, so neither this bootstrap module nor the variations
-// module below re-runs on SPA navigations. The handlers are therefore
-// registered a single time and kept registered, while detection and handler
-// execution are re-run on every navigation through the listener below.
-
-await import(`${BASE_URL}o/audiences/[$PLID$]/variations.([$ELEMENT_VARIATIONS_HASH$]).js`);
+const DEFINITION_URL = `${BASE_URL}o/audiences/definition.([$AUDIENCES_DEFINITION_HASH$]).json`;
 
 async function runAudiences() {
+	const meta = document.head.querySelector(
+		'meta[name="audiences-variations"]'
+	);
+
+	// A page without element variations has no metadata. There is nothing to
+	// apply, so leave any previously registered handlers untouched.
+
+	if (!meta) {
+		return;
+	}
+
+	const [plid, elementVariationsHash] = meta.content.split(':');
+
+	audiences.clearHandlers();
+
+	const variations = await import(
+		`${BASE_URL}o/audiences/${plid}/variations.(${elementVariationsHash}).js`
+	);
+
+	variations.register();
+
 	audiences.clear();
 
-	await audiences.runDetection(
-		`${BASE_URL}o/audiences/definition.([$AUDIENCES_DEFINITION_HASH$]).json`
-	);
+	await audiences.runDetection(DEFINITION_URL);
 
 	await audiences.runHandlers();
 }
-
-// Run detection and handlers for the current page, then again after every SPA
-// navigation. Senna keeps this script (data-senna-track="permanent") from
-// being re-evaluated, so this listener is the only thing that runs per page.
 
 await runAudiences();
 

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/com/liferay/frontend/js/audiences/web/internal/util/dependencies/bootstrap.js.tpl
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/com/liferay/frontend/js/audiences/web/internal/util/dependencies/bootstrap.js.tpl
@@ -6,13 +6,25 @@ audiences.setLogEnabled([$ENABLE_LOG$]);
 
 const DEFINITION_URL = `${BASE_URL}o/audiences/definition.([$AUDIENCES_DEFINITION_HASH$]).json`;
 
+let currentNavigationId = 0;
+
 async function runAudiences() {
+
+	// A rapid sequence of SPA navigations can start several runAudiences() in
+	// parallel, since the endNavigate listener is not awaited. Tag each run and
+	// bail after every await once a newer navigation has started, so only the
+	// latest navigation registers handlers and applies variations.
+
+	const navigationId = ++currentNavigationId;
+
+	// Always start the navigation from a clean handler set, even when the page
+	// has no variations, so a previous page's handlers never linger.
+
+	audiences.clearHandlers();
+
 	const meta = document.head.querySelector(
 		'meta[name="audiences-variations"]'
 	);
-
-	// A page without element variations has no metadata. There is nothing to
-	// apply, so leave any previously registered handlers untouched.
 
 	if (!meta) {
 		return;
@@ -20,17 +32,23 @@ async function runAudiences() {
 
 	const [plid, elementVariationsHash] = meta.content.split(':');
 
-	audiences.clearHandlers();
-
 	const variations = await import(
 		`${BASE_URL}o/audiences/${plid}/variations.(${elementVariationsHash}).js`
 	);
+
+	if (navigationId !== currentNavigationId) {
+		return;
+	}
 
 	variations.register();
 
 	audiences.clear();
 
 	await audiences.runDetection(DEFINITION_URL);
+
+	if (navigationId !== currentNavigationId) {
+		return;
+	}
 
 	await audiences.runHandlers();
 }

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/com/liferay/frontend/js/audiences/web/internal/util/dependencies/bootstrap.js.tpl
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/com/liferay/frontend/js/audiences/web/internal/util/dependencies/bootstrap.js.tpl
@@ -4,9 +4,28 @@ const {audiences} = await import(`${BASE_URL}o/frontend-js-audiences-web/__lifer
 
 audiences.setLogEnabled([$ENABLE_LOG$]);
 
-audiences.clear();
-await audiences.runDetection(`${BASE_URL}o/audiences/definition.([$AUDIENCES_DEFINITION_HASH$]).json`);
+// Register the element variation handlers once. ES modules are evaluated at
+// most once per document, so neither this bootstrap module nor the variations
+// module below re-runs on SPA navigations. The handlers are therefore
+// registered a single time and kept registered, while detection and handler
+// execution are re-run on every navigation through the listener below.
 
 await import(`${BASE_URL}o/audiences/[$PLID$]/variations.([$ELEMENT_VARIATIONS_HASH$]).js`);
 
-await audiences.runHandlers();
+async function runAudiences() {
+	audiences.clear();
+
+	await audiences.runDetection(
+		`${BASE_URL}o/audiences/definition.([$AUDIENCES_DEFINITION_HASH$]).json`
+	);
+
+	await audiences.runHandlers();
+}
+
+// Run detection and handlers for the current page, then again after every SPA
+// navigation. Senna keeps this script (data-senna-track="permanent") from
+// being re-evaluated, so this listener is the only thing that runs per page.
+
+await runAudiences();
+
+Liferay.on('endNavigate', runAudiences);

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/implementation.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/implementation.test.ts
@@ -52,5 +52,27 @@ describe('implementation', () => {
 
 			expect(runCount).toBe(2);
 		});
+
+		it('does not run handlers after they are cleared', async () => {
+			let runCount = 0;
+
+			store.setAudienceIds(new Set(['cleared']));
+
+			audiences.on('cleared', () => {
+				runCount += 1;
+			});
+
+			await audiences.runHandlers();
+
+			expect(runCount).toBe(1);
+
+			// Navigating to another page clears the previous page's handlers
+
+			audiences.clearHandlers();
+
+			await audiences.runHandlers();
+
+			expect(runCount).toBe(1);
+		});
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/implementation.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/implementation.test.ts
@@ -33,12 +33,12 @@ describe('implementation', () => {
 			expect(executionOrder).toHaveLength(audienceIds.length);
 		});
 
-		it('clears the registered handlers after running', async () => {
+		it('keeps the registered handlers so they run again on the next navigation', async () => {
 			let runCount = 0;
 
-			store.setAudienceIds(new Set(['a']));
+			store.setAudienceIds(new Set(['persistent']));
 
-			audiences.on('a', () => {
+			audiences.on('persistent', () => {
 				runCount += 1;
 			});
 
@@ -46,11 +46,11 @@ describe('implementation', () => {
 
 			expect(runCount).toBe(1);
 
-			// The handler was cleared, so a second run does not invoke it again
+			// The handler stays registered so a later navigation runs it again
 
 			await audiences.runHandlers();
 
-			expect(runCount).toBe(1);
+			expect(runCount).toBe(2);
 		});
 	});
 });

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/util/dependencies/element_variations.js.tpl
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/util/dependencies/element_variations.js.tpl
@@ -110,18 +110,22 @@ function applyElementVariationOnce(elementVariation) {
 const elementVariations = [$ELEMENT_VARIATIONS$];
 const sortedAudienceEntryERCs = [$SORTED_AUDIENCE_ENTRY_ERCS$];
 
-elementVariations.forEach((elementVariation) => {
-	elementVariation.audienceEntryERCs.forEach((audienceEntryERC) => {
-		audiences.on(audienceEntryERC, () => {
-			if (
-				elementVariation.targetElement &&
-				getWinnerAudienceEntryERC(elementVariation.targetElement) !==
-					audienceEntryERC
-			) {
-				return;
-			}
+export function register() {
+	appliedElementVariations.clear();
 
-			applyElementVariationOnce(elementVariation);
+	elementVariations.forEach((elementVariation) => {
+		elementVariation.audienceEntryERCs.forEach((audienceEntryERC) => {
+			audiences.on(audienceEntryERC, () => {
+				if (
+					elementVariation.targetElement &&
+					getWinnerAudienceEntryERC(elementVariation.targetElement) !==
+						audienceEntryERC
+				) {
+					return;
+				}
+
+				applyElementVariationOnce(elementVariation);
+			});
 		});
 	});
-});
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97562

## What Is Being Fixed

When moving between pages with SPA navigation, audience-based element
variations were not applied — they only appeared after a full page refresh.
The audiences bootstrap and the element variations were delivered as ES
modules that registered their handlers as a one-time side effect of module
evaluation, and a browser evaluates a given module URL at most once per
document, so nothing re-ran on an SPA navigation. Element variations are also
page specific, so even when the bootstrap did run it only ever loaded the
first page's variations.

## How It Is Being Fixed

The bootstrap script is now loaded once (tracked as a permanent Senna
resource) and wires a listener to the SPA endNavigate event, so detection and
variation application run on every navigation as well as on the initial load.
Because variations differ per page, each page publishes its plid and
variations hash through a meta tag that the SPA engine swaps on navigation.
The listener reads that tag, clears the previous page's handlers, imports the
current page's variations module, and calls its newly exported register()
function. The variations template now exposes register() instead of
registering handlers at module top level, so it can be called on every
navigation even though the module itself is cached, and it resets its own
per-navigation applied-state guard. The audiences engine gains a
clearHandlers() call and drops the earlier per-run reset hook that this
approach makes unnecessary.

## PR Check

**pr-check: PASS** — tested on `db19741aa3dc536b8643a6e9aca268c4e8d82141`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "db19741aa3dc536b8643a6e9aca268c4e8d82141"} -->
