### PR TITLE
LPD-97690 Hide the Select All checkbox in views without item selection

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
@@ -1979,7 +1979,7 @@ const FrontendDataSetContent = ({
 		setAdditionalAPIURLParameters(parameters);
 	}
 
-	const selectable = !!selectionType;
+	const selectable = !!selectionType && (activeView.selectable ?? true);
 
 	const {className} = useFDSDrop({
 		targetDropRef: dataSetWrapperRef,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
@@ -295,6 +295,7 @@ export interface IView {
 	label?: string;
 	name?: string;
 	schema?: ISchema;
+	selectable?: boolean;
 	setItemComponentProps?: ({item, props}: {item: any; props: any}) => any;
 	showPagination?: boolean;
 	thumbnail?: string;

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
@@ -84,6 +84,7 @@ export default function ProjectTasksFDSPropsTransformer({
 			symbol: '',
 			title: 'embedded.title',
 		},
+		selectable: false,
 		showPagination: false,
 		thumbnail: 'calendar',
 	};
@@ -108,6 +109,7 @@ export default function ProjectTasksFDSPropsTransformer({
 			symbol: '',
 			title: 'embedded.title',
 		},
+		selectable: false,
 		showPagination: false,
 		thumbnail: 'columns',
 	};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97690

## What Is Being Fixed

Views that do not support item selection — the Calendar and Kanban task views in the site-cmp Project Tasks data set — still rendered the frontend-data-set toolbar's "Select All" checkbox. Selecting all is meaningless in those views because they have no per-item selection, so the checkbox was misleading.

## How It Is Being Fixed

An optional `selectable` flag is added to the frontend-data-set `IView` type. The toolbar now derives `selectable` from both the selection type and the active view's flag (defaulting to `true` when unset), so a view can opt out of item selection and hide the Select All checkbox. The site-cmp Project Tasks props transformer sets `selectable: false` on its Calendar and Kanban views. The change is split into two commits so the frontend-data-set framework change can be reviewed independently from the site-cmp consumer change.

## Why Are There No Tests?

This is a purely presentational change to toolbar visibility in the frontend-data-set, with no straightforward unit-test seam for the toolbar rendering. The changed code path stays covered by the existing frontend-data-set-web and site-cmp Jest suites and the Project Tasks Playwright suite, all green in the local pr-check run.

## PR Check

**pr-check: PASS** — tested on `47bf07ae957b493a50a093d3128c1a0c6a6ee01a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "47bf07ae957b493a50a093d3128c1a0c6a6ee01a"} -->
