### PR TITLE
LPD-95090 Enable the Enhanced Paste from Office plugin

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditor5EditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditor5EditorConfigContributor.java
@@ -6,20 +6,32 @@
 package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
 
 import com.liferay.frontend.editor.ckeditor.web.internal.configuration.CKEditor5Configuration;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.Validator;
 
+import java.nio.charset.StandardCharsets;
+
+import java.util.Base64;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Marko Cikos
@@ -47,17 +59,21 @@ public class CKEditor5EditorConfigContributor
 			inputEditorTaglibAttributes.get("liferay-ui:input-editor:name"));
 		String placeholder = LanguageUtil.format(
 			themeDisplay.getLocale(), "start-writing-content", false);
+		String licenseKey = _ckEditor5Configuration.licenseKey();
 
 		jsonObject.put(
 			"editorType", "ckeditor5"
 		).put(
 			"itemSelectorEventName", namespace + name + "selectItem"
 		).put(
-			"licenseKey", _ckEditor5Configuration.licenseKey()
+			"licenseKey", licenseKey
 		).put(
 			"placeholder", placeholder
 		).put(
 			"preset", "advanced"
+		).put(
+			"showPasteFromOfficeEnhanced",
+			ReleaseInfo.isDXP() && _isLicenseKeyValid(licenseKey)
 		);
 	}
 
@@ -68,6 +84,54 @@ public class CKEditor5EditorConfigContributor
 			CKEditor5Configuration.class, properties);
 	}
 
+	private boolean _isLicenseKeyValid(String licenseKey) {
+		if (Validator.isNull(licenseKey)) {
+			return false;
+		}
+
+		String[] parts = licenseKey.split("\\.");
+
+		if (parts.length != 3) {
+			return false;
+		}
+
+		try {
+			String payload = parts[1];
+
+			int paddingLength = (4 - (payload.length() % 4)) % 4;
+
+			JSONObject payloadJSONObject = _jsonFactory.createJSONObject(
+				new String(
+					Base64.getUrlDecoder(
+					).decode(
+						payload.concat(StringPool.EQUAL.repeat(paddingLength))
+					),
+					StandardCharsets.UTF_8));
+
+			long expirationTime = payloadJSONObject.getLong("exp", 0);
+
+			if (expirationTime > (System.currentTimeMillis() / Time.SECOND)) {
+				return true;
+			}
+
+			return false;
+		}
+		catch (IllegalArgumentException | JSONException exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to parse the CKEditor 5 license key", exception);
+			}
+
+			return false;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CKEditor5EditorConfigContributor.class);
+
 	private volatile CKEditor5Configuration _ckEditor5Configuration;
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/BalloonEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/BalloonEditor.tsx
@@ -41,6 +41,8 @@ const BalloonEditor = ({
 					editorVariant: EEditorVariant.BALLOON,
 					preset: config?.preset || EEditorConfigPreset.ADVANCED,
 					showAICreator: config?.showAICreator,
+					showPasteFromOfficeEnhanced:
+						config?.showPasteFromOfficeEnhanced,
 				}),
 				...config,
 			}}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
@@ -47,6 +47,8 @@ const ClassicEditor = ({
 					editorVariant: EEditorVariant.CLASSIC,
 					preset: config?.preset || EEditorConfigPreset.ADVANCED,
 					showAICreator: config?.showAICreator,
+					showPasteFromOfficeEnhanced:
+						config?.showPasteFromOfficeEnhanced,
 				}),
 				...config,
 			}}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
@@ -35,6 +35,7 @@ import {Link, LinkImage} from '@ckeditor/ckeditor5-link/dist/index.js';
 import {List} from '@ckeditor/ckeditor5-list/dist/index.js';
 import {MediaEmbed} from '@ckeditor/ckeditor5-media-embed/dist/index.js';
 import {Paragraph} from '@ckeditor/ckeditor5-paragraph/dist/index.js';
+import {PasteFromOfficeEnhanced} from '@ckeditor/ckeditor5-paste-from-office-enhanced/dist/index.js';
 import {PasteFromOffice} from '@ckeditor/ckeditor5-paste-from-office/dist/index.js';
 import {RemoveFormat} from '@ckeditor/ckeditor5-remove-format/dist/index.js';
 import {SourceEditing} from '@ckeditor/ckeditor5-source-editing/dist/index.js';
@@ -58,10 +59,12 @@ const getDefaultEditorConfig = ({
 	editorVariant,
 	preset,
 	showAICreator,
+	showPasteFromOfficeEnhanced,
 }: {
 	editorVariant: EEditorVariant;
 	preset: EEditorConfigPreset;
 	showAICreator?: boolean;
+	showPasteFromOfficeEnhanced?: boolean;
 }): EditorConfig => {
 	const basicPlugins = [
 		BlockToolbar,
@@ -74,7 +77,7 @@ const getDefaultEditorConfig = ({
 		LinkImage,
 		List,
 		Paragraph,
-		PasteFromOffice,
+		showPasteFromOfficeEnhanced ? PasteFromOfficeEnhanced : PasteFromOffice,
 		Underline,
 	];
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
@@ -34,6 +34,7 @@ export interface LiferayEditorConfig extends EditorConfig {
 	itemSelectorRememberSelectionFolder?: boolean;
 	preset?: EEditorConfigPreset;
 	showAICreator?: boolean;
+	showPasteFromOfficeEnhanced?: boolean;
 }
 
 export type TEditor = BalloonEditor | ClassicEditor;

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
@@ -413,3 +413,25 @@ test(
 		).toBeVisible();
 	}
 );
+
+test(
+	'Enhanced Paste from Office plugin is registered for licensed DXP installations',
+	{tag: '@LPD-95090'},
+	async ({classicPage, page}) => {
+		await expect(classicPage.editable).toBeVisible();
+
+		const hasPasteFromOfficeEnhanced = await page.evaluate(() => {
+			const editorElement = Array.from(
+				document.querySelectorAll('.lfr-ck *')
+			).find((element) => (element as any).ckeditorInstance);
+
+			return (
+				(editorElement as any)?.ckeditorInstance?.plugins.has(
+					'PasteFromOfficeEnhanced'
+				) ?? false
+			);
+		});
+
+		expect(hasPasteFromOfficeEnhanced).toBe(true);
+	}
+);

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 10.7.0
+version 10.8.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95090

## What Is Being Fixed

CKEditor 5's advanced toolbar always uses the community Paste from Office plugin, which strips some of the list, table, and heading formatting inherited from pasted Word and Excel content. Licensed DXP installations should instead get the premium Enhanced Paste from Office plugin, which preserves that formatting more faithfully.

## How It Is Being Fixed

The editor config contributor now computes a `showEnhancedPasteFromOffice` flag from the product edition and the validity of the configured CKEditor 5 license key, mirroring the pattern already used for other premium CKEditor 5 features. The flag is threaded through the Balloon and Classic editor components, and the community `PasteFromOffice` plugin is swapped for the premium `PasteFromOfficeEnhanced` plugin whenever the flag is true. A Playwright test confirms the premium plugin is actually registered on the live editor instance.

## PR Check

**pr-check: PASS** — tested on `6cd9b48346699aebfa173ece32f1847e1b96294a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "6cd9b48346699aebfa173ece32f1847e1b96294a"} -->
