### PR TITLE
LPD-98575 Fix broken editor tests caused by LPD-52631

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/balloon.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/balloon.spec.ts
@@ -34,6 +34,7 @@ test(
 			'Accessibility help',
 			'Undo',
 			'Redo',
+			'Find and replace',
 			'Styles',
 			'Normal',
 			'Bold',

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/cet_react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/cet_react.spec.ts
@@ -89,8 +89,6 @@ test(
 		await classicPage.editable.click();
 		await page.keyboard.press('Control+k');
 
-		await expect(
-			page.getByRole('button', {name: 'Insert'})
-		).toBeVisible();
+		await expect(page.getByRole('button', {name: 'Insert'})).toBeVisible();
 	}
 );

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/cet_react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/cet_react.spec.ts
@@ -27,6 +27,7 @@ test(
 			'Redo',
 			'Bold',
 			'Italic',
+			'Link',
 			'Bookmark',
 			'Image',
 			'Video',
@@ -89,7 +90,7 @@ test(
 		await page.keyboard.press('Control+k');
 
 		await expect(
-			page.getByRole('button', {name: 'Select Document'})
+			page.getByRole('button', {name: 'Insert'})
 		).toBeVisible();
 	}
 );

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react.spec.ts
@@ -35,6 +35,7 @@ test(
 				'Redo',
 				'Bold',
 				'Italic',
+				'Link',
 				'Bookmark',
 				'Image',
 				'Video',

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 10.7.0
+version 10.8.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98575

## What Is Being Fixed

LPD-52631 changed the CKEditor 5 editor UI, which broke several Playwright specs that asserted the old interface. The toolbar now includes "Find and replace" and "Link" buttons that the expected item lists did not account for, and the link insertion flow triggered by Control+k now surfaces an "Insert" button rather than a "Select Document" button. As a result the balloon, cet_react, and react editor specs failed.

## How It Is Being Fixed

The expected toolbar item lists in the affected specs are updated to include the newly added "Find and replace" and "Link" entries, and the link-insertion assertion is changed to expect the "Insert" button. The exported package version for the portal test util package is also bumped to satisfy the API baseline.

## PR Check

**pr-check: PASS** — tested on `b20d4f184142d10c16059ececc91d05b7bd7b74b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Full Portal Build | PASS |

<!-- pr-check {"result": "success", "sha": "b20d4f184142d10c16059ececc91d05b7bd7b74b"} -->
