### PR TITLE
LPD-98575 Fix broken editor tests caused by LPD-52631

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/balloon.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/balloon.spec.ts
@@ -34,6 +34,7 @@ test(
 			'Accessibility help',
 			'Undo',
 			'Redo',
+			'Find and replace',
 			'Styles',
 			'Normal',
 			'Bold',

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/cet_react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/cet_react.spec.ts
@@ -27,6 +27,7 @@ test(
 			'Redo',
 			'Bold',
 			'Italic',
+			'Link',
 			'Bookmark',
 			'Image',
 			'Video',
@@ -88,8 +89,6 @@ test(
 		await classicPage.editable.click();
 		await page.keyboard.press('Control+k');
 
-		await expect(
-			page.getByRole('button', {name: 'Select Document'})
-		).toBeVisible();
+		await expect(page.getByRole('button', {name: 'Insert'})).toBeVisible();
 	}
 );

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react.spec.ts
@@ -35,6 +35,7 @@ test(
 				'Redo',
 				'Bold',
 				'Italic',
+				'Link',
 				'Bookmark',
 				'Image',
 				'Video',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98575

## What Is Being Fixed

LPD-52631 changed the CKEditor 5 editor UI, which broke several Playwright specs that asserted the old interface. The toolbar now includes "Find and replace" and "Link" buttons that the expected item lists did not account for, and the link insertion flow triggered by Control+k now surfaces an "Insert" button rather than a "Select Document" button. As a result the balloon, cet_react, and react editor specs failed.

## How It Is Being Fixed

The expected toolbar item lists in the affected specs are updated to include the newly added "Find and replace" and "Link" entries, and the link-insertion assertion is changed to expect the "Insert" button.

## PR Check

**pr-check: PASS** — tested on `4851bbf47ab880123987717618603b5351e48437`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "4851bbf47ab880123987717618603b5351e48437"} -->
