### PR TITLE
LPD-98683 Add a group role to the data set filter resume label

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FilterResume.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FilterResume.tsx
@@ -82,6 +82,7 @@ function FilterResume({
 				'tbar-label',
 				open && 'active'
 			)}
+			role="group"
 		>
 			<ClayLabel.ItemExpand>
 				<ClayDropDown


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98683

## What Is Being Fixed

After LPD-98305 reworked the frontend data set filter markup, the Playwright spec `frontend-data-set-web/.../advanced/configInURL.spec.ts` started failing. The filter resume label was no longer exposed with a semantic grouping in the accessibility tree, so the test could not locate it by role and the grouping information was lost for assistive technology.

## How It Is Being Fixed

Add `role="group"` to the filter resume `<span>` in `FilterResume.tsx`. This restores the semantic grouping the test relies on and correctly exposes the label and its dismiss control as a single group in the accessibility tree.

## Why Are There No Tests?

It actually fixes broken tests related to FDS filters after LPD-98305.

## PR Check

**pr-check: PASS** — tested on `03d5d9057cf1995b041b70e1eeb3d8a54be271ef`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "03d5d9057cf1995b041b70e1eeb3d8a54be271ef"} -->
