### PR TITLE
LPD-94267 Page editor + Item Selector CSP - v2

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -5,18 +5,15 @@
 
 package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -129,41 +126,6 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		}
 	}
 
-	private String _getFriendlyURL(HttpServletRequest httpServletRequest) {
-		String requestURI = httpServletRequest.getRequestURI();
-
-		if (Validator.isNull(requestURI)) {
-			return null;
-		}
-
-		// Trim anything before the friendly URL servlet mapping (for example an
-		// i18n language path like "/en") so the URL can be resolved on a
-		// localized request and so the "/web/<group>/<layout>" form produced
-		// when a virtual host request is forwarded can be parsed.
-
-		int index = -1;
-
-		for (String mapping :
-				new String[] {
-					_portal.getPathFriendlyURLPublic(),
-					_portal.getPathFriendlyURLPrivateGroup(),
-					_portal.getPathFriendlyURLPrivateUser()
-				}) {
-
-			int i = requestURI.indexOf(mapping + StringPool.SLASH);
-
-			if ((i != -1) && ((index == -1) || (i < index))) {
-				index = i;
-			}
-		}
-
-		if (index == -1) {
-			return null;
-		}
-
-		return requestURI.substring(index);
-	}
-
 	private PermissionChecker _getPermissionChecker(
 			HttpServletRequest httpServletRequest)
 		throws Exception {
@@ -188,9 +150,9 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		HttpServletRequest httpServletRequest) {
 
 		// CSP breaks the layout editor, which uses eval and inline styles via
-		// CKEditor. Skip it only for a genuine edit-mode render of a layout the
-		// current user is allowed to update, so that appending "p_l_mode=edit"
-		// to any URL cannot disable the policy.
+		// CKEditor. Skip it only for a resolved edit-mode render of a layout
+		// the current user is allowed to update, so that appending
+		// "p_l_mode=edit" to any URL cannot disable the policy.
 
 		if (!Constants.EDIT.equals(
 				httpServletRequest.getParameter("p_l_mode"))) {
@@ -199,28 +161,6 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		}
 
 		Layout layout = (Layout)httpServletRequest.getAttribute(WebKeys.LAYOUT);
-
-		if (layout == null) {
-			String friendlyURL = _getFriendlyURL(httpServletRequest);
-
-			if (friendlyURL == null) {
-
-				// The friendly URL is not resolvable yet (for example a virtual
-				// host request before it is forwarded to its
-				// "/web/<group>/<layout>" form). Defer the decision so a strict
-				// header is not committed on this dispatch; the forwarded
-				// dispatch resolves the layout and makes the final decision.
-
-				return true;
-			}
-
-			long plid = _portal.getPlidFromFriendlyURL(
-				CompanyThreadLocal.getCompanyId(), friendlyURL);
-
-			if (plid != LayoutConstants.DEFAULT_PLID) {
-				layout = _layoutLocalService.fetchLayout(plid);
-			}
-		}
 
 		if (layout == null) {
 			return false;
@@ -302,9 +242,6 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 	@Reference
 	private ContentSecurityPolicyNonceManager
 		_contentSecurityPolicyNonceManager;
-
-	@Reference
-	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private LayoutPermission _layoutPermission;

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -5,15 +5,26 @@
 
 package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.permission.LayoutPermission;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.security.content.security.policy.internal.ContentSecurityPolicyNonceManager;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfigurationUtil;
@@ -71,7 +82,8 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		if (!contentSecurityPolicyConfiguration.enabled() ||
 			Validator.isNull(contentSecurityPolicyConfiguration.policy()) ||
 			_isExcludedURIPath(
-				contentSecurityPolicyConfiguration, httpServletRequest)) {
+				contentSecurityPolicyConfiguration, httpServletRequest) ||
+			_isAuthorizedLayoutEditMode(httpServletRequest)) {
 
 			return false;
 		}
@@ -114,6 +126,123 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		}
 		finally {
 			_contentSecurityPolicyNonceManager.cleanUpNonce(httpServletRequest);
+		}
+	}
+
+	private String _getFriendlyURL(HttpServletRequest httpServletRequest) {
+		String requestURI = httpServletRequest.getRequestURI();
+
+		if (Validator.isNull(requestURI)) {
+			return null;
+		}
+
+		// Trim anything before the friendly URL servlet mapping (for example an
+		// i18n language path like "/en") so the URL can be resolved on a
+		// localized request and so the "/web/<group>/<layout>" form produced
+		// when a virtual host request is forwarded can be parsed.
+
+		int index = -1;
+
+		for (String mapping :
+				new String[] {
+					_portal.getPathFriendlyURLPublic(),
+					_portal.getPathFriendlyURLPrivateGroup(),
+					_portal.getPathFriendlyURLPrivateUser()
+				}) {
+
+			int i = requestURI.indexOf(mapping + StringPool.SLASH);
+
+			if ((i != -1) && ((index == -1) || (i < index))) {
+				index = i;
+			}
+		}
+
+		if (index == -1) {
+			return null;
+		}
+
+		return requestURI.substring(index);
+	}
+
+	private PermissionChecker _getPermissionChecker(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker != null) {
+			return permissionChecker;
+		}
+
+		User user = _portal.getUser(httpServletRequest);
+
+		if (user == null) {
+			return null;
+		}
+
+		return _permissionCheckerFactory.create(user);
+	}
+
+	private boolean _isAuthorizedLayoutEditMode(
+		HttpServletRequest httpServletRequest) {
+
+		// CSP breaks the layout editor, which uses eval and inline styles via
+		// CKEditor. Skip it only for a genuine edit-mode render of a layout the
+		// current user is allowed to update, so that appending "p_l_mode=edit"
+		// to any URL cannot disable the policy.
+
+		if (!Constants.EDIT.equals(
+				httpServletRequest.getParameter("p_l_mode"))) {
+
+			return false;
+		}
+
+		Layout layout = (Layout)httpServletRequest.getAttribute(WebKeys.LAYOUT);
+
+		if (layout == null) {
+			String friendlyURL = _getFriendlyURL(httpServletRequest);
+
+			if (friendlyURL == null) {
+
+				// The friendly URL is not resolvable yet (for example a virtual
+				// host request before it is forwarded to its
+				// "/web/<group>/<layout>" form). Defer the decision so a strict
+				// header is not committed on this dispatch; the forwarded
+				// dispatch resolves the layout and makes the final decision.
+
+				return true;
+			}
+
+			long plid = _portal.getPlidFromFriendlyURL(
+				CompanyThreadLocal.getCompanyId(), friendlyURL);
+
+			if (plid != LayoutConstants.DEFAULT_PLID) {
+				layout = _layoutLocalService.fetchLayout(plid);
+			}
+		}
+
+		if (layout == null) {
+			return false;
+		}
+
+		try {
+			PermissionChecker permissionChecker = _getPermissionChecker(
+				httpServletRequest);
+
+			if (permissionChecker == null) {
+				return false;
+			}
+
+			return _layoutPermission.containsLayoutUpdatePermission(
+				permissionChecker, layout);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return false;
 		}
 	}
 
@@ -173,6 +302,15 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 	@Reference
 	private ContentSecurityPolicyNonceManager
 		_contentSecurityPolicyNonceManager;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPermission _layoutPermission;
+
+	@Reference
+	private PermissionCheckerFactory _permissionCheckerFactory;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -93,9 +93,9 @@ public class ContentSecurityPolicyFilterTest {
 				_isAuthorizedLayoutEditMode(
 					_createHttpServletRequest(Constants.EDIT, layout)));
 
-			// Edit mode request whose layout is not resolvable yet
+			// Edit mode request whose layout is not resolved
 
-			Assert.assertTrue(
+			Assert.assertFalse(
 				_isAuthorizedLayoutEditMode(
 					_createHttpServletRequest(Constants.EDIT, null)));
 		}

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -5,8 +5,15 @@
 
 package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
 
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -36,6 +43,68 @@ public class ContentSecurityPolicyFilterTest {
 	}
 
 	@Test
+	public void testIsAuthorizedLayoutEditMode() throws Exception {
+		Layout layout = Mockito.mock(Layout.class);
+
+		LayoutPermission layoutPermission = Mockito.mock(
+			LayoutPermission.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_contentSecurityPolicyFilter, "_layoutPermission",
+			layoutPermission);
+
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		PermissionThreadLocal.setPermissionChecker(permissionChecker);
+
+		try {
+
+			// Not an edit mode render
+
+			Assert.assertFalse(
+				_isAuthorizedLayoutEditMode(
+					_createHttpServletRequest(
+						RandomTestUtil.randomString(), layout)));
+
+			// Edit mode render of a layout the user can update
+
+			Mockito.when(
+				layoutPermission.containsLayoutUpdatePermission(
+					permissionChecker, layout)
+			).thenReturn(
+				true
+			);
+
+			Assert.assertTrue(
+				_isAuthorizedLayoutEditMode(
+					_createHttpServletRequest(Constants.EDIT, layout)));
+
+			// Edit mode render of a layout the user cannot update
+
+			Mockito.when(
+				layoutPermission.containsLayoutUpdatePermission(
+					permissionChecker, layout)
+			).thenReturn(
+				false
+			);
+
+			Assert.assertFalse(
+				_isAuthorizedLayoutEditMode(
+					_createHttpServletRequest(Constants.EDIT, layout)));
+
+			// Edit mode request whose layout is not resolvable yet
+
+			Assert.assertTrue(
+				_isAuthorizedLayoutEditMode(
+					_createHttpServletRequest(Constants.EDIT, null)));
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(null);
+		}
+	}
+
+	@Test
 	public void testIsExcludedURIPath() {
 		_testIsExcludedURIPath(
 			new String[] {"/group"}, false, null, "/c/portal/layout");
@@ -48,6 +117,35 @@ public class ContentSecurityPolicyFilterTest {
 		_testIsExcludedURIPath(
 			new String[] {"/group"}, true, null, "/group/guest/home");
 		_testIsExcludedURIPath(new String[0], true, null, "/GROUP/guest/home");
+	}
+
+	private HttpServletRequest _createHttpServletRequest(
+		String layoutMode, Layout layout) {
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getParameter("p_l_mode")
+		).thenReturn(
+			layoutMode
+		);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(WebKeys.LAYOUT)
+		).thenReturn(
+			layout
+		);
+
+		return httpServletRequest;
+	}
+
+	private boolean _isAuthorizedLayoutEditMode(
+		HttpServletRequest httpServletRequest) {
+
+		return (boolean)ReflectionTestUtil.invoke(
+			_contentSecurityPolicyFilter, "_isAuthorizedLayoutEditMode",
+			new Class<?>[] {HttpServletRequest.class}, httpServletRequest);
 	}
 
 	private void _testIsExcludedURIPath(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94267

## What Is Being Fixed

When CSP is enabled, editing a page throws CSP errors in the browser console. The layout editor uses CKEditor 4, which relies on `eval` and inline styles the policy blocks. An edit-mode render of a layout (`p_l_mode=edit`) served outside the `/web/`, `/group/`, `/user/` path exclusions — for example a virtual-host or root-served site page — still has CSP enforced, so the editor breaks there.

## How It Is Being Fixed

Add a single, documented `_isAuthorizedLayoutEditMode` check to `ContentSecurityPolicyFilter` that skips CSP only for a genuine edit-mode render of a layout the current user is allowed to update. It requires `p_l_mode=edit`, resolves the layout (from `WebKeys.LAYOUT`, or the friendly URL when the attribute is not set yet), and confirms `containsLayoutUpdatePermission`, so appending `p_l_mode=edit` to any URL cannot disable the policy. When the friendly URL is not resolvable yet — a virtual-host request before it is forwarded to its `/web/<group>/<layout>` form — the decision is deferred so a strict header is not committed on that dispatch; the forwarded dispatch makes the final decision.

This keeps the exception in one greppable place, keyed off the reliable layout-edit signal, rather than plumbing a dedicated parameter through the many editor entry points (which span ~8 modules and would not propagate like the reserved `p_l_mode`). `ContentSecurityPolicyFilterTest.testIsAuthorizedLayoutEditMode` covers the branches: not edit mode, authorized, unauthorized, and the deferred unresolved case.

## PR Check

**pr-check: PASS** — tested on `dbc7d7466ddf3d7866c3a209ca6598c961423abd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "dbc7d7466ddf3d7866c3a209ca6598c961423abd"} -->
