### PR TITLE
LPD-94267 Page editor + Item Selector CSP (explicit parameter)

### DIFF
--- a/modules/apps/asset/asset-info-display-impl/src/main/java/com/liferay/asset/info/display/internal/url/provider/AssetInfoEditURLProviderImpl.java
+++ b/modules/apps/asset/asset-info-display-impl/src/main/java/com/liferay/asset/info/display/internal/url/provider/AssetInfoEditURLProviderImpl.java
@@ -13,6 +13,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
@@ -82,6 +83,16 @@ public class AssetInfoEditURLProviderImpl implements AssetInfoEditURLProvider {
 					redirect = HttpComponentsUtil.setParameter(
 						_portal.getLayoutRelativeURL(layout, themeDisplay),
 						"p_l_mode", mode);
+
+					if (ParamUtil.getBoolean(
+							_portal.getOriginalServletRequest(
+								httpServletRequest),
+							LayoutConstants.PARAM_CSP_DISABLED)) {
+
+						redirect = HttpComponentsUtil.setParameter(
+							redirect, LayoutConstants.PARAM_CSP_DISABLED,
+							"true");
+					}
 				}
 			}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/display/url/provider/FileEntryAssetInfoEditURLProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/display/url/provider/FileEntryAssetInfoEditURLProvider.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -79,6 +80,16 @@ public class FileEntryAssetInfoEditURLProvider
 					redirect = HttpComponentsUtil.setParameter(
 						_portal.getLayoutRelativeURL(layout, themeDisplay),
 						"p_l_mode", mode);
+
+					if (ParamUtil.getBoolean(
+							_portal.getOriginalServletRequest(
+								httpServletRequest),
+							LayoutConstants.PARAM_CSP_DISABLED)) {
+
+						redirect = HttpComponentsUtil.setParameter(
+							redirect, LayoutConstants.PARAM_CSP_DISABLED,
+							"true");
+					}
 				}
 				catch (Exception exception) {
 					if (_log.isDebugEnabled()) {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/portlet_url/create_portlet_url.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/portlet_url/create_portlet_url.es.js
@@ -35,6 +35,7 @@ export default function createPortletURL(basePortletURL, parameters = {}) {
 		'p_auth_secret',
 		'p_f_id',
 		'p_j_a_id',
+		'p_l_csp_disabled',
 		'p_l_id',
 		'p_l_reset',
 		'p_p_auth',

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/change/tracking/spi/display/LayoutCTDisplayRenderer.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/change/tracking/spi/display/LayoutCTDisplayRenderer.java
@@ -99,7 +99,8 @@ public class LayoutCTDisplayRenderer extends BaseCTDisplayRenderer<Layout> {
 			return HttpComponentsUtil.addParameters(
 				PortalUtil.getLayoutFullURL(
 					layout.fetchDraftLayout(), themeDisplay),
-				"p_l_back_url", currentURL, "p_l_mode", Constants.EDIT);
+				"p_l_back_url", currentURL, "p_l_mode", Constants.EDIT,
+				LayoutConstants.PARAM_CSP_DISABLED, "true");
 		}
 
 		if (layout.isTypePortlet() &&

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
@@ -163,7 +164,8 @@ public class LayoutLookAndFeelDisplayContext {
 					LanguageUtil.get(
 						_themeDisplay.getLocale(),
 						LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN),
-					"p_l_mode", Constants.EDIT);
+					"p_l_mode", Constants.EDIT,
+					LayoutConstants.PARAM_CSP_DISABLED, "true");
 			}
 		).put(
 			"isReadOnly", _layoutsAdminDisplayContext.isReadOnly()

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -2259,10 +2259,17 @@ public class LayoutsAdminDisplayContext {
 	private String _getDraftLayoutURL(Layout layout, String mode)
 		throws Exception {
 
-		return HttpComponentsUtil.addParameters(
+		String draftLayoutURL = HttpComponentsUtil.addParameters(
 			PortalUtil.getLayoutFullURL(getDraftLayout(layout), themeDisplay),
 			"p_l_back_url", _getBackURL(layout), "p_l_back_url_title",
 			LanguageUtil.get(httpServletRequest, "pages"), "p_l_mode", mode);
+
+		if (Objects.equals(mode, Constants.EDIT)) {
+			draftLayoutURL = HttpComponentsUtil.addParameter(
+				draftLayoutURL, LayoutConstants.PARAM_CSP_DISABLED, "true");
+		}
+
+		return draftLayoutURL;
 	}
 
 	private String _getFriendlyURLWarningURL() {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutUtilityPageEntryVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutUtilityPageEntryVerticalCard.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.util.Constants;
@@ -73,7 +74,8 @@ public class LayoutUtilityPageEntryVerticalCard extends BaseVerticalCard {
 				PortalUtil.getLayoutFullURL(_draftLayout, themeDisplay),
 				"p_l_back_url", themeDisplay.getURLCurrent(),
 				"p_l_back_url_title", portletDisplay.getPortletDisplayName(),
-				"p_l_mode", Constants.EDIT);
+				"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+				"true");
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AddLayoutConversionPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AddLayoutConversionPreviewMVCActionCommand.java
@@ -11,6 +11,7 @@ import com.liferay.layout.util.template.LayoutConversionResult;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.MultiSessionMessages;
@@ -68,7 +69,7 @@ public class AddLayoutConversionPreviewMVCActionCommand
 			layoutFullURL = HttpComponentsUtil.addParameters(
 				layoutFullURL, "p_l_back_url", redirect, "p_l_back_url_title",
 				_language.get(themeDisplay.getLocale(), "pages"), "p_l_mode",
-				Constants.EDIT);
+				Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED, "true");
 
 			MultiSessionMessages.add(
 				actionRequest, "layoutConversionWarningMessages",

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AddLayoutUtilityPageEntryMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AddLayoutUtilityPageEntryMVCActionCommand.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
@@ -131,7 +132,7 @@ public class AddLayoutUtilityPageEntryMVCActionCommand
 			).buildString(),
 			"p_l_back_url_title",
 			_language.get(themeDisplay.getLocale(), "pages"), "p_l_mode",
-			Constants.EDIT);
+			Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED, "true");
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/BaseAddLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/BaseAddLayoutMVCActionCommand.java
@@ -8,6 +8,7 @@ package com.liferay.layout.admin.web.internal.portlet.action;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -50,6 +51,8 @@ public abstract class BaseAddLayoutMVCActionCommand
 
 		layoutFullURL = HttpComponentsUtil.setParameter(
 			layoutFullURL, "p_l_mode", Constants.EDIT);
+		layoutFullURL = HttpComponentsUtil.setParameter(
+			layoutFullURL, LayoutConstants.PARAM_CSP_DISABLED, "true");
 
 		String backURL = ParamUtil.getString(actionRequest, "backURL");
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/ConvertEmptyLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/ConvertEmptyLayoutMVCActionCommand.java
@@ -170,7 +170,7 @@ public class ConvertEmptyLayoutMVCActionCommand
 				"p_l_back_url", _getBackURL(actionRequest),
 				"p_l_back_url_title",
 				_language.get(themeDisplay.getLocale(), "pages"), "p_l_mode",
-				Constants.EDIT);
+				Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED, "true");
 		}
 
 		return PortletURLBuilder.createRenderURL(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -291,7 +292,8 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 					"p_l_back_url", _themeDisplay.getURLCurrent(),
 					"p_l_back_url_title",
 					portletDisplay.getPortletDisplayName(), "p_l_mode",
-					Constants.EDIT));
+					Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+					"true"));
 
 			dropdownItem.setIcon("pencil");
 			dropdownItem.setLabel(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/comment/CommentUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/comment/CommentUtil.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -80,9 +81,9 @@ public class CommentUtil {
 			WorkflowUtil.getServiceContextFunction(
 				_getWorkflowAction(actionRequest), actionRequest);
 
-		String notificationRedirect = HttpComponentsUtil.setParameter(
+		String notificationRedirect = HttpComponentsUtil.addParameters(
 			PortalUtil.getLayoutFullURL(themeDisplay), "p_l_mode",
-			Constants.EDIT);
+			Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED, "true");
 
 		return serviceContextFunction.andThen(
 			serviceContext -> {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -1072,7 +1072,7 @@ public class ContentPageEditorDisplayContext {
 	}
 
 	protected String getFragmentEntryActionURL(String action, String command) {
-		return HttpComponentsUtil.addParameter(
+		return HttpComponentsUtil.addParameters(
 			PortletURLBuilder.createActionURL(
 				renderResponse
 			).setActionName(
@@ -1090,7 +1090,8 @@ public class ContentPageEditorDisplayContext {
 					portal.getOriginalServletRequest(httpServletRequest),
 					"p_l_back_url", themeDisplay.getURLCurrent())
 			).buildString(),
-			"p_l_mode", Constants.EDIT);
+			"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+			"true");
 	}
 
 	protected long getGroupId() {
@@ -1991,6 +1992,8 @@ public class ContentPageEditorDisplayContext {
 				"p_l_back_url_title")
 		).setParameter(
 			"p_l_mode", Constants.EDIT
+		).setParameter(
+			LayoutConstants.PARAM_CSP_DISABLED, "true"
 		).setResourceID(
 			resourceID
 		).buildString();

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/ContentManagerImpl.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/ContentManagerImpl.java
@@ -82,6 +82,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -1638,9 +1639,9 @@ public class ContentManagerImpl implements ContentManager {
 		Layout layout = themeDisplay.getLayout();
 
 		try {
-			return HttpComponentsUtil.setParameter(
+			return HttpComponentsUtil.addParameters(
 				_portal.getLayoutRelativeURL(layout, themeDisplay), "p_l_mode",
-				Constants.EDIT);
+				Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED, "true");
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -1656,10 +1657,11 @@ public class ContentManagerImpl implements ContentManager {
 			ThemeDisplay themeDisplay)
 		throws Exception {
 
-		String currentURL = HttpComponentsUtil.addParameter(
+		String currentURL = HttpComponentsUtil.addParameters(
 			_portal.getLayoutRelativeURL(
 				themeDisplay.getLayout(), themeDisplay),
-			"p_l_mode", Constants.EDIT);
+			"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+			"true");
 
 		return HttpComponentsUtil.addParameter(
 			PortletURLBuilder.create(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/EditCollectionConfigurationMVCRenderCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/EditCollectionConfigurationMVCRenderCommand.java
@@ -9,6 +9,7 @@ import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.display.context.EditCollectionConfigurationDisplayContext;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.LiferayRenderRequest;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
@@ -51,6 +52,8 @@ public class EditCollectionConfigurationMVCRenderCommand
 			(DynamicServletRequest)liferayRenderRequest.getHttpServletRequest();
 
 		dynamicServletRequest.setParameter("p_l_mode", Constants.EDIT);
+		dynamicServletRequest.setParameter(
+			LayoutConstants.PARAM_CSP_DISABLED, "true");
 
 		return "/edit_collection_configuration.jsp";
 	}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/change/tracking/display/LayoutPageTemplateEntryCTDisplayRenderer.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/change/tracking/display/LayoutPageTemplateEntryCTDisplayRenderer.java
@@ -14,6 +14,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -78,7 +79,7 @@ public class LayoutPageTemplateEntryCTDisplayRenderer
 			PortalUtil.getLayoutFullURL(
 				layout.fetchDraftLayout(), themeDisplay),
 			"p_l_back_url", themeDisplay.getURLCurrent(), "p_l_mode",
-			Constants.EDIT);
+			Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED, "true");
 	}
 
 	@Override

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/DisplayPageVerticalCard.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/DisplayPageVerticalCard.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -105,7 +106,8 @@ public class DisplayPageVerticalCard
 				PortalUtil.getLayoutFullURL(_draftLayout, _themeDisplay),
 				"p_l_back_url", _themeDisplay.getURLCurrent(),
 				"p_l_back_url_title", portletDisplay.getPortletDisplayName(),
-				"p_l_mode", Constants.EDIT);
+				"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+				"true");
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutPageTemplateEntryVerticalCard.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutPageTemplateEntryVerticalCard.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
@@ -117,7 +118,7 @@ public class LayoutPageTemplateEntryVerticalCard extends BaseVerticalCard {
 					themeDisplay),
 				"p_l_back_url", themeDisplay.getURLCurrent(),
 				"p_l_back_url_title", portletDisplay.getTitle(), "p_l_mode",
-				Constants.EDIT);
+				Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED, "true");
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/MasterLayoutVerticalCard.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/MasterLayoutVerticalCard.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -110,7 +111,8 @@ public class MasterLayoutVerticalCard
 					layout.fetchDraftLayout(), _themeDisplay),
 				"p_l_back_url", _themeDisplay.getURLCurrent(),
 				"p_l_back_url_title", portletDisplay.getPortletDisplayName(),
-				"p_l_mode", Constants.EDIT);
+				"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+				"true");
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddDisplayPageMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddDisplayPageMVCActionCommand.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
@@ -107,7 +108,8 @@ public class AddDisplayPageMVCActionCommand extends BaseMVCActionCommand {
 			).buildString(),
 			"p_l_back_url_title",
 			_language.get(themeDisplay.getLocale(), "page-templates"),
-			"p_l_mode", Constants.EDIT);
+			"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+			"true");
 	}
 
 	private JSONObject _addDisplayPage(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddLayoutPageTemplateEntryMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddLayoutPageTemplateEntryMVCActionCommand.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
@@ -128,7 +129,8 @@ public class AddLayoutPageTemplateEntryMVCActionCommand
 			).buildString(),
 			"p_l_back_url_title",
 			_language.get(themeDisplay.getLocale(), "page-templates"),
-			"p_l_mode", Constants.EDIT);
+			"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+			"true");
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddMasterLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddMasterLayoutMVCActionCommand.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
@@ -119,7 +120,8 @@ public class AddMasterLayoutMVCActionCommand extends BaseMVCActionCommand {
 			).buildString(),
 			"p_l_back_url_title",
 			_language.get(themeDisplay.getLocale(), "page-templates"),
-			"p_l_mode", Constants.EDIT);
+			"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+			"true");
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProvider.java
@@ -31,6 +31,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
@@ -432,7 +433,8 @@ public class DisplayPageActionDropdownItemsProvider {
 				PortalUtil.getLayoutFullURL(_draftLayout, _themeDisplay),
 				"p_l_back_url", _themeDisplay.getURLCurrent(),
 				"p_l_back_url_title", portletDisplay.getPortletDisplayName(),
-				"p_l_mode", Constants.EDIT);
+				"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+				"true");
 
 			if (!_existsMappedContentType && (count > 0)) {
 				dropdownItem.setDisabled(true);

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateEntryActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateEntryActionDropdownItemsProvider.java
@@ -25,6 +25,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
@@ -359,7 +360,8 @@ public class LayoutPageTemplateEntryActionDropdownItemsProvider {
 					PortalUtil.getLayoutFullURL(_draftLayout, _themeDisplay),
 					"p_l_back_url", _themeDisplay.getURLCurrent(),
 					"p_l_back_url_title", portletDisplay.getTitle(), "p_l_mode",
-					Constants.EDIT));
+					Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+					"true"));
 			dropdownItem.setIcon("pencil");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "edit"));

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
@@ -23,6 +23,7 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
@@ -345,7 +346,8 @@ public class MasterLayoutActionDropdownItemsProvider {
 					"p_l_back_url", _themeDisplay.getURLCurrent(),
 					"p_l_back_url_title",
 					portletDisplay.getPortletDisplayName(), "p_l_mode",
-					Constants.EDIT));
+					Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+					"true"));
 			dropdownItem.setIcon("pencil");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "edit"));

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
@@ -1518,6 +1518,13 @@ public class LayoutStructureRenderer {
 				ParamUtil.getString(
 					PortalUtil.getOriginalServletRequest(_httpServletRequest),
 					"p_l_mode", Constants.VIEW)));
+		jspWriter.write(
+			"\"><input name=\"p_l_csp_disabled\" type=\"hidden\" value=\"");
+		jspWriter.write(
+			HtmlUtil.escape(
+				ParamUtil.getString(
+					PortalUtil.getOriginalServletRequest(_httpServletRequest),
+					LayoutConstants.PARAM_CSP_DISABLED)));
 		jspWriter.write("\"><input name=\"plid\" type=\"hidden\" value=\"");
 		jspWriter.write(String.valueOf(_themeDisplay.getPlid()));
 		jspWriter.write(

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
@@ -411,8 +411,9 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 				draftLayout.getName(themeDisplay.getLocale()));
 		}
 
-		layoutFullURL = HttpComponentsUtil.addParameter(
-			layoutFullURL, "p_l_mode", Constants.EDIT);
+		layoutFullURL = HttpComponentsUtil.addParameters(
+			layoutFullURL, "p_l_mode", Constants.EDIT,
+			LayoutConstants.PARAM_CSP_DISABLED, "true");
 
 		long segmentsExperienceId = ParamUtil.getLong(
 			httpServletRequest, "segmentsExperienceId", -1);

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/product/navigation/control/menu/EditLayoutModeProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/product/navigation/control/menu/EditLayoutModeProductNavigationControlMenuEntry.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutTypeController;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
@@ -251,7 +252,8 @@ public class EditLayoutModeProductNavigationControlMenuEntry
 				httpServletRequest, layout,
 				_portal.getLayoutFullURL(layout, themeDisplay)),
 			"p_l_back_url_title", layout.getName(themeDisplay.getLocale()),
-			"p_l_mode", Constants.EDIT);
+			"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+			"true");
 
 		return _addSegmentsExperienceId(httpServletRequest, layout, redirect);
 	}

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/display/context/EditDisplayPageMenuDisplayContext.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/display/context/EditDisplayPageMenuDisplayContext.java
@@ -12,6 +12,7 @@ import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.constants.LayoutDisplayPageWebKeys;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
@@ -67,7 +68,8 @@ public class EditDisplayPageMenuDisplayContext {
 						"p_l_back_url_title",
 						_layoutDisplayPageObjectProvider.getTitle(
 							_themeDisplay.getLocale()),
-						"p_l_mode", Constants.EDIT));
+						"p_l_mode", Constants.EDIT,
+						LayoutConstants.PARAM_CSP_DISABLED, "true"));
 
 				dropdownItem.setLabel(
 					LanguageUtil.get(

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-utility/src/main/java/com/liferay/layout/type/controller/utility/internal/layout/type/controller/UtilityLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-utility/src/main/java/com/liferay/layout/type/controller/utility/internal/layout/type/controller/UtilityLayoutTypeController.java
@@ -278,8 +278,9 @@ public class UtilityLayoutTypeController extends BaseLayoutTypeControllerImpl {
 				draftLayout.getName(themeDisplay.getLocale()));
 		}
 
-		return HttpComponentsUtil.addParameter(
-			layoutFullURL, "p_l_mode", Constants.EDIT);
+		return HttpComponentsUtil.addParameters(
+			layoutFullURL, "p_l_mode", Constants.EDIT,
+			LayoutConstants.PARAM_CSP_DISABLED, "true");
 	}
 
 	private boolean _hasUpdatePermissions(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
@@ -263,7 +264,8 @@ public class ObjectEntryAssetRenderer
 				GroupConstants.CMS_FRIENDLY_URL,
 				"/edit_content_item?objectEntryId=",
 				_objectEntry.getObjectEntryId(), "&p_l_mode=", Constants.EDIT,
-				"&redirect=", portletURL);
+				"&", LayoutConstants.PARAM_CSP_DISABLED, "=true&redirect=",
+				portletURL);
 		}
 
 		return StringBundler.concat(

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -5,15 +5,25 @@
 
 package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.security.content.security.policy.internal.ContentSecurityPolicyNonceManager;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfigurationUtil;
@@ -71,7 +81,8 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		if (!contentSecurityPolicyConfiguration.enabled() ||
 			Validator.isNull(contentSecurityPolicyConfiguration.policy()) ||
 			_isExcludedURIPath(
-				contentSecurityPolicyConfiguration, httpServletRequest)) {
+				contentSecurityPolicyConfiguration, httpServletRequest) ||
+			_isAuthorizedLayoutEditMode(httpServletRequest)) {
 
 			return false;
 		}
@@ -114,6 +125,125 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		}
 		finally {
 			_contentSecurityPolicyNonceManager.cleanUpNonce(httpServletRequest);
+		}
+	}
+
+	private String _getFriendlyURL(HttpServletRequest httpServletRequest) {
+		String requestURI = httpServletRequest.getRequestURI();
+
+		if (Validator.isNull(requestURI)) {
+			return null;
+		}
+
+		// Trim anything before the friendly URL servlet mapping (for example an
+		// i18n language path like "/en") so the URL can be resolved on a
+		// localized request and so the "/web/<group>/<layout>" form produced
+		// when a virtual host request is forwarded can be parsed.
+
+		int index = -1;
+
+		for (String mapping :
+				new String[] {
+					_portal.getPathFriendlyURLPublic(),
+					_portal.getPathFriendlyURLPrivateGroup(),
+					_portal.getPathFriendlyURLPrivateUser()
+				}) {
+
+			int i = requestURI.indexOf(mapping + StringPool.SLASH);
+
+			if ((i != -1) && ((index == -1) || (i < index))) {
+				index = i;
+			}
+		}
+
+		if (index == -1) {
+			return null;
+		}
+
+		return requestURI.substring(index);
+	}
+
+	private PermissionChecker _getPermissionChecker(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker != null) {
+			return permissionChecker;
+		}
+
+		User user = _portal.getUser(httpServletRequest);
+
+		if (user == null) {
+			return null;
+		}
+
+		return _permissionCheckerFactory.create(user);
+	}
+
+	private boolean _isAuthorizedLayoutEditMode(
+		HttpServletRequest httpServletRequest) {
+
+		// CSP breaks the layout editor, which uses eval and inline styles via
+		// CKEditor. The layout editor entry points set the reserved
+		// "p_l_csp_disabled" parameter to request the exception explicitly.
+		// Honor it only for a layout the current user is allowed to update, so
+		// that appending the parameter to any URL cannot disable the policy.
+
+		if (!GetterUtil.getBoolean(
+				httpServletRequest.getParameter(
+					LayoutConstants.PARAM_CSP_DISABLED))) {
+
+			return false;
+		}
+
+		Layout layout = (Layout)httpServletRequest.getAttribute(WebKeys.LAYOUT);
+
+		if (layout == null) {
+			String friendlyURL = _getFriendlyURL(httpServletRequest);
+
+			if (friendlyURL == null) {
+
+				// The friendly URL is not resolvable yet (for example a virtual
+				// host request before it is forwarded to its
+				// "/web/<group>/<layout>" form). Defer the decision so a strict
+				// header is not committed on this dispatch; the forwarded
+				// dispatch resolves the layout and makes the final decision.
+
+				return true;
+			}
+
+			long plid = _portal.getPlidFromFriendlyURL(
+				CompanyThreadLocal.getCompanyId(), friendlyURL);
+
+			if (plid != LayoutConstants.DEFAULT_PLID) {
+				layout = _layoutLocalService.fetchLayout(plid);
+			}
+		}
+
+		if (layout == null) {
+			return false;
+		}
+
+		try {
+			PermissionChecker permissionChecker = _getPermissionChecker(
+				httpServletRequest);
+
+			if (permissionChecker == null) {
+				return false;
+			}
+
+			return _layoutPermission.containsLayoutUpdatePermission(
+				permissionChecker, layout);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return false;
 		}
 	}
 
@@ -173,6 +303,15 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 	@Reference
 	private ContentSecurityPolicyNonceManager
 		_contentSecurityPolicyNonceManager;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPermission _layoutPermission;
+
+	@Reference
+	private PermissionCheckerFactory _permissionCheckerFactory;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -16,7 +15,6 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -128,41 +126,6 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		}
 	}
 
-	private String _getFriendlyURL(HttpServletRequest httpServletRequest) {
-		String requestURI = httpServletRequest.getRequestURI();
-
-		if (Validator.isNull(requestURI)) {
-			return null;
-		}
-
-		// Trim anything before the friendly URL servlet mapping (for example an
-		// i18n language path like "/en") so the URL can be resolved on a
-		// localized request and so the "/web/<group>/<layout>" form produced
-		// when a virtual host request is forwarded can be parsed.
-
-		int index = -1;
-
-		for (String mapping :
-				new String[] {
-					_portal.getPathFriendlyURLPublic(),
-					_portal.getPathFriendlyURLPrivateGroup(),
-					_portal.getPathFriendlyURLPrivateUser()
-				}) {
-
-			int i = requestURI.indexOf(mapping + StringPool.SLASH);
-
-			if ((i != -1) && ((index == -1) || (i < index))) {
-				index = i;
-			}
-		}
-
-		if (index == -1) {
-			return null;
-		}
-
-		return requestURI.substring(index);
-	}
-
 	private PermissionChecker _getPermissionChecker(
 			HttpServletRequest httpServletRequest)
 		throws Exception {
@@ -189,8 +152,9 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		// CSP breaks the layout editor, which uses eval and inline styles via
 		// CKEditor. The layout editor entry points set the reserved
 		// "p_l_csp_disabled" parameter to request the exception explicitly.
-		// Honor it only for a layout the current user is allowed to update, so
-		// that appending the parameter to any URL cannot disable the policy.
+		// Honor it only for a resolved layout the current user is allowed to
+		// update, so that appending the parameter to any URL cannot disable
+		// the policy.
 
 		if (!GetterUtil.getBoolean(
 				httpServletRequest.getParameter(
@@ -200,28 +164,6 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		}
 
 		Layout layout = (Layout)httpServletRequest.getAttribute(WebKeys.LAYOUT);
-
-		if (layout == null) {
-			String friendlyURL = _getFriendlyURL(httpServletRequest);
-
-			if (friendlyURL == null) {
-
-				// The friendly URL is not resolvable yet (for example a virtual
-				// host request before it is forwarded to its
-				// "/web/<group>/<layout>" form). Defer the decision so a strict
-				// header is not committed on this dispatch; the forwarded
-				// dispatch resolves the layout and makes the final decision.
-
-				return true;
-			}
-
-			long plid = _portal.getPlidFromFriendlyURL(
-				CompanyThreadLocal.getCompanyId(), friendlyURL);
-
-			if (plid != LayoutConstants.DEFAULT_PLID) {
-				layout = _layoutLocalService.fetchLayout(plid);
-			}
-		}
 
 		if (layout == null) {
 			return false;
@@ -303,9 +245,6 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 	@Reference
 	private ContentSecurityPolicyNonceManager
 		_contentSecurityPolicyNonceManager;
-
-	@Reference
-	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private LayoutPermission _layoutPermission;

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -91,9 +91,9 @@ public class ContentSecurityPolicyFilterTest {
 				_isAuthorizedLayoutEditMode(
 					_createHttpServletRequest(true, layout)));
 
-			// The parameter is set but the layout is not resolvable yet
+			// The parameter is set but the layout is not resolved
 
-			Assert.assertTrue(
+			Assert.assertFalse(
 				_isAuthorizedLayoutEditMode(
 					_createHttpServletRequest(true, null)));
 		}

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -5,8 +5,14 @@
 
 package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
 
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -36,6 +42,67 @@ public class ContentSecurityPolicyFilterTest {
 	}
 
 	@Test
+	public void testIsAuthorizedLayoutEditMode() throws Exception {
+		Layout layout = Mockito.mock(Layout.class);
+
+		LayoutPermission layoutPermission = Mockito.mock(
+			LayoutPermission.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_contentSecurityPolicyFilter, "_layoutPermission",
+			layoutPermission);
+
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		PermissionThreadLocal.setPermissionChecker(permissionChecker);
+
+		try {
+
+			// The parameter is not set
+
+			Assert.assertFalse(
+				_isAuthorizedLayoutEditMode(
+					_createHttpServletRequest(false, layout)));
+
+			// The parameter is set for a layout the user can update
+
+			Mockito.when(
+				layoutPermission.containsLayoutUpdatePermission(
+					permissionChecker, layout)
+			).thenReturn(
+				true
+			);
+
+			Assert.assertTrue(
+				_isAuthorizedLayoutEditMode(
+					_createHttpServletRequest(true, layout)));
+
+			// The parameter is set for a layout the user cannot update
+
+			Mockito.when(
+				layoutPermission.containsLayoutUpdatePermission(
+					permissionChecker, layout)
+			).thenReturn(
+				false
+			);
+
+			Assert.assertFalse(
+				_isAuthorizedLayoutEditMode(
+					_createHttpServletRequest(true, layout)));
+
+			// The parameter is set but the layout is not resolvable yet
+
+			Assert.assertTrue(
+				_isAuthorizedLayoutEditMode(
+					_createHttpServletRequest(true, null)));
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(null);
+		}
+	}
+
+	@Test
 	public void testIsExcludedURIPath() {
 		_testIsExcludedURIPath(
 			new String[] {"/group"}, false, null, "/c/portal/layout");
@@ -48,6 +115,35 @@ public class ContentSecurityPolicyFilterTest {
 		_testIsExcludedURIPath(
 			new String[] {"/group"}, true, null, "/group/guest/home");
 		_testIsExcludedURIPath(new String[0], true, null, "/GROUP/guest/home");
+	}
+
+	private HttpServletRequest _createHttpServletRequest(
+		boolean contentSecurityPolicyDisabled, Layout layout) {
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getParameter(LayoutConstants.PARAM_CSP_DISABLED)
+		).thenReturn(
+			contentSecurityPolicyDisabled ? "true" : null
+		);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(WebKeys.LAYOUT)
+		).thenReturn(
+			layout
+		);
+
+		return httpServletRequest;
+	}
+
+	private boolean _isAuthorizedLayoutEditMode(
+		HttpServletRequest httpServletRequest) {
+
+		return (boolean)ReflectionTestUtil.invoke(
+			_contentSecurityPolicyFilter, "_isAuthorizedLayoutEditMode",
+			new Class<?>[] {HttpServletRequest.class}, httpServletRequest);
 	}
 
 	private void _testIsExcludedURIPath(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -66,6 +66,7 @@ import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
@@ -776,7 +777,8 @@ public class ActionUtil {
 			String editURL = HttpComponentsUtil.addParameters(
 				PortalUtil.getLayoutFullURL(
 					layout.fetchDraftLayout(), themeDisplay),
-				"p_l_mode", Constants.EDIT);
+				"p_l_mode", Constants.EDIT, LayoutConstants.PARAM_CSP_DISABLED,
+				"true");
 
 			String backURL = ParamUtil.getString(httpServletRequest, "backURL");
 

--- a/modules/apps/site/site-dsr-site-initializer/src/main/java/com/liferay/site/dsr/site/initializer/internal/struts/ViewRoomStrutsAction.java
+++ b/modules/apps/site/site-dsr-site-initializer/src/main/java/com/liferay/site/dsr/site/initializer/internal/struts/ViewRoomStrutsAction.java
@@ -11,6 +11,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -125,7 +126,8 @@ public class ViewRoomStrutsAction implements StrutsAction {
 			httpServletResponse.sendRedirect(
 				StringBundler.concat(
 					groupFriendlyURL, "?p_l_back_url=", groupFriendlyURL,
-					"&p_l_mode=edit"));
+					"&p_l_mode=edit&", LayoutConstants.PARAM_CSP_DISABLED,
+					"=true"));
 		}
 		else {
 			httpServletResponse.sendRedirect(groupFriendlyURL);

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/GetDataMVCResourceCommand.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/GetDataMVCResourceCommand.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.PortletURLFactory;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
@@ -314,7 +315,8 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 
 		return HttpComponentsUtil.addParameters(
 			redirect, "p_l_back_url", backURL, "p_l_back_url_title",
-			backURLTitle, "p_l_mode", Constants.EDIT, "redirect", redirect);
+			backURLTitle, "p_l_mode", Constants.EDIT,
+			LayoutConstants.PARAM_CSP_DISABLED, "true", "redirect", redirect);
 	}
 
 	private long _getLiveGroupId(long groupId) throws Exception {

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLFactory;
@@ -297,6 +298,8 @@ public class SegmentsExperimentProductNavigationControlMenuEntry
 
 		layoutFullURL = HttpComponentsUtil.setParameter(
 			layoutFullURL, "p_l_mode", Constants.EDIT);
+		layoutFullURL = HttpComponentsUtil.setParameter(
+			layoutFullURL, LayoutConstants.PARAM_CSP_DISABLED, "true");
 		layoutFullURL = HttpComponentsUtil.setParameter(
 			layoutFullURL, "redirect", layoutFullURL);
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -460,6 +460,7 @@ public class PortalImpl implements Portal {
 
 		_reservedParams.add("p_l_back_url");
 		_reservedParams.add("p_l_back_url_title");
+		_reservedParams.add(LayoutConstants.PARAM_CSP_DISABLED);
 		_reservedParams.add("p_l_id");
 		_reservedParams.add("p_l_mode");
 		_reservedParams.add("p_l_reset");

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutConstants.java
@@ -30,6 +30,8 @@ public class LayoutConstants {
 
 	public static final String NAME_CONTROL_PANEL_DEFAULT = "Control Panel";
 
+	public static final String PARAM_CSP_DISABLED = "p_l_csp_disabled";
+
 	public static final String TYPE_ASSET_DISPLAY = "asset_display";
 
 	public static final String TYPE_CONTENT = "content";

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 51.0.0
+version 51.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94267

## What Is Being Fixed

When CSP is enabled, editing a page throws CSP errors in the browser console because the layout editor uses CKEditor 4, which relies on `eval` and inline styles the policy blocks. An edit-mode render of a layout served outside the `/web/`, `/group/`, `/user/` path exclusions (for example a virtual-host or root-served site page) still has CSP enforced, so the editor breaks there.

## How It Is Being Fixed

This is the **explicit-parameter (fan-out) approach**, per @brianchandotcom's review of the earlier heuristic version: instead of the CSP filter inferring the editor from `p_l_mode=edit`, the layout editor entry points declare the exception explicitly.

- A new reserved request parameter `LayoutConstants.PARAM_CSP_DISABLED` (`p_l_csp_disabled`), registered in `PortalImpl` and `create_portlet_url.es.js` so it propagates like `p_l_mode`.
- Every layout-editor entry point (control-menu Edit, Site Pages / page-template / display-page / master / utility admin actions, content-page-editor, segments, CMS/DSR site initializers, object entry) sets `p_l_csp_disabled=true` on its edit-mode URL. Preview/history paths are intentionally excluded.
- `ContentSecurityPolicyFilter._isAuthorizedLayoutEditMode` honors the parameter only for a layout the current user may update, so appending it to any URL cannot disable the policy.

An alternative, contained implementation (a single filter-side helper keyed on `p_l_mode=edit` + permission, no fan-out) is on branch `LPD-94267-3` / draft PR liferay-frontend#5639. This PR is the fan-out counterpart for comparison.

## PR Check

**pr-check: PASS** — tested on `0b627d09d1d7a2ec040fd2881912fdc78c1711a7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

Runtime-verified on a running bundle: editor entry URLs carry `p_l_csp_disabled=true`; with CSP enabled, an authorized edit-mode render has the CSP header suppressed while an anonymous request with the same parameter keeps CSP enforced.

<!-- pr-check {"result": "success", "sha": "0b627d09d1d7a2ec040fd2881912fdc78c1711a7"} -->
