### PR TITLE
LPD-98855 Fix video insertion via Item Selector in CKEditor 5

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
@@ -161,21 +161,22 @@ class ItemSelector extends Plugin {
 								folderMemory.remember(folderId);
 							}
 
-							let url: string;
+							let html: string | undefined;
+							let url: string | undefined;
 
 							try {
-								url = JSON.parse(value).url;
+								({html, url} = JSON.parse(value));
 							}
 							catch (error) {
-								url = value.url;
+								({html, url} = value);
 							}
 
-							if (!url) {
+							if (!html && !url) {
 								return;
 							}
 
 							const viewFragment = editor.data.processor.toView(
-								`<oembed url="${url}"></oembed>`
+								html || `<oembed url="${url}"></oembed>`
 							);
 
 							const modelFragment =


### PR DESCRIPTION
# What is this trying to solve?

[LPD-98855](https://liferay.atlassian.net/browse/LPD-98855) | [LPP-64860](https://liferay.atlassian.net/browse/LPP-64860)

When editing a Web Content article in CKEditor 5, users can click a "video" button to open the Documents and Media file picker and insert a previously uploaded video. Doing this does nothing — no video, no error, the editor just stays empty. The only way to get a video into the article is to manually type the raw HTML `<video>` tag into CKEditor's Source view, which is not something a normal user would know to do.

# How am I fixing it?

When a video is selected from the picker, the portal server sends back the picked file's info as data, including two pieces: a ready-to-use HTML snippet for embedding the video, and (only in some cases) a plain link URL. The editor's code was written to only ever look at the plain link URL and ignore the ready-to-use HTML snippet. For a normal uploaded video, that plain link URL is always empty, so the code always gave up before inserting anything. The HTML snippet — the piece that actually contains the video — was sitting right there in the response and simply never used.

One file changed:

1. `ItemSelector.tsx` — the code that runs after a video is selected now uses that ready-to-use HTML snippet to insert the video into the article. It only falls back to the old link-URL approach in the one case where there genuinely is no HTML snippet to use (an externally-linked video, like a pasted YouTube URL, instead of an uploaded file).

# How can you verify that it works?

1. Upload a video file (e.g. an `.mp4`) to Documents and Media.
2. Go to Content & Data → Web Content and create a new Basic Web Content article.
3. In the rich text editor, click the video button to open the Documents and Media picker.
4. Select the video you uploaded.
5. The video should now appear in the article (before this fix, nothing appeared).
6. Publish the article and confirm the video plays back correctly on the page.
