### PR TITLE
LPD-97861 Apply audience variations by Analytics Cloud segment

### DIFF
--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/attributes/segment.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/attributes/segment.ts
@@ -3,6 +3,126 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export function getSegment(acSegments: Set<string>): Set<string> {
-	return acSegments;
+import {log} from '../../log';
+
+declare const Analytics: any;
+
+const AC_SEGMENTS_SESSION_STORAGE_KEY = 'liferay.audiences.acSegments';
+
+const ANALYTICS_WAIT_INTERVAL = 100;
+
+const ANALYTICS_WAIT_TIMEOUT = 10000;
+
+let acSegmentsRequest: Promise<void> | undefined;
+
+export function getSegment(): Set<string> {
+	const cachedAcSegments = readAcSegmentsCache();
+
+	if (cachedAcSegments === undefined) {
+		requestAcSegments();
+
+		return new Set();
+	}
+
+	return cachedAcSegments;
+}
+
+function getCurrentUserId(): string {
+	return Liferay.ThemeDisplay.getUserId();
+}
+
+function readAcSegmentsCache(): Set<string> | undefined {
+	try {
+		const value = sessionStorage.getItem(AC_SEGMENTS_SESSION_STORAGE_KEY);
+
+		if (value === null) {
+			return undefined;
+		}
+
+		const {segments, userId} = JSON.parse(value);
+
+		if (userId !== getCurrentUserId()) {
+			return undefined;
+		}
+
+		return new Set(segments);
+	}
+	catch (error: any) {
+		log(
+			`Unable to read the cached Analytics Cloud segments: ${
+				error.message || error
+			}`
+		);
+
+		return undefined;
+	}
+}
+
+function requestAcSegments(): void {
+	if (acSegmentsRequest !== undefined) {
+		return;
+	}
+
+	acSegmentsRequest = (async () => {
+		await waitForAnalytics();
+
+		const acSegments: Set<string> = new Set();
+
+		for (const segment of await Analytics.segment.getBatchSegmentExternalReferenceCodes()) {
+			acSegments.add(segment);
+		}
+
+		for (const segment of await Analytics.segment.getRealTimeSegmentExternalReferenceCodes()) {
+			acSegments.add(segment);
+		}
+
+		writeAcSegmentsCache(acSegments);
+	})()
+		.catch((error: any) => {
+			log(
+				`Unable to fetch the Analytics Cloud segments: ${
+					error.message || error
+				}`
+			);
+		})
+		.finally(() => {
+			acSegmentsRequest = undefined;
+		});
+}
+
+async function waitForAnalytics(): Promise<void> {
+	let elapsed = 0;
+
+	while (typeof Analytics === 'undefined') {
+		if (elapsed >= ANALYTICS_WAIT_TIMEOUT) {
+			throw new Error(
+				`Unable to get Analytics Cloud segments because 'Analytics' global object is missing`
+			);
+		}
+
+		await new Promise((resolve) =>
+			setTimeout(resolve, ANALYTICS_WAIT_INTERVAL)
+		);
+
+		elapsed += ANALYTICS_WAIT_INTERVAL;
+	}
+}
+
+function writeAcSegmentsCache(acSegments: Set<string>): void {
+	try {
+		sessionStorage.setItem(
+			AC_SEGMENTS_SESSION_STORAGE_KEY,
+			JSON.stringify({
+				segments: [...acSegments],
+				userId: getCurrentUserId(),
+			})
+		);
+	}
+	catch (error: any) {
+		log(
+			`Unable to cache the Analytics Cloud segments: ${
+				error.message || error
+			}`
+		);
+	}
 }

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/index.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/index.ts
@@ -41,8 +41,6 @@ import type {
 	Rule,
 } from '../index';
 
-declare const Analytics: any;
-
 type AttributeValue = Set<string> | boolean | number | string;
 
 interface OperatorImpl {
@@ -79,30 +77,6 @@ export class Detection {
 		}
 
 		return matches;
-	}
-
-	private async _getAcSegments() {
-		if (this._acSegments === undefined) {
-			if (typeof Analytics === 'undefined') {
-				throw new Error(
-					`Unable to get Analytics Cloud segments because 'Analytics' global object is missing`
-				);
-			}
-
-			const set: Set<string> = new Set();
-
-			for (const segment of await Analytics.segment.getBatchSegmentExternalReferenceCodes()) {
-				set.add(segment);
-			}
-
-			for (const segment of await Analytics.segment.getRealTimeSegmentExternalReferenceCodes()) {
-				set.add(segment);
-			}
-
-			this._acSegments = set;
-		}
-
-		return this._acSegments;
 	}
 
 	private async _getAttribute(attr: Attribute): Promise<AttributeValue> {
@@ -143,7 +117,7 @@ export class Detection {
 			return getRequestParameters();
 		}
 		else if (attr === 'segment') {
-			return getSegment(await this._getAcSegments());
+			return getSegment();
 		}
 		else if (attr === 'timezone') {
 			return getTimezone();

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/operators/eq.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/operators/eq.ts
@@ -5,11 +5,19 @@
 
 import {checkTypes} from '../util';
 
-export function eq<T extends boolean | number | string>(
-	value: T,
-	expected: T
+export function eq(
+	value: Set<string> | boolean | number | string,
+	expected: boolean | number | string
 ): boolean {
-	checkTypes(value, ['boolean', 'number', 'string'], `Operator 'eq' value`);
+	checkTypes(
+		value,
+		['Set', 'boolean', 'number', 'string'],
+		`Operator 'eq' value`
+	);
+
+	if (value instanceof Set) {
+		return value.has(expected as string);
+	}
 
 	return value === expected;
 }

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/operators/not_eq.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/operators/not_eq.ts
@@ -5,15 +5,19 @@
 
 import {checkTypes} from '../util';
 
-export function notEq<T extends boolean | number | string>(
-	value: T,
-	expected: T
+export function notEq(
+	value: Set<string> | boolean | number | string,
+	expected: boolean | number | string
 ): boolean {
 	checkTypes(
 		value,
-		['boolean', 'number', 'string'],
+		['Set', 'boolean', 'number', 'string'],
 		`Operator 'not_eq' value`
 	);
+
+	if (value instanceof Set) {
+		return !value.has(expected as string);
+	}
 
 	return value !== expected;
 }

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/attributes.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/attributes.test.ts
@@ -35,6 +35,8 @@ describe('attributes', () => {
 
 		delete (navigator as any).userAgent;
 
+		sessionStorage.clear();
+
 		window.history.replaceState({}, '', '/');
 	});
 
@@ -254,10 +256,16 @@ describe('attributes', () => {
 	});
 
 	describe('attribute segment', () => {
-		it('works and returns a Set<string>', async () => {
-			const value = getSegment(
-				new Set(['SEGMENT_BATCH', 'SEGMENT_REAL_TIME'])
+		it('returns the segments cached for the current user', async () => {
+			sessionStorage.setItem(
+				'liferay.audiences.acSegments',
+				JSON.stringify({
+					segments: ['SEGMENT_BATCH', 'SEGMENT_REAL_TIME'],
+					userId: '20164',
+				})
 			);
+
+			const value = getSegment();
 
 			expect(value).toBeInstanceOf(Set);
 			expect(value).toEqual(

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/detection.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/detection.test.ts
@@ -395,7 +395,7 @@ describe('detection', () => {
 
 			mockAudiencesDefinitionWithAttribute(
 				'segment',
-				'includes',
+				'eq',
 				'SEGMENT_REAL_TIME'
 			);
 
@@ -415,7 +415,7 @@ describe('detection', () => {
 
 			mockAudiencesDefinitionWithAttribute(
 				'segment',
-				'includes',
+				'eq',
 				'NON_EXISTENT_SEGMENT'
 			);
 
@@ -437,7 +437,7 @@ describe('detection', () => {
 
 			mockAudiencesDefinitionWithAttribute(
 				'segment',
-				'includes',
+				'eq',
 				'SEGMENT_REAL_TIME'
 			);
 
@@ -451,7 +451,7 @@ describe('detection', () => {
 
 			mockAudiencesDefinitionWithAttribute(
 				'segment',
-				'includes',
+				'eq',
 				'SEGMENT_REAL_TIME'
 			);
 

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/detection.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/detection.test.ts
@@ -68,6 +68,8 @@ describe('detection', () => {
 
 		delete (navigator as any).userAgent;
 
+		sessionStorage.clear();
+
 		window.history.replaceState({}, '', '/');
 
 		audiences.clear();
@@ -382,7 +384,15 @@ describe('detection', () => {
 	});
 
 	describe('attribute segment', () => {
-		it('positive test', async () => {
+		it('applies variations when a cached segment matches', async () => {
+			sessionStorage.setItem(
+				'liferay.audiences.acSegments',
+				JSON.stringify({
+					segments: ['SEGMENT_REAL_TIME'],
+					userId: '20164',
+				})
+			);
+
 			mockAudiencesDefinitionWithAttribute(
 				'segment',
 				'includes',
@@ -394,11 +404,55 @@ describe('detection', () => {
 			expect(audiences.get()).toEqual(new Set(['the_audience']));
 		});
 
-		it('negative test', async () => {
+		it('shows the default experience when no cached segment matches', async () => {
+			sessionStorage.setItem(
+				'liferay.audiences.acSegments',
+				JSON.stringify({
+					segments: ['SEGMENT_REAL_TIME'],
+					userId: '20164',
+				})
+			);
+
 			mockAudiencesDefinitionWithAttribute(
 				'segment',
 				'includes',
 				'NON_EXISTENT_SEGMENT'
+			);
+
+			await audiences.runDetection(URL);
+
+			expect(audiences.get()).toEqual(new Set());
+		});
+
+		it('ignores segments cached for a different user', async () => {
+			delete (global as any).Analytics;
+
+			sessionStorage.setItem(
+				'liferay.audiences.acSegments',
+				JSON.stringify({
+					segments: ['SEGMENT_REAL_TIME'],
+					userId: '10000',
+				})
+			);
+
+			mockAudiencesDefinitionWithAttribute(
+				'segment',
+				'includes',
+				'SEGMENT_REAL_TIME'
+			);
+
+			await audiences.runDetection(URL);
+
+			expect(audiences.get()).toEqual(new Set());
+		});
+
+		it('shows the default experience on the first visit, before the segments are cached', async () => {
+			delete (global as any).Analytics;
+
+			mockAudiencesDefinitionWithAttribute(
+				'segment',
+				'includes',
+				'SEGMENT_REAL_TIME'
 			);
 
 			await audiences.runDetection(URL);

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/operators.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/operators.test.ts
@@ -13,7 +13,7 @@ import {notEq} from '../src/main/resources/META-INF/resources/main/detection/ope
 import {notIncludes} from '../src/main/resources/META-INF/resources/main/detection/operators/not_includes';
 
 describe('operators', () => {
-	it('operator eq works with boolean, string and number, fails for Set', async () => {
+	it('operator eq works with boolean, string, number and Set', async () => {
 		expect(eq('a', 'a')).toBe(true);
 		expect(eq('a', 'b')).toBe(false);
 
@@ -23,7 +23,10 @@ describe('operators', () => {
 		expect(eq(true, true)).toBe(true);
 		expect(eq(true, false)).toBe(false);
 
-		expect(() => eq(new Set(['a']) as any, new Set(['a']))).toThrow();
+		expect(eq(new Set(['a', 'b']), 'a')).toBe(true);
+		expect(eq(new Set(['a', 'b']), 'c')).toBe(false);
+
+		expect(() => eq({} as any, 'a' as any)).toThrow();
 	});
 
 	it('operator gt works with string and number, fails for Set', async () => {
@@ -80,7 +83,7 @@ describe('operators', () => {
 		expect(() => lte(new Set(['a']) as any, new Set(['a']))).toThrow();
 	});
 
-	it('operator not_eq works with boolean, string and number, fails for Set', async () => {
+	it('operator not_eq works with boolean, string, number and Set', async () => {
 		expect(notEq('a', 'b')).toBe(true);
 		expect(notEq('a', 'a')).toBe(false);
 
@@ -90,7 +93,10 @@ describe('operators', () => {
 		expect(notEq(true, false)).toBe(true);
 		expect(notEq(true, true)).toBe(false);
 
-		expect(() => notEq(new Set(['a']) as any, new Set(['a']))).toThrow();
+		expect(notEq(new Set(['a', 'b']), 'c')).toBe(true);
+		expect(notEq(new Set(['a', 'b']), 'a')).toBe(false);
+
+		expect(() => notEq({} as any, 'a' as any)).toThrow();
 	});
 
 	it('operator not_includes works with string and Set, fails for number', async () => {

--- a/modules/frontend-sdk/node-scripts/package.json
+++ b/modules/frontend-sdk/node-scripts/package.json
@@ -4,7 +4,7 @@
 		"node-scripts": "./bin.js"
 	},
 	"com.liferay": {
-		"sha256": "1c5c7196a14118d213bec19c8d72baa1ee6ef3e294c2ec41b003bb248b35a8a1"
+		"sha256": "9e0a1c7faedf56349cbe1cba52961ec00d56235c44ffc86c3532feb9b08b246a"
 	},
 	"dependencies": {
 		"@babel/preset-env": "7.24.7",

--- a/modules/frontend-sdk/node-scripts/util/jest/mocks/Liferay.js
+++ b/modules/frontend-sdk/node-scripts/util/jest/mocks/Liferay.js
@@ -300,6 +300,8 @@ const ThemeDisplay = {
 
 	getScopeGroupId: jest.fn(() => '20126'),
 
+	getUserId: jest.fn(() => '20164'),
+
 	isSignedIn: jest.fn(() => true),
 };
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97861

## What Is Being Fixed

Audiences can target visitors by their Analytics Cloud (AC) segment, but applying those variations relied on the AC client SDK responding while the page rendered. AC responses are slow, so variations landed late and the visitor saw the content flicker as the page changed under them. In addition, the segment rule is evaluated against the set of segments the visitor belongs to, but the runtime `eq`/`not_eq` operators only accepted scalar values and threw on a `Set`, which aborted all audience detection for any page using a segment rule.

## How It Is Being Fixed

Segment resolution is now non-blocking and cache-first. On a visitor's first visit the runtime warms a `sessionStorage` cache from AC in the background and shows the default experience, so nothing flickers; on subsequent visits it reads the cached segments and applies the matching variations immediately. The cache is keyed to the current user, so switching users discards the previous user's segments rather than applying them.

The audience criteria key was renamed to `segment`, and its runtime lookup returns the set of external reference codes for the segments the visitor belongs to. To evaluate an "Is / Is not `<segment>`" rule against that set, the `eq` and `not_eq` operators were made `Set`-aware — treating the comparison as membership when the value is a `Set` — which aligns the runtime with the operator the editor now emits.

## PR Check

**pr-check: PASS** — tested on `316cf8a9f11b6ad056fdd8a23588024c9e767a68`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "316cf8a9f11b6ad056fdd8a23588024c9e767a68"} -->
