### PR TITLE
LPD-94267 Apply the CSP nonce to scripts recreated by legacy AUI

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/aui_sandbox.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/aui_sandbox.js
@@ -13,6 +13,56 @@
 		ALLOY.html5shiv();
 	}
 
+	const applyCSPNonce = function (Y) {
+		const nonce =
+			(window.Liferay && Liferay.CSP && Liferay.CSP.nonce) || '';
+
+		// Remote scripts recreated by Y.Get. Adding the nonce to the default
+		// node attributes stamps it on every script and link Y.Get inserts.
+
+		if (nonce && Y.Get && Y.Get.options && Y.Get.options.attributes) {
+			Y.Get.options.attributes.nonce = nonce;
+		}
+
+		// Inline scripts recreated by ParseContent.globalEval.
+
+		const ParseContent = Y.Plugin && Y.Plugin.ParseContent;
+
+		if (!ParseContent || ParseContent.prototype._cspNonceApplied) {
+			return;
+		}
+
+		ParseContent.prototype.globalEval = function (data) {
+			if (typeof data === 'string') {
+				data = {
+					text: data,
+					type: 'text/javascript',
+				};
+			}
+
+			const doc = Y.getDoc();
+			const head = doc.one('head') || doc.get('documentElement');
+
+			const newScript = Y.config.doc.createElement('script');
+
+			newScript.type = data.type;
+
+			if (window.Liferay && Liferay.CSP && Liferay.CSP.nonce) {
+				newScript.setAttribute('nonce', Liferay.CSP.nonce);
+			}
+
+			if (data.text) {
+				newScript.text = Y.Lang.trim(data.text);
+			}
+
+			// Removes the script node immediately after executing it
+
+			head.appendChild(newScript).remove();
+		};
+
+		ParseContent.prototype._cspNonceApplied = true;
+	};
+
 	const originalUse = ALLOY.use;
 
 	ALLOY.use = function () {
@@ -23,7 +73,9 @@
 		const originalCallback = args[args.length - 1];
 
 		if (typeof originalCallback === 'function') {
-			args[args.length - 1] = function () {
+			args[args.length - 1] = function (Y) {
+				applyCSPNonce(Y);
+
 				if (Liferay.currentURL === currentURL) {
 					originalCallback.apply(this, arguments);
 				}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94267

## What Is Being Fixed

When a Content Security Policy with a script-src nonce is enforced, the legacy AUI ParseContent plugin executes scripts found in injected markup by recreating them — inline scripts via document.createElement in globalEval, and remote scripts via Y.Get. The recreated script nodes lack the document nonce, so the browser blocks them (script-src-elem violations), for example when a page editor widget re-renders after a configuration save.

## How It Is Being Fixed

The always-loaded aui_sandbox.js wraps the AUI use() callback to stamp Liferay.CSP.nonce on both script-recreation paths: it overrides ParseContent.globalEval to set the nonce on the inline script element it builds, and it adds the nonce to Y.Get's default node attributes so every script Y.Get inserts carries it. This mirrors the modern runScriptsInElement handling, so AUI-injected scripts run under CSP instead of being blocked.

## Why Are There No Tests?

This change makes scripts that the legacy AUI stack recreates at runtime carry the document CSP nonce. Exercising it requires a live document nonce and an enforced Content Security Policy in a real browser; frontend-js-aui-web ships vendored AUI with no jest harness, so there is no unit-test layer to hook into. The behavior was verified end to end at runtime under an enforced nonce policy: AUI-injected inline scripts execute with no CSP violations, remote scripts loaded through Y.Get carry the document nonce, and an unnonced control script is blocked.

## PR Check

**pr-check: PASS** — tested on `effb33939273cfb5be7fa13e795ddc89fc1d17cf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | N/A — module has no JS test suite |

<!-- pr-check {"result": "success", "sha": "effb33939273cfb5be7fa13e795ddc89fc1d17cf"} -->
