### PR TITLE
LPD-99228 Prevent AlloyEditor from loading when CKEditor 5 is enabled

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/init.jsp
@@ -25,6 +25,7 @@ page import="com.liferay.layout.content.page.editor.web.internal.display.context
 page import="com.liferay.layout.content.page.editor.web.internal.display.context.EditCollectionConfigurationDisplayContext" %><%@
 page import="com.liferay.layout.content.page.editor.web.internal.display.context.EditElementVariationsDisplayContext" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
+page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/view.jsp
@@ -13,9 +13,11 @@ ContentPageEditorDisplayContext contentPageEditorDisplayContext = (ContentPageEd
 Group group = themeDisplay.getScopeGroup();
 %>
 
-<liferay-editor:resources
-	editorName="alloyeditor"
-/>
+<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPD-11235") %>'>
+	<liferay-editor:resources
+		editorName="alloyeditor"
+	/>
+</c:if>
 
 <liferay-util:html-top>
 	<aui:link hashedFile="<%= true %>" href="layout-content-page-editor-web/page_editor/app/components/App.css" rel="stylesheet" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99228

## What Is Being Fixed

The Content Page editor loads both CKEditor 4 and CKEditor 5. Its main view (view.jsp) includes the AlloyEditor resources unconditionally, so ckeditor.js — CKEditor 4, which AlloyEditor is built on — is injected on every page editor render even though CKEditor 5 is the active editor. With a Content Security Policy enabled, CKEditor 4's lack of CSP support surfaces as console errors pointing at ckeditor.js.

## How It Is Being Fixed

Gate the AlloyEditor resources include on the LPD-11235 feature flag, matching how the page editor's text, rich-text, link, action, and comment consumers already select their editor. On this line LPD-11235 is a deprecation flag — CKEditor 5 is the default and enabling it rolls inline and comment editing back to AlloyEditor — so the include is emitted only when the flag is enabled, the one case where AlloyEditor is actually used. The import lives in init.jsp per the JSP imports convention.

## Why Are There No Tests?

This wraps an existing JSP resource include in the same FeatureFlagManagerUtil.isEnabled("LPD-11235") guard the page editor already uses to select its editor; the module has no unit-test layer for feature-flag-gated JSP dynamic includes. The dual load and its removal were verified at runtime on a running bundle — AlloyEditor/CKEditor 4 no longer loads while CKEditor 5 keeps working, including inline and comment editing — and the JSP compiles cleanly (see JSP Compile below).

## PR Check

**pr-check: PASS** — tested on `d8cbe02e927514aa0576ba5cb76ab76b4f67018e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d8cbe02e927514aa0576ba5cb76ab76b4f67018e"} -->
