### PR TITLE
LPD-98432 Fix stale client extension type cache under change tracking

### DIFF
--- a/modules/apps/client-extension/client-extension-test/build.gradle
+++ b/modules/apps/client-extension/client-extension-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
 	testIntegrationImplementation project(":apps:client-extension:client-extension-api")
 	testIntegrationImplementation project(":apps:client-extension:client-extension-type-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/manager/test/CETManagerImplTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/manager/test/CETManagerImplTest.java
@@ -6,13 +6,17 @@
 package com.liferay.client.extension.type.internal.manager.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.model.ClientExtensionEntry;
 import com.liferay.client.extension.service.ClientExtensionEntryLocalService;
 import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.GlobalCSSCET;
 import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -92,36 +96,51 @@ public class CETManagerImplTest {
 	}
 
 	private void _testGetCETIsRebuiltAfterUpdate() throws Exception {
-		ClientExtensionEntry clientExtensionEntry = _addClientExtensionEntry(
-			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS,
-			"http://" + RandomTestUtil.randomString());
 
-		CET cet1 = _cetManager.getCET(
-			TestPropsValues.getCompanyId(),
-			clientExtensionEntry.getExternalReferenceCode());
+		// Run inside a change tracking collection to verify that the cached
+		// CET is rebuilt even when the entity cache writes to a change
+		// tracking scoped cache instead of the production cache
 
-		String url = "http://" + RandomTestUtil.randomString();
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-		clientExtensionEntry.setTypeSettings(
-			UnicodePropertiesBuilder.create(
-				true
-			).put(
-				"url", url
-			).buildString());
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
 
-		clientExtensionEntry =
-			_clientExtensionEntryLocalService.updateClientExtensionEntry(
-				clientExtensionEntry);
+			ClientExtensionEntry clientExtensionEntry =
+				_addClientExtensionEntry(
+					ClientExtensionEntryConstants.TYPE_GLOBAL_CSS,
+					"http://" + RandomTestUtil.randomString());
 
-		CET cet2 = _cetManager.getCET(
-			TestPropsValues.getCompanyId(),
-			clientExtensionEntry.getExternalReferenceCode());
+			CET cet1 = _cetManager.getCET(
+				TestPropsValues.getCompanyId(),
+				clientExtensionEntry.getExternalReferenceCode());
 
-		Assert.assertNotSame(cet1, cet2);
+			String url = "http://" + RandomTestUtil.randomString();
 
-		GlobalCSSCET globalCSSCET = (GlobalCSSCET)cet2;
+			clientExtensionEntry.setTypeSettings(
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"url", url
+				).buildString());
 
-		Assert.assertEquals(url, globalCSSCET.getURL());
+			clientExtensionEntry =
+				_clientExtensionEntryLocalService.updateClientExtensionEntry(
+					clientExtensionEntry);
+
+			CET cet2 = _cetManager.getCET(
+				TestPropsValues.getCompanyId(),
+				clientExtensionEntry.getExternalReferenceCode());
+
+			Assert.assertNotSame(cet1, cet2);
+
+			GlobalCSSCET globalCSSCET = (GlobalCSSCET)cet2;
+
+			Assert.assertEquals(url, globalCSSCET.getURL());
+		}
 	}
 
 	private void _testGetCETsReturnsOnlyRequestedType() throws Exception {
@@ -191,5 +210,8 @@ public class CETManagerImplTest {
 
 	@Inject
 	private ClientExtensionEntryLocalService _clientExtensionEntryLocalService;
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
 
 }

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/manager/CETManagerImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/manager/CETManagerImpl.java
@@ -186,15 +186,19 @@ public class CETManagerImpl implements CETManager {
 		long clientExtensionEntryId =
 			clientExtensionEntry.getClientExtensionEntryId();
 
-		CET cet = _cets.get(clientExtensionEntryId);
+		CETHolder cetHolder = _cets.get(clientExtensionEntryId);
 
-		if (cet != null) {
-			return cet;
+		if ((cetHolder != null) &&
+			(cetHolder._mvccVersion == clientExtensionEntry.getMvccVersion())) {
+
+			return cetHolder._cet;
 		}
 
-		cet = _cetFactory.create(clientExtensionEntry, true);
+		CET cet = _cetFactory.create(clientExtensionEntry, true);
 
-		_cets.put(clientExtensionEntryId, cet);
+		_cets.put(
+			clientExtensionEntryId,
+			new CETHolder(cet, clientExtensionEntry.getMvccVersion()));
 
 		return cet;
 	}
@@ -352,7 +356,7 @@ public class CETManagerImpl implements CETManager {
 	@Reference
 	private CETFactory _cetFactory;
 
-	private final Map<Long, CET> _cets = new ConcurrentHashMap<>();
+	private final Map<Long, CETHolder> _cets = new ConcurrentHashMap<>();
 	private final Map<Long, Map<String, CET>> _cetsMaps =
 		new ConcurrentHashMap<>();
 
@@ -364,5 +368,17 @@ public class CETManagerImpl implements CETManager {
 
 	private final Map<Long, Map<String, List<ServiceRegistration<?>>>>
 		_serviceRegistrationsMaps = new ConcurrentHashMap<>();
+
+	private static class CETHolder {
+
+		private CETHolder(CET cet, long mvccVersion) {
+			_cet = cet;
+			_mvccVersion = mvccVersion;
+		}
+
+		private final CET _cet;
+		private final long _mvccVersion;
+
+	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98432

## What Is Being Fixed

CETManagerImpl caches each constructed client extension type in a node-local map keyed by client extension entry ID, and relies on a PortalCacheMapSynchronizeUtil listener registered on the ClientExtensionEntry entity cache to evict a cached type when its entry changes. Because ClientExtensionEntry is change tracking enabled, its entity cache is a CTAwarePortalCache. Inside an active change tracking collection (a publication), entity cache reads and writes go to a collection-scoped cache, while the listener is registered on the production cache and never observes those writes. Updating a client extension entry within a publication therefore left the previously built type cached, and getCET kept returning the stale instance until the entry was evicted or expired. The CETManagerImplTest integration test surfaced this only when run inside a change tracking collection — which is how CI exercises it — so it passed locally and failed in CI.

## How It Is Being Fixed

The cached type is now stored together with the mvccVersion of the entry it was built from. getCET compares the freshly fetched entry's mvccVersion against the cached one and rebuilds the type when they differ, so correctness no longer depends on the entity cache listener firing and holds regardless of change tracking or clustering. The entity cache listener stays as a proactive eviction optimization. The rebuild-after-update test is wrapped in a change tracking collection so it reproduces the failure path and guards against regressions.

## PR Check

**pr-check: PASS** — tested on `5e8c14fef71a4df301766f174430ce122d7198be`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5e8c14fef71a4df301766f174430ce122d7198be"} -->
