### PR TITLE
LPD-99548 Fix the sorting test after the Localization screen split

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/sorting.spec.ts
@@ -652,6 +652,10 @@ test('Sorting label in the table is not blank after changing default site langua
 			await globalMenuPage.goToControlPanel('Instance Settings');
 
 			await page.getByRole('link', {name: 'Localization'}).click();
+
+			await page
+				.getByRole('menuitem', {exact: true, name: 'Language'})
+				.click();
 		});
 
 		await test.step('Change default site language to Spanish', async () => {
@@ -701,6 +705,10 @@ test('Sorting label in the table is not blank after changing default site langua
 				await globalMenuPage.goToControlPanel('Instance Settings');
 
 				await page.getByRole('link', {name: 'Localization'}).click();
+
+				await page
+					.getByRole('menuitem', {exact: true, name: 'Language'})
+					.click();
 			});
 
 			await test.step('Change default site language back to English', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99548

## What Is Being Fixed

The Playwright test "Sorting label in the table is not blank after changing default site language" in `modules/test/playwright/tests/frontend-data-set-admin-web/main/sorting.spec.ts` was failing with a 90 second timeout.

Instance Settings → Localization no longer renders a single form. It now renders a vertical nav of four configuration screens (Language Selector, Language, Locale Prepend Friendly URL Style, and Time Zone) and lands on Language Selector, so the Default Language field the test drives is no longer present on the landing screen.

## How It Is Being Fixed

The test now opens the Language screen after reaching Localization, before selecting the default language.

The nav is rendered by `clay:vertical-nav`, which emits each item as an anchor carrying an explicit `role="menuitem"`. That explicit role overrides the implicit link role, so the item has to be located by the menuitem role rather than by the link role, with `exact: true` so it does not collide with Language Selector. The same step was added to the cleanup block in `finally`, which had the same latent problem and would otherwise have left the virtual instance's default language set to Spanish and poisoned later runs.

Verified locally: the target test passes and the full `sorting.spec.ts` suite passes 13 of 13.

## PR Check

**pr-check: PASS** — tested on `376a15b0aa9c6a157948ba7861f9684d9f9ced5b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "376a15b0aa9c6a157948ba7861f9684d9f9ced5b"} -->

