### PR TITLE
LPD-99688 Add an accessible label to the input time taglib

### DIFF
--- a/modules/test/playwright/tests/portal-web/main/html/taglib/liferay-ui/input-time.spec.ts
+++ b/modules/test/playwright/tests/portal-web/main/html/taglib/liferay-ui/input-time.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {isolatedSiteTest} from '../../../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../../../fixtures/loginTest';
+import {journalPagesTest} from '../../../../../journal-web/main/fixtures/journalPagesTest';
+
+const test = mergeTests(isolatedSiteTest, journalPagesTest, loginTest());
+
+test(
+	'Input time tag renders an accessible label on the time input',
+	{
+		tag: '@LPD-99688',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		await test.step('Open a new Basic Web Content', async () => {
+			await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+		});
+
+		await test.step('Check the date-time picker time inputs expose an aria-label', async () => {
+			for (const name of ['expirationDateTime', 'reviewDateTime']) {
+				await expect(
+					page.locator(
+						`#_com_liferay_journal_web_portlet_JournalPortlet_${name}`
+					)
+				).toHaveAttribute('aria-label', 'Time');
+			}
+		});
+	}
+);

--- a/portal-web/docroot/html/taglib/ui/input_time/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_time/page.jsp
@@ -75,79 +75,79 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(_SIMPLE_DATE_FORMA
 </span>
 
 <aui:script use="aui-timepicker-native">
-	Liferay.component(
-		'<%= nameId %>TimePicker',
-		function () {
-			var timePicker = new A.TimePickerNative(
-				{
-					container: '#<%= randomNamespace %>displayTime',
-					on: {
-						enterKey: function(event) {
-							var instance = this;
+	Liferay.component('<%= nameId %>TimePicker', function () {
+		var timePicker = new A.TimePickerNative({
+			container: '#<%= randomNamespace %>displayTime',
+			on: {
+				enterKey: function (event) {
+					var instance = this;
 
-							var inputVal = instance.get('activeInput').val();
+					var inputVal = instance.get('activeInput').val();
 
-							var date = instance.getParsedDatesFromInputValue(inputVal).pop();
+					var date = instance
+						.getParsedDatesFromInputValue(inputVal)
+						.pop();
 
-							instance.updateTime(date);
-						},
-						selectionChange: function(event) {
-							var instance = this;
+					instance.updateTime(date);
+				},
+				selectionChange: function (event) {
+					var instance = this;
 
-							var date = event.newSelection[0];
+					var date = event.newSelection[0];
 
-							instance.updateTime(date);
-						}
-					},
-					trigger: '#<%= nameId %>',
-				}
+					instance.updateTime(date);
+				},
+			},
+			trigger: '#<%= nameId %>',
+		});
+
+		timePicker.getTime = function () {
+			var instance = this;
+
+			var container = instance.get('container');
+
+			var amPm = A.Lang.toInt(container.one('#<%= amPmParamId %>').val());
+			var hours = A.Lang.toInt(container.one('#<%= hourParamId %>').val());
+			var minutes = container.one('#<%= minuteParamId %>').val();
+
+			if (amPm) {
+				hours += 12;
+			}
+
+			var time = A.Date.parse(
+				A.Date.aggregates.T,
+				hours + ':' + minutes + ':0'
 			);
 
-			timePicker.getTime = function () {
-				var instance = this;
+			return time;
+		};
 
-				var container = instance.get('container');
+		timePicker.updateTime = function (date) {
+			var instance = this;
 
-				var amPm = A.Lang.toInt(container.one('#<%= amPmParamId %>').val());
-				var hours = A.Lang.toInt(container.one('#<%= hourParamId %>').val());
-				var minutes = container.one('#<%= minuteParamId %>').val();
+			var container = instance.get('container');
 
-				if (amPm) {
-					hours += 12;
+			var hours = date.getHours();
+
+			var amPm = 0;
+
+			<c:if test="<%= amPm %>">
+				if (hours > 11) {
+					amPm = 1;
+					hours -= 12;
 				}
+			</c:if>
 
-				var time = A.Date.parse(A.Date.aggregates.T, hours + ':' + minutes + ':0');
+			if (date) {
+				container.one('#<%= hourParamId %>').val(hours);
+				container.one('#<%= minuteParamId %>').val(date.getMinutes());
+				container.one('#<%= amPmParamId %>').val(amPm);
+				container.one('#<%= dateParamId %>').val(date);
+			}
+		};
 
-				return time;
-			};
-
-			timePicker.updateTime = function(date) {
-				var instance = this;
-
-				var container = instance.get('container');
-
-				var hours = date.getHours();
-
-				var amPm = 0;
-
-				<c:if test="<%= amPm %>">
-					if (hours > 11) {
-						amPm = 1;
-						hours -= 12;
-					}
-				</c:if>
-
-				if (date) {
-					container.one('#<%= hourParamId %>').val(hours);
-					container.one('#<%= minuteParamId %>').val(date.getMinutes());
-					container.one('#<%= amPmParamId %>').val(amPm);
-					container.one('#<%= dateParamId %>').val(date);
-				}
-			};
-
-			return timePicker;
-		}
-	);
+		return timePicker;
+	});
 
 	Liferay.component('<%= nameId %>TimePicker');
 </aui:script>

--- a/portal-web/docroot/html/taglib/ui/input_time/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_time/page.jsp
@@ -66,7 +66,7 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(_SIMPLE_DATE_FORMA
 %>
 
 <span class="lfr-input-time" id="<%= randomNamespace %>displayTime">
-	<input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" type="time" value="<%= format.format(calendar.getTime()) %>" />
+	<input aria-label="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(request, "time")) %>" <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> class="form-control <%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= namespace + HtmlUtil.escapeAttribute(name) %>" type="time" value="<%= format.format(calendar.getTime()) %>" />
 
 	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= hourParamId %>" name="<%= namespace + HtmlUtil.escapeAttribute(hourParam) %>" type="hidden" value="<%= hourValue %>" />
 	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= minuteParamId %>" name="<%= namespace + HtmlUtil.escapeAttribute(minuteParam) %>" type="hidden" value="<%= minuteValue %>" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99688

## What Is Being Fixed

The time input rendered by the `liferay-ui:input-time` taglib had no accessible name. The `<input type="time">` element carried no label, no `aria-label`, and no associated `<label>` element, so a screen reader announced it with no indication of what the field controls. This surfaced as an accessibility violation on the web content form, where the expiration and review date-time pickers each render one of these inputs.

## How It Is Being Fixed

The taglib's `page.jsp` now renders an `aria-label` on the time input, translated through `LanguageUtil.get(request, "time")` and escaped with `HtmlUtil.escapeAttribute`. Placing the label in the taglib itself means every date-time picker that composes it gains the accessible name without each caller having to supply one. The surrounding `aui:script` block shows up in the diff as reformatted, which is the source formatter normalizing the existing indentation rather than a behavior change.

A Playwright test opens a new Basic Web Content and asserts that the expiration and review date-time pickers both expose the `aria-label`, so the assertion covers the rendered output rather than the JSP source.

## PR Check

**pr-check: PASS** — tested on `fe00a6e6148ab3663b68c97d6be459a78c3b6e53`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |

<!-- pr-check {"result": "success", "sha": "fe00a6e6148ab3663b68c97d6be459a78c3b6e53"} -->
