### PR TITLE
LPD-99359 Fix ERC token resolution on display page templates

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-fragment-web/src/main/java/com/liferay/frontend/data/set/fragment/web/internal/fragment/renderer/FDSFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-fragment-web/src/main/java/com/liferay/frontend/data/set/fragment/web/internal/fragment/renderer/FDSFragmentRenderer.java
@@ -56,6 +56,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
@@ -213,19 +214,24 @@ public class FDSFragmentRenderer implements FragmentRenderer {
 			boolean hasTokens = _hasTokens(
 				externalReferenceCode, httpServletRequest);
 
+			JSONObject apiURLTokenMappingsJSONObject =
+				_getAPIURLTokenMappingsJSONObject(
+					(String)_fragmentEntryConfigurationParser.getFieldValue(
+						configurationJSONObject,
+						fragmentEntryLink.getEditableValuesJSONObject(),
+						fragmentRendererContext.getLocale(),
+						"apiURLTokenMappings"));
+
 			JSONObject tokenResolutionsJSONObject =
 				_getTokenResolutionsJSONObject(
-					_getAPIURLTokenMappingsJSONObject(
-						(String)_fragmentEntryConfigurationParser.getFieldValue(
-							configurationJSONObject,
-							fragmentEntryLink.getEditableValuesJSONObject(),
-							fragmentRendererContext.getLocale(),
-							"apiURLTokenMappings")),
-					externalReferenceCode, httpServletRequest);
+					apiURLTokenMappingsJSONObject, externalReferenceCode,
+					httpServletRequest);
 
-			boolean resolved = _isResolved(
+			Set<String> unresolvedTokenNames = _getUnresolvedTokenNames(
 				externalReferenceCode, httpServletRequest,
 				tokenResolutionsJSONObject);
+
+			boolean resolved = unresolvedTokenNames.isEmpty();
 
 			if (fragmentRendererContext.isEditMode()) {
 				if (hasTokens) {
@@ -243,6 +249,11 @@ public class FDSFragmentRenderer implements FragmentRenderer {
 					printWriter);
 
 				if (hasTokens && !resolved) {
+					Set<String> unresolvedContextTokenNames =
+						_getUnresolvedContextTokenNames(
+							apiURLTokenMappingsJSONObject, httpServletRequest,
+							unresolvedTokenNames);
+
 					_reactRenderer.renderReact(
 						new ComponentDescriptor(
 							"{UnresolvedDataSetPreview} from " +
@@ -253,6 +264,13 @@ public class FDSFragmentRenderer implements FragmentRenderer {
 							_fdsRenderer.getFDSAPIURL(
 								externalReferenceCode, httpServletRequest, true,
 								tokenResolutionsJSONObject)
+						).put(
+							"hasUnmappedTokens",
+							unresolvedTokenNames.size() >
+								unresolvedContextTokenNames.size()
+						).put(
+							"hasUnresolvedContextTokens",
+							!unresolvedContextTokenNames.isEmpty()
 						).build(),
 						httpServletRequest, printWriter);
 				}
@@ -504,6 +522,63 @@ public class FDSFragmentRenderer implements FragmentRenderer {
 		return mappingJSONObject.getString("classPK");
 	}
 
+	private Set<String> _getUnresolvedContextTokenNames(
+		JSONObject apiURLTokenMappingsJSONObject,
+		HttpServletRequest httpServletRequest,
+		Set<String> unresolvedTokenNames) {
+
+		InfoItemReference infoItemReference =
+			(InfoItemReference)httpServletRequest.getAttribute(
+				InfoDisplayWebKeys.INFO_ITEM_REFERENCE);
+
+		if (infoItemReference != null) {
+			return Collections.emptySet();
+		}
+
+		Set<String> unresolvedContextTokenNames = new HashSet<>();
+
+		for (String unresolvedTokenName : unresolvedTokenNames) {
+			JSONObject mappingJSONObject =
+				apiURLTokenMappingsJSONObject.getJSONObject(
+					unresolvedTokenName);
+
+			if (mappingJSONObject == null) {
+				continue;
+			}
+
+			// A token mapped to the page context entity through a field is
+			// fully configured. It stays unresolved only because the page is
+			// being edited without a page context entity.
+
+			if (Objects.equals(
+					mappingJSONObject.getString("mappingMode"), "context") &&
+				Validator.isNotNull(mappingJSONObject.getString("fieldId"))) {
+
+				unresolvedContextTokenNames.add(unresolvedTokenName);
+			}
+		}
+
+		return unresolvedContextTokenNames;
+	}
+
+	private Set<String> _getUnresolvedTokenNames(
+		String externalReferenceCode, HttpServletRequest httpServletRequest,
+		JSONObject tokenResolutionsJSONObject) {
+
+		Set<String> unresolvedTokenNames = new HashSet<>();
+
+		Matcher matcher = _pattern.matcher(
+			_fdsRenderer.getFDSAPIURL(
+				externalReferenceCode, httpServletRequest, true,
+				tokenResolutionsJSONObject));
+
+		while (matcher.find()) {
+			unresolvedTokenNames.add(matcher.group(1));
+		}
+
+		return unresolvedTokenNames;
+	}
+
 	private boolean _hasManualMapping(
 		JSONObject apiURLTokenMappingsJSONObject, String tokenName) {
 
@@ -530,18 +605,6 @@ public class FDSFragmentRenderer implements FragmentRenderer {
 				externalReferenceCode, httpServletRequest, false, null));
 
 		return matcher.find();
-	}
-
-	private boolean _isResolved(
-		String externalReferenceCode, HttpServletRequest httpServletRequest,
-		JSONObject tokenResolutionsJSONObject) {
-
-		Matcher matcher = _pattern.matcher(
-			_fdsRenderer.getFDSAPIURL(
-				externalReferenceCode, httpServletRequest, true,
-				tokenResolutionsJSONObject));
-
-		return !matcher.find();
 	}
 
 	private void _writeAutoResolvedTokenNames(

--- a/modules/apps/frontend-data-set/frontend-data-set-fragment-web/src/main/java/com/liferay/frontend/data/set/fragment/web/internal/fragment/renderer/FDSFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-fragment-web/src/main/java/com/liferay/frontend/data/set/fragment/web/internal/fragment/renderer/FDSFragmentRenderer.java
@@ -14,8 +14,12 @@ import com.liferay.frontend.data.set.renderer.FDSRenderer;
 import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.InfoItemDetails;
 import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemDetailsProvider;
+import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
@@ -325,6 +329,66 @@ public class FDSFragmentRenderer implements FragmentRenderer {
 		return tokenNames;
 	}
 
+	private String _getExternalReferenceCode(InfoItemDetails infoItemDetails) {
+		if (infoItemDetails == null) {
+			return null;
+		}
+
+		InfoItemReference infoItemReference =
+			infoItemDetails.getInfoItemReference();
+
+		InfoItemIdentifier infoItemIdentifier =
+			infoItemReference.getInfoItemIdentifier();
+
+		if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
+			return null;
+		}
+
+		ERCInfoItemIdentifier ercInfoItemIdentifier =
+			(ERCInfoItemIdentifier)infoItemIdentifier;
+
+		return ercInfoItemIdentifier.getExternalReferenceCode();
+	}
+
+	private InfoItemDetails _getInfoItemDetails(
+		HttpServletRequest httpServletRequest,
+		InfoItemReference infoItemReference) {
+
+		String className = infoItemReference.getClassName();
+
+		InfoItemIdentifier infoItemIdentifier =
+			infoItemReference.getInfoItemIdentifier();
+
+		InfoItemObjectProvider<Object> infoItemObjectProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemObjectProvider.class, className,
+				infoItemIdentifier.getInfoItemServiceFilter());
+
+		InfoItemDetailsProvider<Object> infoItemDetailsProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemDetailsProvider.class, className);
+
+		if ((infoItemObjectProvider == null) ||
+			(infoItemDetailsProvider == null)) {
+
+			return null;
+		}
+
+		try {
+			return infoItemDetailsProvider.getInfoItemDetails(
+				_portal.getScopeGroupId(httpServletRequest),
+				ERCInfoItemIdentifier.class,
+				infoItemObjectProvider.getInfoItem(infoItemIdentifier));
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return null;
+		}
+	}
+
 	private Set<String> _getTokenNames(
 		String externalReferenceCode, HttpServletRequest httpServletRequest) {
 
@@ -411,13 +475,16 @@ public class FDSFragmentRenderer implements FragmentRenderer {
 			InfoItemIdentifier infoItemIdentifier =
 				infoItemReference.getInfoItemIdentifier();
 
-			if (Objects.equals(fieldId, "externalReferenceCode") &&
-				(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
+			if (Objects.equals(fieldId, "externalReferenceCode")) {
+				if (infoItemIdentifier instanceof ERCInfoItemIdentifier) {
+					ERCInfoItemIdentifier ercInfoItemIdentifier =
+						(ERCInfoItemIdentifier)infoItemIdentifier;
 
-				ERCInfoItemIdentifier ercInfoItemIdentifier =
-					(ERCInfoItemIdentifier)infoItemIdentifier;
+					return ercInfoItemIdentifier.getExternalReferenceCode();
+				}
 
-				return ercInfoItemIdentifier.getExternalReferenceCode();
+				return _getExternalReferenceCode(
+					_getInfoItemDetails(httpServletRequest, infoItemReference));
 			}
 
 			if (infoItemIdentifier instanceof ClassPKInfoItemIdentifier) {
@@ -560,6 +627,9 @@ public class FDSFragmentRenderer implements FragmentRenderer {
 
 	@Reference
 	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;
+
+	@Reference
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/apps/frontend-data-set/frontend-data-set-fragment-web/src/main/resources/META-INF/resources/js/UnresolvedDataSetPreview.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-fragment-web/src/main/resources/META-INF/resources/js/UnresolvedDataSetPreview.tsx
@@ -4,6 +4,7 @@
  */
 
 import ClayAlert from '@clayui/alert';
+import {sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import './UnresolvedDataSetPreview.scss';
@@ -14,23 +15,56 @@ const SKELETON_ROWS = [1, 2, 3, 4, 5];
 
 interface IUnresolvedDataSetPreview {
 	apiURL: string;
+	hasUnmappedTokens?: boolean;
+	hasUnresolvedContextTokens?: boolean;
 }
 
 export default function UnresolvedDataSetPreview({
 	apiURL,
+	hasUnmappedTokens = false,
+	hasUnresolvedContextTokens = false,
 }: IUnresolvedDataSetPreview) {
-	const [showAlert, setShowAlert] = useState(true);
+	const [showAlert, setShowAlert] = useState([true, true]);
+
+	const messages: string[] = [];
+
+	if (hasUnresolvedContextTokens) {
+		messages.push(
+			sub(
+				Liferay.Language.get('unresolved-context-url-help-x'),
+				Liferay.Language.get('preview-with')
+			)
+		);
+	}
+
+	if (hasUnmappedTokens || !messages.length) {
+		messages.push(Liferay.Language.get('unmapped-url-help'));
+	}
 
 	return (
 		<div className="unresolved-data-set-preview">
-			{showAlert && (
-				<ClayAlert
-					displayType="info"
-					onClose={() => setShowAlert(false)}
-				>
-					{Liferay.Language.get('unmapped-url-help')}
-				</ClayAlert>
-			)}
+			{messages.map((message, messageIndex) => (
+				<>
+					{showAlert[messageIndex] && (
+						<ClayAlert
+							displayType="info"
+							key={messageIndex}
+							onClose={() =>
+								setShowAlert(() =>
+									showAlert.map(
+										(value: boolean, alertIndex) =>
+											alertIndex === messageIndex
+												? false
+												: value
+									)
+								)
+							}
+						>
+							<p className="mb-0">{message}</p>
+						</ClayAlert>
+					)}
+				</>
+			))}
 
 			<div className="border p-2 pl-3 rounded text-break">
 				{(apiURL || '')

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -23274,6 +23274,7 @@ unread=Unread
 unread-messages=Unread Messages
 unread-thread=Unread Thread:
 unrelated-objects=Unrelated Objects
+unresolved-context-url-help-x=The URL is incomplete. Tokens mapped to the page context entity are resolved when the page displays an entity. Use the "{0}" selector to pick one and display the data set.
 unsatisfied-component-scanner-configuration-name=Unsatisfied Component Scanner
 unsatisfied-component-scanning-interval=Unsatisfied Component Scanning Interval
 unsatisfied-component-scanning-interval-help=Set the unsatisfied component scanning interval by second. When set to zero or negative, the scan will be disabled. The default value is -1.

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -57,9 +57,11 @@ export class PageEditorPage {
 	readonly publishButton: Locator;
 	readonly publishMasterButton: Locator;
 	readonly publishToLiveButton: Locator;
+	readonly previewItemSelectorButton: Locator;
 	readonly redoButton: Locator;
 	readonly segmentEditorPage: SegmentEditorPage;
 	readonly selectItemMappingButton: Locator;
+	readonly selectOtherPreviewItemMenuItem: Locator;
 	readonly undoButton: Locator;
 	readonly undoHistory: Locator;
 
@@ -86,9 +88,19 @@ export class PageEditorPage {
 		this.publishToLiveButton = page.getByRole('button', {
 			name: 'Publish to Live',
 		});
+
+		// Projects configure testIdAttribute differently, so the page editor
+		// data-qa-id attributes are matched explicitly
+
+		this.previewItemSelectorButton = page.locator(
+			'[data-qa-id="previewItemSelectorButton"]'
+		);
 		this.redoButton = page.getByTitle('Redo');
 		this.segmentEditorPage = new SegmentEditorPage(page);
 		this.selectItemMappingButton = page.getByLabel('Select Item');
+		this.selectOtherPreviewItemMenuItem = page.locator(
+			'[data-qa-id="selectOtherItemDropdownItem"]'
+		);
 		this.undoButton = page.getByTitle('Undo');
 		this.undoHistory = page.locator('.page-editor__undo-history');
 	}
@@ -1783,6 +1795,26 @@ export class PageEditorPage {
 
 			await expect(treeNode).toHaveClass(/focus/);
 		}
+	}
+
+	async selectDisplayPagePreviewItem(itemName: string) {
+		await this.previewItemSelectorButton.click();
+
+		await this.selectOtherPreviewItemMenuItem.click();
+
+		// The item selector renders each entry differently per item type, so the
+		// entry is reached by its name and the click bubbles up to the row
+
+		const item = this.page
+			.frameLocator('iframe[title="Select"]')
+			.getByText(itemName, {exact: true})
+			.first();
+
+		await expect(item).toBeVisible();
+
+		await item.click();
+
+		await expect(this.previewItemSelectorButton).toHaveText(itemName);
 	}
 
 	async selectDirectImage(fileName: string, imageId: string) {

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/pages/DataSetFragmentPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/pages/DataSetFragmentPage.ts
@@ -72,7 +72,7 @@ export class DataSetFragmentPage {
 	// Unresolved API URL preview rendered by the fragment in edit mode
 
 	readonly unresolvedPreview: {
-		alert: Locator;
+		alerts: Locator;
 		container: Locator;
 		skeletonBars: Locator;
 		urlBox: Locator;
@@ -192,7 +192,7 @@ export class DataSetFragmentPage {
 		);
 
 		this.unresolvedPreview = {
-			alert: unresolvedPreviewContainer.locator('.alert-info'),
+			alerts: unresolvedPreviewContainer.locator('.alert-info'),
 			container: unresolvedPreviewContainer,
 			skeletonBars: unresolvedPreviewContainer.locator(
 				'.data-set-skeleton-bar'

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/urlTokenMapping.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/urlTokenMapping.spec.ts
@@ -43,6 +43,9 @@ const MAPPING_MODE = {
 const UNMAPPED_URL_HELP =
 	'The URL is incomplete. Please map all unmapped tokens in the fragment panel to display the data set.';
 
+const UNRESOLVED_CONTEXT_URL_HELP =
+	'The URL is incomplete. Tokens mapped to the page context entity are resolved when the page displays an entity. Use the "Preview With" selector to pick one and display the data set.';
+
 const dataSetERCs: string[] = [];
 let article: any;
 let articleSiteId: string;
@@ -105,6 +108,12 @@ async function createTokenizedDataSet({
 	return dataSet;
 }
 
+/**
+ * The article external reference code is its title, which is also its friendly
+ * URL path. A token filtering on `friendlyUrlPath` therefore matches this
+ * article whichever identifier the mapping resolves to, which is what makes a
+ * token resolved from the external reference code observable in the rows.
+ */
 async function createArticle({apiHelpers, siteId}: any) {
 	const title = getRandomString().toLowerCase();
 
@@ -112,11 +121,37 @@ async function createArticle({apiHelpers, siteId}: any) {
 
 	article = await apiHelpers.jsonWebServicesJournal.addWebContent({
 		ddmStructureId: await getBasicWebContentStructureId(apiHelpers),
+		externalReferenceCode: title,
 		groupId: siteId,
 		titleMap: {en_US: title},
 	});
 
 	return title;
+}
+
+async function editBasicWebContentDisplayPageTemplate({
+	apiHelpers,
+	displayPageTemplatesPage,
+	site,
+}: any) {
+	const className = await apiHelpers.jsonWebServicesClassName.fetchClassName(
+		'com.liferay.journal.model.JournalArticle'
+	);
+
+	const displayPageTemplateName = getRandomString();
+
+	await apiHelpers.jsonWebServicesLayoutPageTemplateEntry.addDisplayPageLayoutPageTemplateEntry(
+		{
+			classNameId: className.classNameId,
+			classTypeKey: 'BASIC-WEB-CONTENT',
+			groupId: site.id,
+			name: displayPageTemplateName,
+		}
+	);
+
+	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+	await displayPageTemplatesPage.editTemplate(displayPageTemplateName);
 }
 
 test(
@@ -168,9 +203,13 @@ test(
 		});
 
 		await test.step('Assert that the fragment renders the help alert, the URL and the skeleton', async () => {
+
+			// Unmapped tokens are the only reason the URL is incomplete, so the
+			// page context help must stay out.
+
 			await expect(
-				dataSetFragmentPage.unresolvedPreview.alert
-			).toContainText(UNMAPPED_URL_HELP);
+				dataSetFragmentPage.unresolvedPreview.alerts
+			).toContainText([UNMAPPED_URL_HELP]);
 
 			await expect(
 				dataSetFragmentPage.unresolvedPreview.urlBox
@@ -486,7 +525,7 @@ test(
 
 test(
 	'Mapping a token to the page context entity is offered on display page templates',
-	{tag: '@LPD-93809'},
+	{tag: ['@LPD-93809', '@LPD-99359']},
 	async ({
 		apiHelpers,
 		dataSetFragmentPage,
@@ -501,29 +540,12 @@ test(
 					dataSetManagerApiHelpers,
 				}));
 
-		await test.step('Create a display page template for basic web content', async () => {
-			const className =
-				await apiHelpers.jsonWebServicesClassName.fetchClassName(
-					'com.liferay.journal.model.JournalArticle'
-				);
-
-			const displayPageTemplateName = getRandomString();
-
-			await apiHelpers.jsonWebServicesLayoutPageTemplateEntry.addDisplayPageLayoutPageTemplateEntry(
-				{
-					classNameId: className.classNameId,
-					classTypeKey: 'BASIC-WEB-CONTENT',
-					groupId: site.id,
-					name: displayPageTemplateName,
-				}
-			);
-
-			await displayPageTemplatesPage.goto(site.friendlyUrlPath);
-
-			await displayPageTemplatesPage.editTemplate(
-				displayPageTemplateName
-			);
-		});
+		await test.step('Create a display page template for basic web content', async () =>
+			editBasicWebContentDisplayPageTemplate({
+				apiHelpers,
+				displayPageTemplatesPage,
+				site,
+			}));
 
 		await test.step('Add the fragment and assign the data set', async () => {
 			await pageEditorPage.addFragment('Content Display', 'Data Set');
@@ -557,10 +579,168 @@ test(
 			).toHaveText('Completed');
 		});
 
-		await test.step('Assert that the fragment keeps showing the preview: without a page context entity in the editor the value cannot be resolved yet', async () => {
+		await test.step('Assert that the fragment explains why the completed mapping cannot be resolved yet: the editor has no page context entity', async () => {
 			await expect(
 				dataSetFragmentPage.unresolvedPreview.skeletonBars.first()
 			).toBeVisible();
+
+			// Every token is either resolved or mapped to the page context
+			// entity, so the unmapped token help must stay out.
+
+			await expect(
+				dataSetFragmentPage.unresolvedPreview.alerts
+			).toContainText([UNRESOLVED_CONTEXT_URL_HELP]);
+		});
+	}
+);
+
+test(
+	'A token mapped to the external reference code of the page context entity resolves and renders the data set',
+	{tag: '@LPD-99359'},
+	async ({
+		apiHelpers,
+		dataSetFragmentPage,
+		dataSetManagerApiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		const dataSet =
+			await test.step('Create a data set with tokens in its API URL', async () =>
+				createTokenizedDataSet({
+					dataSetManagerApiHelpers,
+				}));
+
+		const articleTitle =
+			await test.step('Create an article to preview the display page template with', async () =>
+				createArticle({apiHelpers, siteId: site.id}));
+
+		await test.step('Create a display page template for basic web content', async () =>
+			editBasicWebContentDisplayPageTemplate({
+				apiHelpers,
+				displayPageTemplatesPage,
+				site,
+			}));
+
+		await test.step('Add the fragment and assign the data set', async () => {
+			await pageEditorPage.addFragment('Content Display', 'Data Set');
+
+			await dataSetFragmentPage.fragmentSelectionArea.click();
+
+			await dataSetFragmentPage.selectDataSetButton.click();
+
+			await dataSetFragmentPage.selectDataSet(dataSet.label);
+		});
+
+		await test.step('Map {path} to the external reference code of the page context entity', async () => {
+			await dataSetFragmentPage.selectToken('path');
+
+			await dataSetFragmentPage.selectMappingMode(MAPPING_MODE.CONTEXT);
+
+			await dataSetFragmentPage.tokenMappingFieldSelect.selectOption({
+				label: 'External Reference Code',
+			});
+
+			await expect(
+				dataSetFragmentPage.unresolvedPreview.alerts
+			).toContainText([UNRESOLVED_CONTEXT_URL_HELP]);
+		});
+
+		await test.step('Preview the display page template with the article', async () =>
+			pageEditorPage.selectDisplayPagePreviewItem(articleTitle));
+
+		await test.step('Assert that the data set replaces the preview, showing the article the token resolved to', async () => {
+			await expect(
+				dataSetFragmentPage.unresolvedPreview.container
+			).toBeHidden();
+
+			await waitForFDS({page});
+
+			await expect(
+				dataSetFragmentPage.table.bodyRows.getByText(articleTitle)
+			).toBeVisible();
+		});
+	}
+);
+
+test(
+	'Both the unmapped token and the page context entity help are shown when each applies to a different token',
+	{tag: '@LPD-99359'},
+	async ({
+		apiHelpers,
+		dataSetFragmentPage,
+		dataSetManagerApiHelpers,
+		displayPageTemplatesPage,
+		pageEditorPage,
+		site,
+	}) => {
+		const dataSet =
+			await test.step('Create a data set with two manually mapped tokens in its API URL', async () =>
+				createTokenizedDataSet({
+					additionalAPIURLParameters:
+						"filter=contains(friendlyUrlPath,'{path}') and contains(title,'{title}')",
+					dataSetManagerApiHelpers,
+				}));
+
+		await test.step('Create a display page template for basic web content', async () =>
+			editBasicWebContentDisplayPageTemplate({
+				apiHelpers,
+				displayPageTemplatesPage,
+				site,
+			}));
+
+		await test.step('Add the fragment and assign the data set', async () => {
+			await pageEditorPage.addFragment('Content Display', 'Data Set');
+
+			await dataSetFragmentPage.fragmentSelectionArea.click();
+
+			await dataSetFragmentPage.selectDataSetButton.click();
+
+			await dataSetFragmentPage.selectDataSet(dataSet.label);
+		});
+
+		await test.step('Map {path} to the page context entity and leave {title} unmapped', async () => {
+			await dataSetFragmentPage.selectToken('path');
+
+			await dataSetFragmentPage.selectMappingMode(MAPPING_MODE.CONTEXT);
+
+			await dataSetFragmentPage.tokenMappingFieldSelect.selectOption({
+				label: 'External Reference Code',
+			});
+
+			await expect(
+				dataSetFragmentPage.tokenMappingTokenStatusLabel
+			).toHaveText('Mapped');
+
+			await expect(
+				dataSetFragmentPage.tokenMappingStatusLabel
+			).toHaveText('Incomplete');
+		});
+
+		await test.step('Assert that the fragment explains both reasons the URL is incomplete', async () => {
+			await expect(
+				dataSetFragmentPage.unresolvedPreview.skeletonBars.first()
+			).toBeVisible();
+
+			await expect(
+				dataSetFragmentPage.unresolvedPreview.alerts
+			).toContainText([UNRESOLVED_CONTEXT_URL_HELP, UNMAPPED_URL_HELP]);
+		});
+
+		await test.step('Assert that each help alert can be dismissed on its own', async () => {
+
+			// The page editor marks the fragment content as aria-hidden, so
+			// nothing inside it is reachable by role.
+
+			await dataSetFragmentPage.unresolvedPreview.alerts
+				.first()
+				.locator('.close')
+				.click();
+
+			await expect(
+				dataSetFragmentPage.unresolvedPreview.alerts
+			).toContainText([UNMAPPED_URL_HELP]);
 		});
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99359

## What Is Being Fixed

A data set fragment can map a token in its API URL to a field of the page context entity. When the chosen field was the external reference code and the fragment lived on a display page template, the token resolved to the wrong value and the data set request came back with a 404.

The renderer read the external reference code directly off the page context's info item identifier, which only carries one when the identifier is an `ERCInfoItemIdentifier`. A display page template supplies its context entity through a `ClassPKInfoItemIdentifier`, so that branch never matched and the token fell through to the class primary key instead.

Editing a display page template was also misleading. A token mapped to the page context entity cannot resolve until a preview entity is picked, but the fragment showed the unmapped-token help, asking the developer to finish a mapping that was already complete.

## How It Is Being Fixed

When the mapped field is the external reference code and the info item identifier does not carry one, the renderer loads the context entity through its `InfoItemObjectProvider` and asks the `InfoItemDetailsProvider` for details keyed by `ERCInfoItemIdentifier`, taking the external reference code from the resulting info item reference. Identifiers that already carry an external reference code keep the previous, cheaper path, so the lookup only happens when it is needed.

For the editing feedback, `_isResolved` gives way to `_getUnresolvedTokenNames` so the renderer knows which tokens are unresolved rather than only whether any are. Those names are then partitioned: a token whose mapping mode is `context` with a field selected is fully configured and unresolved only because the editor has no page context entity, while anything else is genuinely unmapped. Both conditions reach `UnresolvedDataSetPreview`, which renders one dismissible alert per applicable reason, so a fragment mixing the two cases explains both. The new `unresolved-context-url-help-x` key points the developer at the "Preview With" selector.

The Playwright coverage adds a display page template preview-item helper to the page editor page object, and asserts that a token mapped to the external reference code of the page context entity resolves and renders the matching row once a preview entity is selected, that the context help appears alone while no entity is selected, and that both messages appear together and dismiss independently when each applies to a different token.

## PR Check

**pr-check: PASS** — tested on `236337c4e1c9eea17608478cffe698315c68b817`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "236337c4e1c9eea17608478cffe698315c68b817"} -->
