### PR TITLE
LPD-100374 Default sortable to false and always allow changing it

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
@@ -20,9 +20,7 @@ import {fetch} from 'frontend-js-web';
 import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
-import FieldSelectModalContent, {
-	visit,
-} from '../../../components/AddDataSourceFieldsModalContent';
+import FieldSelectModalContent from '../../../components/AddDataSourceFieldsModalContent';
 import OrderableTable from '../../../components/OrderableTable';
 import {
 	DEFAULT_FETCH_HEADERS,
@@ -47,7 +45,6 @@ import {
 	IDataSet,
 	IDataSetTableSection,
 	IField,
-	IFieldTreeItem,
 } from '../../../utils/types';
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
@@ -124,7 +121,6 @@ const EditTableSectionModalContent = ({
 	dataSet,
 	namespace,
 	onSaveButtonClick,
-	sortable,
 	tableSection,
 }: {
 	cellClientExtensionRenderers: IClientExtensionRenderer[];
@@ -132,7 +128,6 @@ const EditTableSectionModalContent = ({
 	dataSet: IDataSet;
 	namespace: string;
 	onSaveButtonClick: Function;
-	sortable: boolean;
 	tableSection: IDataSetTableSection;
 }) => {
 	const [selectedRenderer, setSelectedRenderer] = useState(
@@ -322,7 +317,6 @@ const EditTableSectionModalContent = ({
 				<ClayForm.Group>
 					<ClayCheckbox
 						checked={tableSectionSortable}
-						disabled={!sortable}
 						inline
 						label={Liferay.Language.get('sortable')}
 						onChange={({target: {checked}}) =>
@@ -630,7 +624,7 @@ function Table(props: IDataSetSectionProps & {title?: string}) {
 					onSaveButtonClick={({name}: {name: string}) => {
 						saveDataSetTableColumns({
 							closeModal,
-							fields: [{name, sortable: true}] as IField[],
+							fields: [{name, sortable: false}] as IField[],
 						});
 					}}
 				/>
@@ -666,7 +660,6 @@ function Table(props: IDataSetSectionProps & {title?: string}) {
 							}) || null
 						);
 					}}
-					sortable={isSortable(fieldTreeItems, item)}
 					tableSection={item}
 				/>
 			),
@@ -773,23 +766,6 @@ export function Fields(props: IDataSetSectionProps) {
 			<Table {...props} title={Liferay.Language.get('fields')} />
 		</ClayLayout.ContainerFluid>
 	);
-}
-
-function isSortable(
-	fieldTreeItems: Array<IFieldTreeItem>,
-	selectedItem: IDataSetTableSection
-): boolean {
-	let isSortable = false;
-
-	visit(fieldTreeItems, (fieldTreeItem: IFieldTreeItem) => {
-		if (fieldTreeItem.name === selectedItem.fieldName) {
-			isSortable = fieldTreeItem.sortable || false;
-
-			return;
-		}
-	});
-
-	return isSortable;
 }
 
 export default Table;

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/visualizationModes.spec.ts
@@ -495,7 +495,7 @@ test('Configure table visualization mode @LPD-11049', async ({
 				.getRowByText(sampleScalarFieldName)
 				.locator('td')
 				.nth(visualizationModesPage.SORTABLE_COLUMN_INDEX)
-		).toHaveText('true');
+		).toHaveText('false');
 
 		await expect(
 			visualizationModesPage
@@ -542,7 +542,7 @@ test('Configure table visualization mode @LPD-11049', async ({
 		).toHaveText('false');
 	});
 
-	await test.step('Check if object field has disabled sortable option', async () => {
+	await test.step('Check if object field has an editable sortable option', async () => {
 		await clickActionInRow({
 			actionName: 'Edit',
 			page,
@@ -554,7 +554,9 @@ test('Configure table visualization mode @LPD-11049', async ({
 
 		await expect(sortableLabel).toBeInViewport();
 
-		await expect(sortableLabel).toBeDisabled();
+		await expect(sortableLabel).toBeEnabled();
+
+		await expect(sortableLabel).not.toBeChecked();
 
 		await visualizationModesPage.cancelAddFieldsModal();
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100374

## What Is Being Fixed

A field added through "Assign Field Manually" in a data set's Table visualization mode was always stored as sortable, and the Sortable checkbox was then disabled, so the value could not be corrected.

The checkbox took its value from what was saved, but its editability from the data source schema. A manually assigned field is by definition absent from that schema, so the lookup always answered "not sortable" and the checkbox rendered checked and disabled at the same time, leaving the administrator no way out.

## How It Is Being Fixed

The manual assignment path now stores `sortable` as `false`, matching the "Assign from Data Source" path, which already used the field's own value or `false`.

The Sortable checkbox is no longer disabled. Sortability cannot be derived for a manually assigned field, and it is not reliably known for declared fields either, so the decision belongs to the administrator rather than to a schema heuristic. Removing the gate left the schema lookup with no remaining consumer, so the `sortable` prop, the `isSortable` helper, and their now unused imports were removed as well.

Two assertions in `visualizationModes.spec.ts` were realigned to the corrected behavior: a manually assigned field now defaults to `false`, and an object field's Sortable option is editable rather than disabled.

## Why Are There No Tests?

The behavior is already covered by `Configure table visualization mode` in `visualizationModes.spec.ts`. That test asserts the sortable defaults for data source, nested, and manually assigned fields side by side, and its `Edit a field` step already exercises toggling the option off and verifies the persisted value. This change realigns those existing assertions to the corrected behavior rather than adding a redundant test.

## PR Check

**pr-check: PASS** — tested on `069a3e15504d9422cf30ed9015555af9410ed39c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "069a3e15504d9422cf30ed9015555af9410ed39c"} -->
