### PR TITLE
LPD-100100 Stop registering licensed-only CKEditor test in CI

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
@@ -414,37 +414,27 @@ test(
 	}
 );
 
-test(
-	'Enhanced Paste from Office plugin is registered for licensed DXP installations',
-	{tag: '@LPD-95090'},
-	async ({classicPage, page}) => {
-		await expect(classicPage.editable).toBeVisible();
+if (!process.env.CI) {
+	test(
+		'Enhanced Paste from Office plugin is registered for licensed DXP installations',
+		{tag: '@LPD-95090'},
+		async ({classicPage, page}) => {
+			await expect(classicPage.editable).toBeVisible();
 
-		const {hasPasteFromOfficeEnhanced, showPasteFromOfficeEnhanced} =
-			await page.evaluate(() => {
+			const hasPasteFromOfficeEnhanced = await page.evaluate(() => {
 				const editorElement = Array.from(
 					document.querySelectorAll('.lfr-ck *')
 				).find((element) => (element as any).ckeditorInstance);
 
 				const editor = (editorElement as any)?.ckeditorInstance;
 
-				return {
-					hasPasteFromOfficeEnhanced:
-						editor?.plugins.has('PasteFromOfficeEnhanced') ?? false,
-					showPasteFromOfficeEnhanced:
-						editor?.config.get('showPasteFromOfficeEnhanced') ??
-						false,
-				};
+				return editor?.plugins.has('PasteFromOfficeEnhanced') ?? false;
 			});
 
-		test.skip(
-			!showPasteFromOfficeEnhanced,
-			'Enhanced Paste from Office is only available on licensed DXP installations'
-		);
-
-		expect(hasPasteFromOfficeEnhanced).toBe(true);
-	}
-);
+			expect(hasPasteFromOfficeEnhanced).toBe(true);
+		}
+	);
+}
 
 test(
 	'Style Book text colors are available in the Styles dropdown',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100100

## What Is Being Fixed

The Playwright test `Enhanced Paste from Office plugin is registered for licensed DXP installations` needs a licensed DXP installation, which CI does not have. It was guarded at runtime with `test.skip`, so CI still registered and started it, which left a bogus blocked entry in Testray reports and occasionally surfaced as an outright failure. The reality is that this test simply cannot run in CI.

## How It Is Being Fixed

Instead of skipping the test at runtime, its registration is now skipped altogether by wrapping the `test(...)` declaration in `if (!process.env.CI)`. Under CI the test is never registered, so it cannot report as blocked or errored, while local runs against a licensed installation still exercise it.

Because the runtime `test.skip` guard is gone, the `showPasteFromOfficeEnhanced` configuration read that existed only to feed it is removed as well, which reduces the `page.evaluate` callback to returning the plugin presence alone.

## Why Are There No Tests?

The change is confined to a Playwright spec and alters only whether a test is registered under CI, so there is no product code for a new test to cover. The behavior change was verified by listing the spec's tests both ways: 13 tests locally with the test present, and 12 under `CI=true` with it absent rather than skipped.

## PR Check

**pr-check: PASS** — tested on `e960b6ccca2c1df3dde954d962d163ab7c1a5cb9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Per-Module Compile and JavaScript Unit Tests matched by path regex but resolved as not applicable: `modules/test/playwright` has no `bnd.bnd`, no `.lfrbuild-portal` marker, and no `deploy` task, and its `test` script is `playwright test`, whose execution is out of scope for pr-check. In their place, `tsc --noEmit` over the Playwright tree passed and `playwright test --list` confirmed the intended registration change.

<!-- pr-check {"result": "success", "sha": "e960b6ccca2c1df3dde954d962d163ab7c1a5cb9"} -->
