### PR TITLE
LPD-100995 Fix missing PasteFromOffice soft-required plugin

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
@@ -77,7 +77,8 @@ const getDefaultEditorConfig = ({
 		LinkImage,
 		List,
 		Paragraph,
-		showPasteFromOfficeEnhanced ? PasteFromOfficeEnhanced : PasteFromOffice,
+		PasteFromOffice,
+		...(showPasteFromOfficeEnhanced ? [PasteFromOfficeEnhanced] : []),
 		Underline,
 	];
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100995

## What Is Being Fixed

CKEditor 5 swapped `PasteFromOffice` for `PasteFromOfficeEnhanced` when the enhanced plugin was enabled for licensed DXP installations, instead of loading both. `PasteFromOfficeEnhanced` soft-requires `PasteFromOffice`, so licensed installations threw a `plugincollection-soft-required` `CKEditorError` when the editor loaded, which surfaced as a CI failure.

## How It Is Being Fixed

`PasteFromOffice` is now loaded unconditionally, and `PasteFromOfficeEnhanced` is added alongside it through a conditional spread inside the same plugins array literal, instead of a ternary that picked one or the other. Keeping both plugins in the same array literal also lets TypeScript infer the correct union type for the array without an extra type annotation.

## Why Are There No Tests?

This is a bug fix, and the team's convention is not to add tests for bug fixes.

## PR Check

**pr-check: PASS** — tested on `81f5ae3ffe2c398347d560d0d6ac2ef2ca11a10c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "81f5ae3ffe2c398347d560d0d6ac2ef2ca11a10c"} -->
