### PR TITLE
LPD-101414 Assert the range check in the FDS date filter test

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
@@ -14,6 +14,14 @@ import {IDateFilter, IField, IFilter} from '../../../utils/types';
 import Configuration from './Configuration';
 import Footer from './Footer';
 
+// This is the admin form that defines a date range filter, and it deliberately
+// keeps the locale independent "yyyy-MM-dd" layout of the stored value. The
+// widget that renders the filter for the end user is a different component,
+// frontend-data-set-web's management_bar/controls/filters/implementation/
+// DateTimeRangeFilter.tsx, which accepts and displays dates in the viewer
+// locale format instead. Do not take the format used here as evidence of what
+// the end user sees.
+
 function Header() {
 	return <>{Liferay.Language.get('new-date-range-filter')}</>;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/filters/implementation/DateTimeRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/filters/implementation/DateTimeRangeFilter.tsx
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
 import {
 	dateTimeRangeFilterImplementation,
 	formatDatePartsForClay,
@@ -10,9 +16,13 @@ import {
 	isWithinBounds,
 	parseClayValue,
 } from '../../../../../src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/DateTimeRangeFilter';
+import {EEntityFieldType} from '../../../../../src/main/resources/META-INF/resources/management_bar/controls/filters/utils/types';
 
-const {getOdataString, getSelectedItemsLabel} =
-	dateTimeRangeFilterImplementation;
+const {
+	Component: DateTimeRangeFilter,
+	getOdataString,
+	getSelectedItemsLabel,
+} = dateTimeRangeFilterImplementation;
 
 const fromDateTime = {day: 11, hour: 15, minute: 30, month: 5, year: 2026};
 const toDateTime = {day: 11, hour: 17, minute: 45, month: 5, year: 2026};
@@ -506,5 +516,92 @@ describe('DateTimeRangeFilter.getSelectedItemsLabel', () => {
 		} as any);
 
 		expect(result).toBe('05/11/2026 08:00 AM - 05/11/2026 10:25 AM');
+	});
+});
+
+describe('DateTimeRangeFilter submit validation', () => {
+	const FROM = '06/15/2020 02:30 PM';
+	const TO = '11/22/2020 09:15 AM';
+
+	function renderFilter(props: Record<string, unknown> = {}) {
+		render(
+			<DateTimeRangeFilter
+				{...({
+					active: true,
+					entityFieldType: EEntityFieldType.DATE_TIME,
+					id: 'testField',
+					selectedData: null,
+					setFilter: jest.fn(),
+					...props,
+				} as any)}
+			/>
+		);
+
+		return {
+			fromInput: screen.getByLabelText('from'),
+			submitButton: screen.getByRole('button', {name: 'add-filter'}),
+			toInput: screen.getByLabelText('to[date-time]'),
+		};
+	}
+
+	beforeEach(() => {
+		setTimeZone('UTC');
+	});
+
+	it('reports an invalid date when a value does not match the locale format', async () => {
+		const {submitButton, toInput} = renderFilter();
+
+		await userEvent.type(toInput, '2020-11-22');
+
+		expect(screen.getByText('date-is-invalid')).toBeInTheDocument();
+
+		expect(submitButton).toBeDisabled();
+	});
+
+	it('reports an invalid range, not an invalid date, when "to" is before "from"', async () => {
+		const {fromInput, submitButton, toInput} = renderFilter();
+
+		await userEvent.type(fromInput, TO);
+		await userEvent.type(toInput, FROM);
+
+		expect(
+			screen.getByText('date-range-is-invalid.-from-must-be-before-to')
+		).toBeInTheDocument();
+
+		expect(screen.queryByText('date-is-invalid')).not.toBeInTheDocument();
+
+		expect(submitButton).toBeDisabled();
+	});
+
+	it('enables the submit button when "from" is before "to"', async () => {
+		const {fromInput, submitButton, toInput} = renderFilter();
+
+		await userEvent.type(fromInput, FROM);
+		await userEvent.type(toInput, TO);
+
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+		expect(submitButton).toBeEnabled();
+	});
+
+	it('enables the submit button when both ends are the same instant', async () => {
+		const {fromInput, submitButton, toInput} = renderFilter();
+
+		await userEvent.type(fromInput, FROM);
+		await userEvent.type(toInput, FROM);
+
+		expect(submitButton).toBeEnabled();
+	});
+
+	it('reports an out-of-range date when a value falls outside the bounds', async () => {
+		const {submitButton, toInput} = renderFilter({
+			max: {day: 31, hour: 23, minute: 59, month: 12, year: 2020},
+		});
+
+		await userEvent.type(toInput, '01/02/2021 09:15 AM');
+
+		expect(screen.getByText('date-is-out-of-range')).toBeInTheDocument();
+
+		expect(submitButton).toBeDisabled();
 	});
 });

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/dateRangeFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/dateRangeFilters.spec.ts
@@ -10,6 +10,7 @@ import {dataSetManagerApiHelpersTest} from '../../../fixtures/dataSetManagerApiH
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {isolatedLayoutTest} from '../../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {formatDateTimeForUI} from '../../../utils/applyFDSDateTimeRangeFilter';
 import getRandomString from '../../../utils/getRandomString';
 import {dataSetFragmentPageTest} from './fixtures/dataSetFragmentPageTest';
 
@@ -98,22 +99,45 @@ test('Date-time filter is displayed in fragment, and applied to data @LPD-10754'
 
 	await assertDataIsFetched();
 
-	await test.step('Assert that a filter cannot be applied when setting an impossible date range', async () => {
-		await activeFilterButton.click();
+	const editButton = dataSetFragmentPage.page.getByRole('button', {
+		name: 'Show Results',
+	});
 
-		const toInput = dataSetFragmentPage.page.getByLabel('To', {
-			exact: true,
-		});
+	const fromInput = dataSetFragmentPage.page.getByLabel('From', {
+		exact: true,
+	});
+
+	const toInput = dataSetFragmentPage.page.getByLabel('To', {exact: true});
+
+	await test.step('Assert that a filter cannot be applied when a date is not in the viewer locale format', async () => {
+		await activeFilterButton.click();
 
 		await expect(toInput).toBeVisible();
 
-		await toInput.click();
-
 		await toInput.fill('2020-01-02');
 
-		const editButton = dataSetFragmentPage.page.getByRole('button', {
-			name: 'Show Results',
-		});
+		await expect(
+			dataSetFragmentPage.page.getByText('Date is invalid.', {
+				exact: true,
+			})
+		).toBeVisible();
+
+		await expect(editButton).toBeDisabled();
+	});
+
+	await test.step('Assert that a filter cannot be applied when setting an impossible date range', async () => {
+		await fromInput.fill(
+			formatDateTimeForUI(new Date(2020, 5, 15, 14, 30))
+		);
+
+		await toInput.fill(formatDateTimeForUI(new Date(2020, 0, 2, 9, 15)));
+
+		await expect(
+			dataSetFragmentPage.page.getByText(
+				'Date range is invalid. "From" must be before "to".',
+				{exact: true}
+			)
+		).toBeVisible();
 
 		await expect(editButton).toBeDisabled();
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101414

## What Is Being Fixed

A Playwright step named "Assert that a filter cannot be applied when setting an impossible date range" stopped testing the range at all. It filled the To input with a year first date, which no longer parses now that the filter input rejects invalid dates and accepts only the viewer locale format. The button under assertion was therefore disabled through the invalid date path rather than the range check, so the step passed while covering nothing, and it would have kept passing if the range logic broke.

The submit gating had no coverage anywhere else either. The Jest suite exercised only the exported pure functions and never rendered the component, leaving the range comparison, the bounds check, and the feedback message selection untested.

## How It Is Being Fixed

Both ends are now typed in the accepted format with To before From, so the disabled state can only come from the range check, and the feedback message is asserted so an invalid date and an impossible range are distinguishable from the outside. A second step keeps the year first input and asserts the invalid date message, which pins down the path the original assertion was actually taking. The existing `formatDateTimeForUI` helper builds the locale formatted values rather than a new inline formatter.

Render level Jest cases now cover the submit gating: invalid format, inverted range, ordered range, the boundary where both ends are the same instant, and out of bounds. Each was verified by mutation rather than by a green run alone. Forcing the range check to always pass fails only the inverted range case, and narrowing the comparison to a strict inequality fails only the same instant case, so the cases are tied to the logic they claim to cover.

The admin form component that shares the DateRangeFilter name keeps its own locale independent layout for the stored value, which reads as evidence that a year first date is what the end user sees. A comment there now points at the widget that actually renders the filter.

## PR Check

**pr-check: PASS** — tested on `7538bf0dd34d73f776bfda50334eac4c6f8cf0e3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7538bf0dd34d73f776bfda50334eac4c6f8cf0e3"} -->
