### PR TITLE
LPD-101567 Open the page editor through the draft layout friendly URL

### DIFF
--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutApiHelper.ts
@@ -99,6 +99,12 @@ export class JSONWebServicesLayoutApiHelper {
 			}
 		);
 
+		// Content layouts are edited through their draft layout
+
+		if (options.type === 'content') {
+			layout.draftLayout = await this.getDraftLayout(layout);
+		}
+
 		// Publish content layouts using UI (since there's no headless method available yet)
 
 		if (options.publish && options.type === 'content') {
@@ -125,6 +131,30 @@ export class JSONWebServicesLayoutApiHelper {
 
 		return this.apiHelpers.post(
 			`${liferayConfig.environment.baseUrl}${this.basePath}/delete-layout`,
+			{
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+				headers: await this.apiHelpers.getJSONWebServicesHeaders(),
+			}
+		);
+	}
+
+	/**
+	 * Returns the draft layout of the given content layout, which is the one
+	 * serving the page editor. The draft layout carries the external reference
+	 * code of its live layout with a '-draft' suffix.
+	 */
+	async getDraftLayout(layout: Layout): Promise<Layout> {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append(
+			'externalReferenceCode',
+			`${layout.externalReferenceCode}-draft`
+		);
+		urlSearchParams.append('groupId', layout.groupId);
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.basePath}/get-layout-by-external-reference-code`,
 			{
 				data: urlSearchParams.toString(),
 				failOnStatusCode: true,

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -109,7 +109,7 @@ export class PageEditorPage {
 		await this.page.goto('/');
 
 		await this.page.goto(
-			`/web${siteUrl || '/guest'}${layout.friendlyUrlPath || layout.friendlyURL}?p_l_mode=edit`
+			`/web${siteUrl || '/guest'}${layout.draftLayout?.friendlyURL || layout.friendlyUrlPath || layout.friendlyURL}?p_l_mode=edit`
 		);
 	}
 

--- a/modules/test/playwright/tests/client-extension-web/main/customElement.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/customElement.spec.ts
@@ -124,9 +124,7 @@ testSample.describe('Samples', () => {
 				});
 
 				await test.step(`${sample.name} can be added to a page and is rendered`, async () => {
-					await page.goto(
-						`/web/guest${layout.friendlyURL}?p_l_mode=edit`
-					);
+					await pageEditorPage.goto(layout);
 
 					await pageEditorPage.addWidget(
 						'Client Extensions',
@@ -592,7 +590,7 @@ testSample(
 		});
 
 		await test.step('Add the widget to two grid columns', async () => {
-			await page.goto(`/web/guest${layout.friendlyURL}?p_l_mode=edit`);
+			await pageEditorPage.goto(layout);
 
 			await pageEditorPage.addWidget(
 				'Client Extensions',
@@ -661,7 +659,7 @@ testSample(
 		});
 
 		await test.step('Add widget to page and verify HTML property', async () => {
-			await page.goto(`/web/guest${layout.friendlyURL}?p_l_mode=edit`);
+			await pageEditorPage.goto(layout);
 
 			await pageEditorPage.addWidget(
 				'Client Extensions',
@@ -722,7 +720,7 @@ testSample(
 		});
 
 		await test.step('Add widget to page and verify script type', async () => {
-			await page.goto(`/web/guest${layout.friendlyURL}?p_l_mode=edit`);
+			await pageEditorPage.goto(layout);
 
 			await pageEditorPage.addWidget(
 				'Client Extensions',
@@ -777,7 +775,7 @@ testSample(
 		});
 
 		await test.step('Add to page and verify type="module" script', async () => {
-			await page.goto(`/web/guest${layout.friendlyURL}?p_l_mode=edit`);
+			await pageEditorPage.goto(layout);
 
 			await pageEditorPage.addWidget(
 				'Client Extensions',
@@ -877,7 +875,7 @@ testSample(
 		});
 
 		await test.step('Add the widget and remove VIEW permission for the Guest role', async () => {
-			await page.goto(`/web/guest${layout.friendlyURL}?p_l_mode=edit`);
+			await pageEditorPage.goto(layout);
 
 			await pageEditorPage.addWidget(
 				'Client Extensions',

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/pages/DataSetFragmentPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/pages/DataSetFragmentPage.ts
@@ -300,7 +300,11 @@ export class DataSetFragmentPage {
 	}
 
 	async editPage({layout}: {layout: Layout}) {
-		await this.page.goto(`/web/guest${layout.friendlyURL}?p_l_mode=edit`);
+		await this.page.goto(
+			`/web/guest${layout.draftLayout?.friendlyURL || layout.friendlyURL}?p_l_mode=edit`
+		);
+
+		await expect(this.fragmentWidgetSearchInput).toBeVisible();
 	}
 
 	async goToPage({layout}: {layout: Layout}) {

--- a/modules/test/playwright/tests/frontend-js-spa-web/main/settings.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-spa-web/main/settings.spec.ts
@@ -12,7 +12,7 @@ import isSPAEnabled from '../../../utils/isSPAEnabled';
 import {waitForAlert} from '../../../utils/waitForAlert';
 
 export const test = mergeTests(
-	isolatedLayoutTest({publish: false}),
+	isolatedLayoutTest(),
 	loginTest(),
 	systemSettingsPageTest
 );
@@ -24,7 +24,7 @@ test(
 	},
 	async ({layout, page, systemSettingsPage}) => {
 		await test.step('Navigate to an isolated page', async () => {
-			await page.goto(`/web/guest/${layout.friendlyURL}`);
+			await page.goto(`/web/guest${layout.friendlyURL}`);
 		});
 
 		await test.step('Check if SPA is enabled', async () => {

--- a/modules/test/playwright/types/content-page.d.ts
+++ b/modules/test/playwright/types/content-page.d.ts
@@ -57,6 +57,7 @@ type FormConfig = {
 
 type Layout = {
 	companyId: string;
+	draftLayout?: Layout;
 	externalReferenceCode: string;
 	friendlyURL: string;
 	friendlyUrlPath: string;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101567

## What Is Being Fixed

An unpublished content page has no live friendly URL that resolves — it has a draft URL. Navigating to `/web/<site>/<live-friendly-url>` was therefore never a valid way to reach it, in edit mode or in view mode.

It only appeared to work because the portal silently fell back to the site's first published page, so the tests were exercising the home page rather than the page they created. Once that fallback was closed, the tests started failing late and opaquely — the CI symptom was a `locator.dragTo` timeout waiting for the empty-page drop zone, which the home page does not have.

Two distinct cases follow from that, one per commit.

## How It Is Being Fixed

**Opening the editor (first commit).** The editor is served from the layout's draft layout, so the draft's friendly URL is the entry point to use. It cannot be derived, since it is a randomly generated UUID, but the draft carries the external reference code of its live layout with a `-draft` suffix, which makes it resolvable through `/api/jsonws/layout/get-layout-by-external-reference-code`. Draft layouts are `system=true`, so the `get-layouts` listings filter them out and the external reference code lookup is the way in.

`addLayout` now resolves the draft once for every content layout it creates and attaches it to the returned layout, so both `isolatedLayoutTest` and the specs that call `addLayout` directly get it without changing any test signature. `PageEditorPage.goto` and `DataSetFragmentPage.editPage` prefer the draft friendly URL and fall back to the previous behaviour for layouts that have no draft, such as portlet layouts and headless-created pages. `DataSetFragmentPage.editPage` also asserts that the editor loaded, so a wrong navigation fails at the navigation instead of timing out later. The six hand-rolled edit-mode navigations in `customElement.spec.ts` now go through `pageEditorPage.goto`.

**Viewing a page (second commit).** `frontend-js-spa-web/main/settings.spec.ts` views a page to check whether SPA is enabled on it, so a draft URL is the wrong tool — it needs a page it can actually view. Its isolated layout is now published, and a stray slash in the first navigation is removed so the requested path matches the one the test later excludes in the SPA settings.

## Verification

Run locally against a bundle carrying the `isPublished()` gate:

- `creationActions.spec.ts` passes 4/4, and reverting just the navigation change reproduces the exact CI failure.
- `settings.spec.ts` passes 2/2 with the change.
- `navigate.spec.ts`, whose SPA test exercises `PageEditorPage.goto` on an unpublished content layout, passes.
- `iframe.spec.ts` passes 8/10, and `customElement.spec.ts` 9/21. In both, the `Samples` tests that exercise `pageEditorPage.goto` pass. Every failure in both suites shares one unrelated signature: a click in the Client Extension Admin portlet intercepted by the Product Menu side-navigation overlay. Those tests fail before reaching any page-editor navigation, and the first of them does not even take a `layout` fixture.

## Why Are There No Tests?

This PR changes Playwright test infrastructure and specs only; there is no production code to cover. The change is validated by the existing suites it repairs.

## PR Check

**pr-check: PASS** — tested on `6d5db93f4b6395a53e05def451f9cfcb0c21d31a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | N/A |

Per-Module Compile is not applicable: `modules/test/playwright` is not a Gradle subproject, so `:test:playwright:deploy` does not exist. The compile-equivalent signal is the TypeScript check, which passed inside the formatter and standalone via `tsc --noEmit`.

JavaScript Unit Tests is not applicable: this module's `npm test` is `playwright test`, which the pr-check skill puts out of scope. There is no jest suite. See the verification runs above.

<!-- pr-check {"result": "success", "sha": "6d5db93f4b6395a53e05def451f9cfcb0c21d31a"} -->
