### PR TITLE
LPD-101989 Exit with an error when jest tests fail

### DIFF
--- a/modules/frontend-sdk/node-scripts/package.json
+++ b/modules/frontend-sdk/node-scripts/package.json
@@ -4,7 +4,7 @@
 		"node-scripts": "./bin.js"
 	},
 	"com.liferay": {
-		"sha256": "17b438979df8cc61d69dc3d3ad66d424a0c135d28e041d0faf0a17ba36a5d1ab"
+		"sha256": "dd84fbd73e18f45373989cfd5d939a72e1306958345a4d743bcc1d7a00c81179"
 	},
 	"dependencies": {
 		"@babel/preset-env": "7.24.7",

--- a/modules/frontend-sdk/node-scripts/test/index.mjs
+++ b/modules/frontend-sdk/node-scripts/test/index.mjs
@@ -13,16 +13,20 @@ import {PORTAL_DIR} from '../util/locations.mjs';
 import print from '../util/print.mjs';
 import runConcurrentTasks from '../util/runConcurrentTasks.mjs';
 
+const SYNC_FLAG = '--sync';
+
 export default async function () {
 	const {sync} = getNamedArguments({
-		sync: '--sync',
+		sync: SYNC_FLAG,
 	});
 
 	const originalNodeEnv = process.env.NODE_ENV;
 
 	process.env.NODE_ENV = 'test';
 
-	const args = process.argv.slice(3);
+	// Every remaining argument is forwarded to jest, which rejects our own flags
+
+	const args = process.argv.slice(3).filter((arg) => arg !== SYNC_FLAG);
 
 	/**
 	 * When using 'yarn run ...' it sets the cwd to the nearest package.json

--- a/modules/frontend-sdk/node-scripts/test/index.mjs
+++ b/modules/frontend-sdk/node-scripts/test/index.mjs
@@ -73,17 +73,19 @@ export default async function () {
 
 	const totalTestableProjects = testableProjectsMap.size;
 
+	let failed = false;
+
 	if (totalTestableProjects === 1) {
 		const [[projectPath, envObj]] = testableProjectsMap.entries();
 
-		await runJest({
+		({failed} = await runJest({
 			cliFlags: args,
 			execaConfig: {
 				env: envObj,
 				stdio: 'inherit',
 			},
 			projectPath,
-		});
+		}));
 	}
 	else {
 		print(
@@ -99,7 +101,7 @@ export default async function () {
 			asyncItems.push(async () => {
 				const projectName = path.relative(PORTAL_DIR, projectPath);
 
-				const {all, failed} = await runJest({
+				const {all, failed: projectFailed} = await runJest({
 					cliFlags: args,
 					execaConfig: {
 						all: true,
@@ -110,7 +112,7 @@ export default async function () {
 					projectPath,
 				});
 
-				if (failed) {
+				if (projectFailed) {
 					print(
 						1,
 						print.error('FAILED:'),
@@ -127,20 +129,36 @@ export default async function () {
 						'\n'
 					);
 				}
+
+				return projectFailed;
 			});
 		}
 
 		if (sync) {
 			for (const task of asyncItems) {
-				await task('inherit');
+				if (await task()) {
+					failed = true;
+				}
 			}
 		}
 		else {
-			await runConcurrentTasks(asyncItems);
+			const results = await runConcurrentTasks(asyncItems);
+
+			failed = results.some(Boolean);
+		}
+
+		if (failed) {
+			print(
+				0,
+				print.error('ERROR:'),
+				'Some projects have failing tests.\n'
+			);
 		}
 	}
 
 	process.env.NODE_ENV = originalNodeEnv;
+
+	process.exitCode = failed ? 1 : 0;
 }
 
 function getEnvVars(value) {

--- a/modules/frontend-sdk/node-scripts/util/jest/runJest.mjs
+++ b/modules/frontend-sdk/node-scripts/util/jest/runJest.mjs
@@ -44,6 +44,7 @@ export default async function runJest({
 				...execaConfig.env,
 				NODE_ENV: 'test',
 			},
+			reject: false,
 			...execaConfig,
 		};
 

--- a/modules/frontend-sdk/node-scripts/util/jest/runJest.mjs
+++ b/modules/frontend-sdk/node-scripts/util/jest/runJest.mjs
@@ -28,7 +28,7 @@ export default async function runJest({
 	const hasForceDebug = cliFlags.includes(FORCE_DEBUG_FLAG);
 
 	if (!hasForceDebug) {
-		cliFlags.push(SILENT_FLAG);
+		cliFlags = [...cliFlags, SILENT_FLAG];
 	}
 	else {
 		cliFlags = cliFlags.filter((flag) => flag !== FORCE_DEBUG_FLAG);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101989

## What Is Being Fixed

`node-scripts test` reported failures on screen but always terminated with exit code 0, so any CI gate keying on the exit code — or any `yarn test && ...` chain — treated a failing Jest run as green. This was spotted while checking the PR for LPD-100943, where three modules printed failures yet the command still succeeded.

Making the exit code honest uncovered a second defect it had been masking: `--sync` was forwarded verbatim to Jest, which rejects it as an unrecognized option. Every serial run therefore failed on all projects, which nobody noticed while the exit code was always 0.

## How It Is Being Fixed

The flag forwarding is fixed first, so no commit in the series leaves `--sync` broken. `test/index.mjs` now filters `--sync` out of the arguments handed to Jest, following the pattern `runJest.mjs` already uses for `--force-debug`, and the `--silent` append is no longer mutating, so it stops accumulating one copy per project on the shared array.

The exit code itself is fixed by making the failure state reliable and then propagating it. `runJest.mjs` gains `reject: false` in its default execa config, placed before the `...execaConfig` spread so callers can still override it; previously the single-project caller omitted it, so a failing run threw and was swallowed by the surrounding `catch`, which then returned an object the caller discarded. `test/index.mjs` now threads that result out of both branches — destructuring in the single-project case, and returning per-project status from each task in the multi-project case, collected from the results `runConcurrentTasks` already returns — and sets `process.exitCode`. Using `process.exitCode` rather than `process.exit()` avoids truncating the buffered `print()` output and the `onExit` cleanup of `TEMP_jest.config.json`.

## Why Are There No Tests?

node-scripts has no test harness of its own — no `test` script in its `package.json` and no `__tests__` anywhere in the package — so there is nowhere to add a test. The fix was verified by invocation against `modules/apps/document-library` (4 testable projects), covering both outcomes in all three modes: single project, multi-project parallel, and multi-project `--sync`. Passing runs exit 0 and runs with an injected failure exit 1 in every mode.

## PR Check

**pr-check: PASS** — tested on `4f22efcbccb4f8139bbeda863bcf335c833de362`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | PASS |

Per-Module Compile matched on `package.json` but the deploy set is empty — `modules/frontend-sdk` has no Gradle project. JavaScript Unit Tests ran a representative set, since 112 modules consume `node-scripts test`.

<!-- pr-check {"result": "success", "sha": "4f22efcbccb4f8139bbeda863bcf335c833de362"} -->
