### PR TITLE
LPD-102287 Allow form selection in the widget setup under CSP

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -64,7 +64,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 					</div>
 
 					<aui:fieldset>
-						<div class="lfr-ddl-content">
+						<div class="lfr-ddl-content" id="<portlet:namespace />recordSets">
 							<clay:sheet>
 								<liferay-ui:search-container
 									emptyResultsMessage="no-lists-were-found"
@@ -101,35 +101,30 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 									>
 
 										<%
-										StringBundler sb = new StringBundler(7);
-
-										sb.append("javascript:");
-										sb.append(liferayPortletResponse.getNamespace());
-										sb.append("selectRecordSet('");
-										sb.append(recordSet.getRecordSetId());
-										sb.append("','");
-										sb.append(HtmlUtil.escapeJS(recordSet.getName(locale)));
-										sb.append("');");
-
-										String rowURL = sb.toString();
+										row.setData(
+											HashMapBuilder.<String, Object>put(
+												"record-set-id", recordSet.getRecordSetId()
+											).put(
+												"record-set-name", HtmlUtil.unescape(recordSet.getName(locale))
+											).build());
 										%>
 
 										<liferay-ui:search-container-column-text
-											href="<%= rowURL %>"
+											href="#"
 											name="name"
 											orderable="<%= false %>"
 											value="<%= recordSet.getName(locale) %>"
 										/>
 
 										<liferay-ui:search-container-column-text
-											href="<%= rowURL %>"
+											href="#"
 											name="description"
 											orderable="<%= false %>"
 											value="<%= StringUtil.shorten(recordSet.getDescription(locale), 100) %>"
 										/>
 
 										<liferay-ui:search-container-column-date
-											href="<%= rowURL %>"
+											href="#"
 											name="modified-date"
 											orderable="<%= false %>"
 											value="<%= recordSet.getModifiedDate() %>"
@@ -150,7 +145,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 			</liferay-ui:section>
 		</aui:form>
 
-		<aui:form action="<%= configurationActionURL %>" method="post" name="fm">
+		<aui:form action="<%= configurationActionURL %>" data-senna-off="<%= true %>" method="post" name="fm">
 			<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 			<aui:input name="redirect" type="hidden" value='<%= configurationRenderURL.toString() + StringPool.AMPERSAND + liferayPortletResponse.getNamespace() + "cur" + cur %>' />
 			<aui:input name="preferences--recordSetId--" type="hidden" value="<%= recordSetId %>" />
@@ -265,34 +260,64 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 </aui:script>
 
 <aui:script>
-	window['<portlet:namespace />selectRecordSet'] = function (
-		recordSetId,
-		recordSetName
-	) {
-		document.<portlet:namespace />fm.<portlet:namespace />recordSetId.value =
-			recordSetId;
+	if (!window['<portlet:namespace />selectRecordSet']) {
+		window['<portlet:namespace />selectRecordSet'] = function (event) {
+			var rowElement = event.target.closest(
+				'#<portlet:namespace />recordSets [data-record-set-id]'
+			);
 
-		var displayingRecordSetIdHolder = document.querySelector(
-			'.displaying-record-set-id-holder'
-		);
-		displayingRecordSetIdHolder.classList.remove('hide');
-		displayingRecordSetIdHolder.removeAttribute('hidden');
-		displayingRecordSetIdHolder.style.display = '';
+			if (!rowElement) {
+				return;
+			}
 
-		var displayingHelpMessageHolder = document.querySelector(
-			'.displaying-help-message-holder'
-		);
-		displayingHelpMessageHolder.classList.add('hide');
-		displayingHelpMessageHolder.setAttribute('hidden', 'hidden');
-		displayingHelpMessageHolder.style.display = 'none';
+			event.preventDefault();
 
-		var displayRecordSetId = document.querySelector(
-			'.displaying-record-set-id'
+			var recordSetIdInput = document.getElementById(
+				'<portlet:namespace />recordSetId'
+			);
+
+			if (recordSetIdInput) {
+				recordSetIdInput.value = rowElement.dataset.recordSetId;
+			}
+
+			var displayingRecordSetIdHolder = document.querySelector(
+				'.displaying-record-set-id-holder'
+			);
+
+			if (displayingRecordSetIdHolder) {
+				displayingRecordSetIdHolder.classList.remove('hide');
+				displayingRecordSetIdHolder.removeAttribute('hidden');
+				displayingRecordSetIdHolder.style.display = '';
+			}
+
+			var displayingHelpMessageHolder = document.querySelector(
+				'.displaying-help-message-holder'
+			);
+
+			if (displayingHelpMessageHolder) {
+				displayingHelpMessageHolder.classList.add('hide');
+				displayingHelpMessageHolder.setAttribute('hidden', 'hidden');
+				displayingHelpMessageHolder.style.display = 'none';
+			}
+
+			var displayRecordSetId = document.querySelector(
+				'.displaying-record-set-id'
+			);
+
+			if (displayRecordSetId) {
+				displayRecordSetId.textContent =
+					rowElement.dataset.recordSetName +
+					' (<%= UnicodeLanguageUtil.get(request, "modified") %>)';
+
+				displayRecordSetId.classList.add('modified');
+			}
+		};
+
+		document.addEventListener(
+			'click',
+			window['<portlet:namespace />selectRecordSet']
 		);
-		displayRecordSetId.innerHTML =
-			recordSetName + ' (<liferay-ui:message key="modified" />)';
-		displayRecordSetId.classList.add('modified');
-	};
+	}
 </aui:script>
 
 <%!

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
@@ -42,7 +42,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 			</div>
 
 			<aui:fieldset>
-				<div class="lfr-form-content">
+				<div class="lfr-form-content" id="<portlet:namespace />formInstances">
 					<clay:sheet>
 						<liferay-ui:search-container
 							emptyResultsMessage="no-forms-were-found"
@@ -78,21 +78,16 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 							>
 
 								<%
-								StringBundler sb = new StringBundler(7);
-
-								sb.append("javascript:");
-								sb.append(liferayPortletResponse.getNamespace());
-								sb.append("selectFormInstance('");
-								sb.append(formInstance.getFormInstanceId());
-								sb.append("','");
-								sb.append(HtmlUtil.escapeJS(HtmlUtil.escape(formInstance.getName(locale))));
-								sb.append("');");
-
-								String rowURL = sb.toString();
+								row.setData(
+									HashMapBuilder.<String, Object>put(
+										"form-instance-id", formInstance.getFormInstanceId()
+									).put(
+										"form-instance-name", formInstance.getName(locale)
+									).build());
 								%>
 
 								<liferay-ui:search-container-column-text
-									href="<%= rowURL %>"
+									href="#"
 									name="name"
 									orderable="<%= false %>"
 									value="<%= HtmlUtil.escape(formInstance.getName(locale)) %>"
@@ -100,7 +95,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 
 								<liferay-ui:search-container-column-text
 									buffer="buffer"
-									href="<%= rowURL %>"
+									href="#"
 									name="description"
 									orderable="<%= false %>"
 								>
@@ -112,7 +107,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 								</liferay-ui:search-container-column-text>
 
 								<liferay-ui:search-container-column-date
-									href="<%= rowURL %>"
+									href="#"
 									name="modified-date"
 									orderable="<%= false %>"
 									value="<%= formInstance.getModifiedDate() %>"
@@ -132,7 +127,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 	</div>
 </aui:form>
 
-<aui:form action="<%= configurationActionURL %>" method="post" name="fm">
+<aui:form action="<%= configurationActionURL %>" data-senna-off="<%= true %>" method="post" name="fm">
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value='<%= configurationRenderURL.toString() + StringPool.AMPERSAND + liferayPortletResponse.getNamespace() + "cur" + cur %>' />
 	<aui:input name="preferences--formInstanceId--" type="hidden" value="<%= formInstanceId %>" />
@@ -144,14 +139,27 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 </aui:form>
 
 <aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />selectFormInstance',
-		(formInstanceId, formInstanceName) => {
-			document.getElementById('<portlet:namespace />formInstanceId').value =
-				formInstanceId;
+	if (!window['<portlet:namespace />selectFormInstance']) {
+		window['<portlet:namespace />selectFormInstance'] = function (event) {
+			var rowElement = event.target.closest(
+				'#<portlet:namespace />formInstances [data-form-instance-id]'
+			);
 
-			const formInstanceHolder = document.querySelector(
+			if (!rowElement) {
+				return;
+			}
+
+			event.preventDefault();
+
+			var formInstanceIdInput = document.getElementById(
+				'<portlet:namespace />formInstanceId'
+			);
+
+			if (formInstanceIdInput) {
+				formInstanceIdInput.value = rowElement.dataset.formInstanceId;
+			}
+
+			var formInstanceHolder = document.querySelector(
 				'.displaying-form-instance-id-holder'
 			);
 
@@ -159,7 +167,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 				formInstanceHolder.classList.remove('hide');
 			}
 
-			const messageHolder = document.querySelector(
+			var messageHolder = document.querySelector(
 				'.displaying-help-message-holder'
 			);
 
@@ -167,15 +175,22 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 				messageHolder.classList.add('hide');
 			}
 
-			const displayFormInstanceId = document.querySelector(
+			var displayFormInstanceId = document.querySelector(
 				'.displaying-form-instance-id'
 			);
 
-			displayFormInstanceId.innerHTML =
-				formInstanceName + ' (<liferay-ui:message key="modified" />)';
+			if (displayFormInstanceId) {
+				displayFormInstanceId.textContent =
+					rowElement.dataset.formInstanceName +
+					' (<%= UnicodeLanguageUtil.get(request, "modified") %>)';
 
-			displayFormInstanceId.classList.add('modified');
-		},
-		['aui-base']
-	);
+				displayFormInstanceId.classList.add('modified');
+			}
+		};
+
+		document.addEventListener(
+			'click',
+			window['<portlet:namespace />selectFormInstance']
+		);
+	}
 </aui:script>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/init.jsp
@@ -35,7 +35,6 @@ page import="com.liferay.dynamic.data.mapping.validator.DDMFormValuesValidationE
 page import="com.liferay.object.exception.ObjectEntryCountException" %><%@
 page import="com.liferay.object.exception.ObjectEntryValuesException" %><%@
 page import="com.liferay.object.exception.ObjectValidationRuleEngineException" %><%@
-page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.captcha.CaptchaException" %><%@
 page import="com.liferay.portal.kernel.captcha.CaptchaTextException" %><%@


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102287

## What Is Being Fixed

The Forms widget setup screen selected a published form through a `javascript:` URL on each search container row. A nonce based content security policy blocks that, because a URL cannot carry a nonce and `'unsafe-inline'` is ignored as soon as a nonce or `'strict-dynamic'` appears in `script-src`. Under such a policy the form list rendered but clicking a row did nothing, so the widget could not be pointed at a form. The Dynamic Data Lists display widget had the identical defect on its own setup screen.

The same screen also lost its confirmation: after saving, the "You have successfully updated the setup" message never appeared.

## How It Is Being Fixed

Each row now carries the form in `data-form-instance-id` and `data-form-instance-name` attributes set through `ResultRow.setData`, and the selection runs from a delegated click listener registered inside the already nonced script block. No `javascript:` URL remains, so nothing in the flow depends on inline script permissions.

The listener is assigned to a namespaced `window` property behind a guard rather than declared with `const`. Liferay concatenates every deferred script for a portlet into a single script element, so a redeclaration on re-execution raises a SyntaxError that kills every later script in that block, which is what suppressed the confirmation message. Keeping the assignment idempotent and null guarding each lookup means a re-render cannot throw.

Saving also needed `data-senna-off` on the setup form. SPA submitted it over AJAX and followed the action redirect itself, consuming the one shot session message before the iframe rendered it. Turning SPA off for that form restores the browser navigation that carries the message through.

## Why Are There No Tests?

The PT User Business Process Management team should take a further look at this to confirm the fix is correct, and test coverage will follow from there.

## PR Check

**pr-check: PASS** — tested on `9dc36a25bb25c18e94d9cfd7041b1ab7404e7a53`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "9dc36a25bb25c18e94d9cfd7041b1ab7404e7a53"} -->
