### PR TITLE
LPD-102582 Announce form validation messages to screen readers

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
@@ -535,8 +535,9 @@ AUI.add(
 					if (formNode) {
 						const formValidator = new A.FormValidator({
 							boundingBox: formNode,
+							messageContainer: '<div></div>',
 							stackErrorContainer:
-								'<div class="form-feedback-item form-validator-stack help-block"></div>',
+								'<div class="form-feedback-item form-validator-stack help-block" role="alert"></div>',
 							validateOnBlur: instance.get('validateOnBlur'),
 						});
 

--- a/modules/test/playwright/tests/frontend-js-aui-web/main/formValidator.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-aui-web/main/formValidator.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../../fixtures/loginTest';
+import {passwordPoliciesAdminPageTest} from '../../../fixtures/passwordPoliciesAdminConfigPageTest';
+import {checkAccessibility} from '../../../utils/checkAccessibility';
+
+const test = mergeTests(loginTest(), passwordPoliciesAdminPageTest);
+
+test(
+	'The validation message of a required field is announced to screen readers',
+	{tag: '@LPD-102582'},
+	async ({page, passwordPoliciesAdminConfigPage}) => {
+		await passwordPoliciesAdminConfigPage.goTo();
+
+		await passwordPoliciesAdminConfigPage.newButton.click();
+
+		await passwordPoliciesAdminConfigPage.name.click();
+
+		await page.locator('body').click();
+
+		const validationMessage = page.locator('.form-validator-stack');
+
+		await expect(validationMessage).toContainText(
+			'The Name field is required.'
+		);
+
+		await expect(passwordPoliciesAdminConfigPage.name).toHaveAttribute(
+			'aria-errormessage',
+			(await validationMessage.getAttribute('id')) as string
+		);
+
+		await expect(validationMessage).toHaveAttribute('role', 'alert');
+
+		await checkAccessibility({page, soft: false});
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102582

## What Is Being Fixed

Triggering a required-field validation message raised an "ARIA attributes must conform to valid values" error in AXE DevTools. The AUI form validator sets `aria-errormessage` on the invalid field, pointing at the `<field-id>Helper` container that holds the message. That container carried no announcement technique of its own — the `role="alert"` sat on the message `<div>` nested inside it, and `aria-describedby` pointed elsewhere. Axe requires the referenced element itself to be a live region, so a descendant with `role="alert"` does not satisfy the check, and screen readers were not reliably announcing the message.

This is not specific to any one screen. Every `<aui:input required="<%= true %>" />` in the product goes through the same validator, so any form that fails validation produced the violation.

## How It Is Being Fixed

Both templates are configurable attributes on `A.FormValidator`, so the change is contained to Liferay's wrapper in `frontend-js-aui-web` and needs no change to the AlloyUI webjar. `role="alert"` moves onto `stackErrorContainer`, which is the element that receives the `Helper` id and is therefore the element `aria-errormessage` names. It is dropped from `messageContainer` at the same time, so a live region is not nested inside another live region and the message is announced once rather than twice.

The Playwright test drives Password Policies, whose Name field is a plain required `aui:input` with no localization layer around it, keeping the test focused on the validator rather than on any one app's form. It asserts the message renders, that `aria-errormessage` resolves to the container's id, and that the container carries `role="alert"`, then runs an axe scan. The explicit `role` assertion pins the contract directly, so the test keeps its meaning as axe's rule severities change between versions.

## PR Check

**pr-check: PASS** — tested on `44e9ff26afe40e62d062478606d38b863c18e891`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "44e9ff26afe40e62d062478606d38b863c18e891"} -->
