### PR TITLE
LPD-102542 Remove the stray link end tag from the stylesheet includes

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicInclude.java
@@ -50,7 +50,7 @@ public class AUITopHeadCSSDynamicInclude extends BaseDynamicInclude {
 		printWriter.print(
 			ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
 				httpServletRequest));
-		printWriter.print(" rel=\"stylesheet\"></link>\n");
+		printWriter.print(" rel=\"stylesheet\">\n");
 	}
 
 	@Override

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/test/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicIncludeTest.java
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/test/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicIncludeTest.java
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.js.aui.web.internal.servlet.taglib;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+import com.liferay.portal.url.builder.WebContextStylesheetAbsolutePortalURLBuilder;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Georgel Pop
+ */
+public class AUITopHeadCSSDynamicIncludeTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPD-102542")
+	public void testInclude() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		AUITopHeadCSSDynamicInclude auiTopHeadCSSDynamicInclude =
+			new AUITopHeadCSSDynamicInclude();
+
+		String href = RandomTestUtil.randomString();
+
+		ReflectionTestUtil.setFieldValue(
+			auiTopHeadCSSDynamicInclude, "_absolutePortalURLBuilderFactory",
+			_getAbsolutePortalURLBuilderFactory(href, mockHttpServletRequest));
+
+		auiTopHeadCSSDynamicInclude.include(
+			mockHttpServletRequest, mockHttpServletResponse,
+			"/html/common/themes/top_head.jsp#post");
+
+		Assert.assertEquals(
+			"<link data-senna-track=\"permanent\" href=\"" + href +
+				"\" rel=\"stylesheet\">\n",
+			mockHttpServletResponse.getContentAsString());
+	}
+
+	private AbsolutePortalURLBuilderFactory _getAbsolutePortalURLBuilderFactory(
+		String href, MockHttpServletRequest mockHttpServletRequest) {
+
+		AbsolutePortalURLBuilderFactory absolutePortalURLBuilderFactory =
+			Mockito.mock(AbsolutePortalURLBuilderFactory.class);
+
+		WebContextStylesheetAbsolutePortalURLBuilder
+			webContextStylesheetAbsolutePortalURLBuilder = Mockito.mock(
+				WebContextStylesheetAbsolutePortalURLBuilder.class);
+
+		Mockito.when(
+			webContextStylesheetAbsolutePortalURLBuilder.build()
+		).thenReturn(
+			href
+		);
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder = Mockito.mock(
+			AbsolutePortalURLBuilder.class);
+
+		Mockito.when(
+			absolutePortalURLBuilder.forWebContextStylesheet(
+				"frontend-js-aui-web", "/alloy_ui.css")
+		).thenReturn(
+			webContextStylesheetAbsolutePortalURLBuilder
+		);
+
+		Mockito.when(
+			absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				mockHttpServletRequest)
+		).thenReturn(
+			absolutePortalURLBuilder
+		);
+
+		return absolutePortalURLBuilderFactory;
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTag.java
@@ -67,7 +67,7 @@ public class StylesheetTag extends AttributesTagSupport {
 		sb.append(
 			ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
 				httpServletRequest));
-		sb.append(" rel=\"stylesheet\" type=\"text/css\"></link>");
+		sb.append(" rel=\"stylesheet\" type=\"text/css\">");
 
 		outputData.addDataSB(_getOutputKey(), WebKeys.PAGE_TOP, sb);
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTagTest.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTagTest.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.taglib.servlet.taglib;
+
+import com.liferay.frontend.taglib.internal.util.ServicesProvider;
+import com.liferay.portal.kernel.servlet.taglib.util.OutputData;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+import com.liferay.portal.url.builder.WebContextStylesheetAbsolutePortalURLBuilder;
+
+import java.util.Collections;
+import java.util.Hashtable;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.osgi.framework.Bundle;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockPageContext;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * @author Georgel Pop
+ */
+public class StylesheetTagTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@After
+	public void tearDown() {
+		_servicesProviderMockedStatic.close();
+	}
+
+	@Test
+	@TestInfo("LPD-102542")
+	public void testDoEndTag() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		String bundleSymbolicName = RandomTestUtil.randomString();
+		String css = RandomTestUtil.randomString();
+		String href = RandomTestUtil.randomString();
+
+		_setUpServicesProvider(
+			bundleSymbolicName, css, href, mockHttpServletRequest);
+
+		StylesheetTag stylesheetTag = new StylesheetTag();
+
+		stylesheetTag.setBundle(bundleSymbolicName);
+		stylesheetTag.setCss(css);
+		stylesheetTag.setPageContext(
+			new MockPageContext(
+				new MockServletContext(), mockHttpServletRequest));
+
+		stylesheetTag.doEndTag();
+
+		OutputData outputData = (OutputData)mockHttpServletRequest.getAttribute(
+			WebKeys.OUTPUT_DATA);
+
+		Assert.assertEquals(
+			"<link href=\"" + href + "\" rel=\"stylesheet\" type=\"text/css\">",
+			String.valueOf(
+				outputData.getDataSB(
+					bundleSymbolicName + "/" + css, WebKeys.PAGE_TOP)));
+	}
+
+	private void _setUpServicesProvider(
+		String bundleSymbolicName, String css, String href,
+		MockHttpServletRequest mockHttpServletRequest) {
+
+		AbsolutePortalURLBuilderFactory absolutePortalURLBuilderFactory =
+			Mockito.mock(AbsolutePortalURLBuilderFactory.class);
+
+		String webContextPath = RandomTestUtil.randomString();
+
+		Bundle bundle = Mockito.mock(Bundle.class);
+
+		Mockito.when(
+			bundle.getHeaders("")
+		).thenReturn(
+			new Hashtable<>(
+				Collections.singletonMap("Web-ContextPath", webContextPath))
+		);
+
+		_servicesProviderMockedStatic.when(
+			ServicesProvider::getBundleMap
+		).thenReturn(
+			Collections.singletonMap(bundleSymbolicName, bundle)
+		);
+
+		WebContextStylesheetAbsolutePortalURLBuilder
+			webContextStylesheetAbsolutePortalURLBuilder = Mockito.mock(
+				WebContextStylesheetAbsolutePortalURLBuilder.class);
+
+		Mockito.when(
+			webContextStylesheetAbsolutePortalURLBuilder.build()
+		).thenReturn(
+			href
+		);
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder = Mockito.mock(
+			AbsolutePortalURLBuilder.class);
+
+		Mockito.when(
+			absolutePortalURLBuilder.forWebContextStylesheet(
+				webContextPath, css)
+		).thenReturn(
+			webContextStylesheetAbsolutePortalURLBuilder
+		);
+
+		Mockito.when(
+			absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				mockHttpServletRequest)
+		).thenReturn(
+			absolutePortalURLBuilder
+		);
+
+		_servicesProviderMockedStatic.when(
+			ServicesProvider::getAbsolutePortalURLBuilderFactory
+		).thenReturn(
+			absolutePortalURLBuilderFactory
+		);
+	}
+
+	private final MockedStatic<ServicesProvider> _servicesProviderMockedStatic =
+		Mockito.mockStatic(ServicesProvider.class);
+
+}

--- a/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/main/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImpl.java
+++ b/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/main/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImpl.java
@@ -96,7 +96,7 @@ public class PortletDependencyImpl implements PortletDependency {
 				sb.append(
 					ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
 						null));
-				sb.append(" type=\"text/css\"></link>");
+				sb.append(" type=\"text/css\">");
 			}
 			else if (_type == Type.JAVASCRIPT) {
 				sb.append("<script");

--- a/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/test/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImplTest.java
+++ b/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/test/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImplTest.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.dependency.factory.internal;
+
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.PortletDependencyAbsolutePortalURLBuilder;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Georgel Pop
+ */
+public class PortletDependencyImplTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPD-102542")
+	public void testToStringBundler() {
+		AbsolutePortalURLBuilder absolutePortalURLBuilder = Mockito.mock(
+			AbsolutePortalURLBuilder.class);
+
+		PortletDependencyImpl portletDependencyImpl = new PortletDependencyImpl(
+			"main.css", null, null, null, absolutePortalURLBuilder);
+
+		String cssURL = RandomTestUtil.randomString();
+
+		_setUpAbsolutePortalURLBuilder(
+			absolutePortalURLBuilder, portletDependencyImpl, cssURL);
+
+		Assert.assertEquals(
+			"<link href=\"" + cssURL + "\" type=\"text/css\">",
+			String.valueOf(portletDependencyImpl.toStringBundler()));
+
+		portletDependencyImpl = new PortletDependencyImpl(
+			"main.js", null, null, null, absolutePortalURLBuilder);
+
+		String javaScriptURL = RandomTestUtil.randomString();
+
+		_setUpAbsolutePortalURLBuilder(
+			absolutePortalURLBuilder, portletDependencyImpl, javaScriptURL);
+
+		Assert.assertEquals(
+			"<script src=\"" + javaScriptURL +
+				"\" type=\"text/javascript\"></script>",
+			String.valueOf(portletDependencyImpl.toStringBundler()));
+	}
+
+	private void _setUpAbsolutePortalURLBuilder(
+		AbsolutePortalURLBuilder absolutePortalURLBuilder,
+		PortletDependencyImpl portletDependencyImpl, String url) {
+
+		PortletDependencyAbsolutePortalURLBuilder
+			portletDependencyAbsolutePortalURLBuilder = Mockito.mock(
+				PortletDependencyAbsolutePortalURLBuilder.class);
+
+		Mockito.when(
+			portletDependencyAbsolutePortalURLBuilder.build()
+		).thenReturn(
+			url
+		);
+
+		Mockito.when(
+			absolutePortalURLBuilder.forPortletDependency(
+				portletDependencyImpl, PropsValues.PORTLET_DEPENDENCY_CSS_URN,
+				PropsValues.PORTLET_DEPENDENCY_JAVASCRIPT_URN)
+		).thenReturn(
+			portletDependencyAbsolutePortalURLBuilder
+		);
+	}
+
+}


### PR DESCRIPTION
[LPD-102542](https://liferay.atlassian.net/browse/LPD-102542)

Three classes write a `</link>` end tag after a `<link>` element. `<link>` is a void element, so it has no end tag, and the W3C validator reports each one as `Stray end tag "link"`. This surfaced in an STQC markup and accessibility audit of a customer site running DXP.

Only one of the three is visible on an ordinary page. `AUITopHeadCSSDynamicInclude` writes the `alloy_ui.css` link into every page head, which is why the audit reported exactly one stray tag and not three; `StylesheetTag` and `PortletDependencyImpl` fire only for pages that use them. Verified against a local bundle: the stock build renders one stray `</link>` on the guest home page, this branch renders none, and all 21 `<link>` elements are still there.

Each writer gets a unit test, and each was confirmed to fail on master and pass with the fix: `AUITopHeadCSSDynamicIncludeTest.testInclude`, `StylesheetTagTest.testDoEndTag`, and `PortletDependencyImplTest.testToStringBundler`. `frontend-js-aui-web` and `portlet-dependency-factory-impl` had no `src/test` before this; neither needed a `build.gradle` change to get one.

Coming to you rather than through Page Management because CODEOWNERS gives `modules/apps/frontend-js/` and `modules/apps/frontend-taglib/` to @liferay-frontend, and `modules/apps/portlet-dependency-factory/` has no owner listed at all, which is worth knowing separately.

**pr-check: PASS** — tested on `e7847c9b41c2c7dada100fc537ef4f9de0d57a9d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
