### PR TITLE
LPD-102224 Prevent arbitrary JavaScript execution via unvalidated custom: attribute URL

### DIFF
--- a/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/exception/AudiencesEntryAttributeException.java
+++ b/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/exception/AudiencesEntryAttributeException.java
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.audiences.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Miguel Arroyo
+ */
+public class AudiencesEntryAttributeException extends PortalException {
+
+	public AudiencesEntryAttributeException() {
+	}
+
+	public AudiencesEntryAttributeException(String msg) {
+		super(msg);
+	}
+
+	public AudiencesEntryAttributeException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public AudiencesEntryAttributeException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/service/impl/AudiencesEntryLocalServiceImpl.java
+++ b/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/service/impl/AudiencesEntryLocalServiceImpl.java
@@ -5,22 +5,33 @@
 
 package com.liferay.audiences.service.impl;
 
+import com.liferay.audiences.criteria.AudiencesCriteria;
+import com.liferay.audiences.criteria.AudiencesCriteriaProvider;
+import com.liferay.audiences.criteria.AudiencesCriteriaType;
+import com.liferay.audiences.exception.AudiencesEntryAttributeException;
 import com.liferay.audiences.exception.AudiencesEntryJSONException;
 import com.liferay.audiences.exception.AudiencesEntryNameException;
 import com.liferay.audiences.model.AudiencesEntry;
 import com.liferay.audiences.service.base.AudiencesEntryLocalServiceBaseImpl;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
 import com.liferay.portal.json.validator.JSONValidator;
 import com.liferay.portal.json.validator.JSONValidatorException;
 import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -40,14 +51,14 @@ public class AudiencesEntryLocalServiceImpl
 			String externalReferenceCode, long userId, String json, String name)
 		throws PortalException {
 
-		_validate(json, name);
+		User user = _userLocalService.getUser(userId);
+
+		_validate(user.getCompanyId(), json, name);
 
 		AudiencesEntry audiencesEntry = audiencesEntryPersistence.create(
 			counterLocalService.increment());
 
 		audiencesEntry.setExternalReferenceCode(externalReferenceCode);
-
-		User user = _userLocalService.getUser(userId);
 
 		audiencesEntry.setCompanyId(user.getCompanyId());
 		audiencesEntry.setUserId(user.getUserId());
@@ -108,10 +119,10 @@ public class AudiencesEntryLocalServiceImpl
 			String json, String name)
 		throws PortalException {
 
-		_validate(json, name);
-
 		AudiencesEntry audiencesEntry =
 			audiencesEntryPersistence.findByPrimaryKey(audiencesEntryId);
+
+		_validate(audiencesEntry.getCompanyId(), json, name);
 
 		audiencesEntry.setExternalReferenceCode(externalReferenceCode);
 
@@ -126,7 +137,9 @@ public class AudiencesEntryLocalServiceImpl
 		return audiencesEntryPersistence.update(audiencesEntry);
 	}
 
-	private void _validate(String json, String name) throws PortalException {
+	private void _validate(long companyId, String json, String name)
+		throws PortalException {
+
 		try {
 			_criteriaJSONValidator.validate(json);
 		}
@@ -138,6 +151,59 @@ public class AudiencesEntryLocalServiceImpl
 		if (Validator.isNull(name)) {
 			throw new AudiencesEntryNameException();
 		}
+
+		_validateAttributes(companyId, json);
+	}
+
+	private void _validateAttributes(
+			JSONObject jsonObject, Set<String> validAttributes)
+		throws PortalException {
+
+		JSONArray rulesJSONArray = jsonObject.getJSONArray("rules");
+
+		if (rulesJSONArray == null) {
+			String attribute = jsonObject.getString("attribute");
+
+			if (attribute.startsWith("custom:") &&
+				!validAttributes.contains(attribute)) {
+
+				throw new AudiencesEntryAttributeException(
+					StringBundler.concat(
+						"Attribute \"", attribute,
+						"\" is not a valid custom attribute"));
+			}
+
+			return;
+		}
+
+		for (int i = 0; i < rulesJSONArray.length(); i++) {
+			_validateAttributes(
+				rulesJSONArray.getJSONObject(i), validAttributes);
+		}
+	}
+
+	private void _validateAttributes(long companyId, String json)
+		throws PortalException {
+
+		if (Validator.isNull(json)) {
+			return;
+		}
+
+		Set<String> validAttributes = new HashSet<>();
+
+		for (AudiencesCriteriaType audiencesCriteriaType :
+				_audiencesCriteriaProvider.getAudiencesCriteriaTypes(
+					companyId, LocaleUtil.getSiteDefault())) {
+
+			for (AudiencesCriteria audiencesCriteria :
+					audiencesCriteriaType.getAudiencesCriterias()) {
+
+				validAttributes.add(audiencesCriteria.getKey());
+			}
+		}
+
+		_validateAttributes(
+			_jsonFactory.createJSONObject(json), validAttributes);
 	}
 
 	private static final JSONValidator _criteriaJSONValidator =
@@ -146,7 +212,13 @@ public class AudiencesEntryLocalServiceImpl
 				"dependencies/audiences-criteria-json-schema.json"));
 
 	@Reference
+	private AudiencesCriteriaProvider _audiencesCriteriaProvider;
+
+	@Reference
 	private CustomSQL _customSQL;
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/portlet/action/UpdateAudiencesEntryMVCActionCommand.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/portlet/action/UpdateAudiencesEntryMVCActionCommand.java
@@ -6,6 +6,7 @@
 package com.liferay.audiences.web.internal.portlet.action;
 
 import com.liferay.audiences.constants.AudiencesPortletKeys;
+import com.liferay.audiences.exception.AudiencesEntryAttributeException;
 import com.liferay.audiences.exception.AudiencesEntryJSONException;
 import com.liferay.audiences.exception.AudiencesEntryNameException;
 import com.liferay.audiences.exception.DuplicateAudiencesEntryExternalReferenceCodeException;
@@ -92,7 +93,14 @@ public class UpdateAudiencesEntryMVCActionCommand extends BaseMVCActionCommand {
 	private JSONObject _getErrorJSONObject(
 		Exception exception, ThemeDisplay themeDisplay) {
 
-		if (exception instanceof AudiencesEntryJSONException) {
+		if (exception instanceof AudiencesEntryAttributeException) {
+			return JSONUtil.put(
+				"other",
+				_language.get(
+					themeDisplay.getLocale(),
+					"you-have-entered-an-invalid-custom-attribute"));
+		}
+		else if (exception instanceof AudiencesEntryJSONException) {
 			return JSONUtil.put(
 				"other",
 				_language.get(

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -25492,6 +25492,7 @@ you-have-been-invited-to-collaborate-in-the-x-space=You have been invited to col
 you-have-been-logged-off-because-you-signed-on-with-this-account-using-a-different-session=You have been logged off because you signed on with this account using a different session.
 you-have-been-removed-from-x=You have been removed from {0}.
 you-have-blocked-this-user=You have blocked this user.
+you-have-entered-an-invalid-custom-attribute=You have entered an invalid custom attribute.
 you-have-entered-invalid-data=You have entered invalid data. Please try again.
 you-have-entered-invalid-json=You have entered invalid JSON.
 you-have-exceeded-the-maximum-amount-of-x-files-allowed-per-envelope=You have exceeded the maximum amount of {0} files allowed per envelope.


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-102224

## What is being fixed
An Audiences author only needs the low-privilege `MANAGE_AUDIENCES_ENTRIES` permission to persist a criterion whose `attribute` is `custom:<any URL>`. Neither the JSON schema nor `AudiencesEntryLocalServiceImpl` verified that the URL corresponded to a client extension an administrator had actually registered. The client resolves that URL with a dynamic `import()` on every page view, so an author could get arbitrary JavaScript to execute in every visitor's browser, including administrators — a stored XSS and privilege escalation.

## How it is fixed
`AudiencesEntryLocalServiceImpl` now walks the criteria tree and checks every `custom:` attribute against the criteria `AudiencesCriteriaProvider` currently exposes for the entry's company, which already reflects both registered client extensions and the built-in general attributes. Anything else is rejected with the new `AudiencesEntryAttributeException`, surfaced by the portlet action as a friendly validation error.