### PR TITLE
LPD-89791 Store a Data Set's recent searches in local storage

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/recentSearches.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/recentSearches.ts
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {localStorage} from 'frontend-js-web';
+
+const DEFAULT_MAX_ENTRIES = 20;
+
+const STORAGE_KEY_PREFIX = 'LFR_RECENT_SEARCHES_';
+
+/**
+ * Stores a search query, most recent first.
+ *
+ * Queries are deduplicated case insensitively, and a query that continues a
+ * stored query within the same word replaces it, so typing "pant" and then
+ * "pantalon" leaves only "pantalon". A query that merely extends a stored one
+ * at a word boundary is kept alongside it, because the two read as different
+ * intents: "lego" and "lego star wars" are both stored.
+ *
+ * @param fdsName Name of the Data Set the query belongs to
+ * @param query The search query to store
+ * @param options Caps the history, evicting the oldest queries. Defaults to 20
+ * entries.
+ */
+function add(
+	fdsName: string,
+	query: string,
+	{maxEntries = DEFAULT_MAX_ENTRIES}: {maxEntries?: number} = {}
+): void {
+	const search = query.trim();
+
+	if (!search) {
+		return;
+	}
+
+	const recentSearches = get(fdsName);
+
+	if (
+		recentSearches.some((recentSearch) =>
+			_continuesWord(search, recentSearch)
+		)
+	) {
+		return;
+	}
+
+	_setRecentSearches(
+		fdsName,
+		[
+			search,
+			...recentSearches.filter(
+				(recentSearch) =>
+					!_isSameSearch(recentSearch, search) &&
+					!_continuesWord(recentSearch, search)
+			),
+		].slice(0, maxEntries)
+	);
+}
+
+/**
+ * Removes every stored search query for a Data Set.
+ *
+ * @param fdsName Name of the Data Set
+ */
+function clear(fdsName: string): void {
+	localStorage.removeItem(_getStorageKey(fdsName));
+}
+
+/**
+ * Returns the stored search queries for a Data Set, most recent first, or an
+ * empty array when there are none or the stored value cannot be read.
+ *
+ * @param fdsName Name of the Data Set
+ */
+function get(fdsName: string): string[] {
+	let recentSearches;
+
+	try {
+		recentSearches = JSON.parse(
+			localStorage.getItem(
+				_getStorageKey(fdsName),
+				localStorage.TYPES.FUNCTIONAL
+			) as string
+		);
+	}
+	catch (error) {
+		return [];
+	}
+
+	if (
+		!Array.isArray(recentSearches) ||
+		recentSearches.some((recentSearch) => typeof recentSearch !== 'string')
+	) {
+		return [];
+	}
+
+	return recentSearches;
+}
+
+/**
+ * Removes a single stored search query, matched case insensitively.
+ *
+ * @param fdsName Name of the Data Set
+ * @param query The search query to remove
+ */
+function remove(fdsName: string, query: string): void {
+	_setRecentSearches(
+		fdsName,
+		get(fdsName).filter(
+			(recentSearch) => !_isSameSearch(recentSearch, query)
+		)
+	);
+}
+
+function _continuesWord(prefix: string, search: string): boolean {
+	const normalizedPrefix = _normalize(prefix);
+	const normalizedSearch = _normalize(search);
+
+	return (
+		normalizedSearch.length > normalizedPrefix.length &&
+		normalizedSearch.startsWith(normalizedPrefix) &&
+		normalizedSearch[normalizedPrefix.length] !== ' '
+	);
+}
+
+function _getStorageKey(fdsName: string): string {
+	return `${STORAGE_KEY_PREFIX}${fdsName}`;
+}
+
+function _isSameSearch(search: string, otherSearch: string): boolean {
+	return _normalize(search) === _normalize(otherSearch);
+}
+
+function _normalize(search: string): string {
+	return search.trim().toLowerCase();
+}
+
+function _setRecentSearches(fdsName: string, recentSearches: string[]): void {
+	try {
+		localStorage.setItem(
+			_getStorageKey(fdsName),
+			JSON.stringify(recentSearches),
+			localStorage.TYPES.FUNCTIONAL
+		);
+	}
+	catch (error) {
+
+		// Local storage may be unavailable or out of quota
+
+	}
+}
+
+export default {
+	add,
+	clear,
+	get,
+	remove,
+};

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/recentSearches.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/recentSearches.ts
@@ -18,7 +18,8 @@ function setStoredValue(value: string) {
 
 describe('recentSearches', () => {
 	afterEach(() => {
-		localStorage.clear();
+		recentSearches.clear(FDS_NAME);
+		recentSearches.clear(OTHER_FDS_NAME);
 	});
 
 	describe('add', () => {
@@ -162,9 +163,20 @@ describe('recentSearches', () => {
 		});
 
 		it('returns queries stored before a page reload', () => {
-			setStoredValue(JSON.stringify(['pantalon', 'camiseta']));
+			recentSearches.add(FDS_NAME, 'camiseta');
+			recentSearches.add(FDS_NAME, 'pantalon');
 
-			expect(recentSearches.get(FDS_NAME)).toEqual([
+			// A reload leaves the module registry behind, so a freshly imported
+			// API reads the queries the way the next page load does
+
+			let reloadedRecentSearches!: typeof recentSearches;
+
+			jest.isolateModules(() => {
+				reloadedRecentSearches =
+					require('../../src/main/resources/META-INF/resources/utils/recentSearches').default;
+			});
+
+			expect(reloadedRecentSearches.get(FDS_NAME)).toEqual([
 				'pantalon',
 				'camiseta',
 			]);

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/recentSearches.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/recentSearches.ts
@@ -1,0 +1,222 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {localStorage} from 'frontend-js-web';
+
+import recentSearches from '../../src/main/resources/META-INF/resources/utils/recentSearches';
+
+const FDS_NAME = 'FDS_NAME';
+const OTHER_FDS_NAME = 'OTHER_FDS_NAME';
+
+const STORAGE_KEY = `LFR_RECENT_SEARCHES_${FDS_NAME}`;
+
+function setStoredValue(value: string) {
+	localStorage.setItem(STORAGE_KEY, value, localStorage.TYPES.FUNCTIONAL);
+}
+
+describe('recentSearches', () => {
+	afterEach(() => {
+		localStorage.clear();
+	});
+
+	describe('add', () => {
+		it('stores a query', () => {
+			recentSearches.add(FDS_NAME, 'pantalon');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['pantalon']);
+		});
+
+		it('trims surrounding whitespace', () => {
+			recentSearches.add(FDS_NAME, '  pantalon  ');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['pantalon']);
+		});
+
+		it('ignores an empty or whitespace only query', () => {
+			recentSearches.add(FDS_NAME, '');
+			recentSearches.add(FDS_NAME, '   ');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual([]);
+		});
+
+		it('returns unrelated queries most recent first', () => {
+			recentSearches.add(FDS_NAME, 'blogs');
+			recentSearches.add(FDS_NAME, 'documents');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual([
+				'documents',
+				'blogs',
+			]);
+		});
+
+		it('moves a repeated query to the front without duplicating it', () => {
+			recentSearches.add(FDS_NAME, 'blogs');
+			recentSearches.add(FDS_NAME, 'documents');
+			recentSearches.add(FDS_NAME, 'blogs');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual([
+				'blogs',
+				'documents',
+			]);
+		});
+
+		it('deduplicates a repeated query case insensitively', () => {
+			recentSearches.add(FDS_NAME, 'Pantalon');
+			recentSearches.add(FDS_NAME, 'pantalon');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['pantalon']);
+		});
+
+		it('replaces a stored query the new query continues within a word', () => {
+			recentSearches.add(FDS_NAME, 'pant');
+			recentSearches.add(FDS_NAME, 'pantalon');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['pantalon']);
+		});
+
+		it('replaces every stored query the new query continues within a word', () => {
+			recentSearches.add(FDS_NAME, 'pa');
+			recentSearches.add(FDS_NAME, 'pan');
+			recentSearches.add(FDS_NAME, 'pant');
+			recentSearches.add(FDS_NAME, 'pantalon');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['pantalon']);
+		});
+
+		it('discards a new query a stored query continues within a word', () => {
+			recentSearches.add(FDS_NAME, 'pantalon');
+			recentSearches.add(FDS_NAME, 'pant');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['pantalon']);
+		});
+
+		it('keeps both queries when the shorter one ends at a word boundary', () => {
+			recentSearches.add(FDS_NAME, 'lego');
+			recentSearches.add(FDS_NAME, 'lego star wars');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual([
+				'lego star wars',
+				'lego',
+			]);
+		});
+
+		it('replaces a stored query continued within the last word of the new query', () => {
+			recentSearches.add(FDS_NAME, 'lego s');
+			recentSearches.add(FDS_NAME, 'lego star wars');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['lego star wars']);
+		});
+
+		it('evicts the oldest query beyond the given maximum', () => {
+			recentSearches.add(FDS_NAME, 'a', {maxEntries: 2});
+			recentSearches.add(FDS_NAME, 'b', {maxEntries: 2});
+			recentSearches.add(FDS_NAME, 'c', {maxEntries: 2});
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['c', 'b']);
+		});
+
+		it('stores at most twenty queries by default', () => {
+			const queries = Array.from({length: 21}, (value, index) =>
+				String.fromCharCode(97 + index)
+			);
+
+			queries.forEach((query) => recentSearches.add(FDS_NAME, query));
+
+			const storedSearches = recentSearches.get(FDS_NAME);
+
+			expect(storedSearches).toHaveLength(20);
+			expect(storedSearches[0]).toBe('u');
+			expect(storedSearches).not.toContain('a');
+		});
+
+		it('isolates queries per Data Set', () => {
+			recentSearches.add(FDS_NAME, 'pantalon');
+			recentSearches.add(OTHER_FDS_NAME, 'camiseta');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['pantalon']);
+			expect(recentSearches.get(OTHER_FDS_NAME)).toEqual(['camiseta']);
+		});
+	});
+
+	describe('clear', () => {
+		it('removes every query of a Data Set and leaves the other Data Sets alone', () => {
+			recentSearches.add(FDS_NAME, 'pantalon');
+			recentSearches.add(OTHER_FDS_NAME, 'camiseta');
+
+			recentSearches.clear(FDS_NAME);
+
+			expect(recentSearches.get(FDS_NAME)).toEqual([]);
+			expect(recentSearches.get(OTHER_FDS_NAME)).toEqual(['camiseta']);
+		});
+	});
+
+	describe('get', () => {
+		it('scopes the stored value by the Data Set name', () => {
+			recentSearches.add(FDS_NAME, 'pantalon');
+
+			expect(
+				localStorage.getItem(STORAGE_KEY, localStorage.TYPES.FUNCTIONAL)
+			).toBe(JSON.stringify(['pantalon']));
+		});
+
+		it('returns queries stored before a page reload', () => {
+			setStoredValue(JSON.stringify(['pantalon', 'camiseta']));
+
+			expect(recentSearches.get(FDS_NAME)).toEqual([
+				'pantalon',
+				'camiseta',
+			]);
+		});
+
+		it('returns an empty array for a Data Set without queries', () => {
+			expect(recentSearches.get(OTHER_FDS_NAME)).toEqual([]);
+		});
+
+		it('returns an empty array when the stored value is not valid JSON', () => {
+			setStoredValue('pantalon');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual([]);
+		});
+
+		it('returns an empty array when the stored value is not an array', () => {
+			setStoredValue(JSON.stringify({query: 'pantalon'}));
+
+			expect(recentSearches.get(FDS_NAME)).toEqual([]);
+		});
+
+		it('returns an empty array when the stored value holds anything but strings', () => {
+			setStoredValue(JSON.stringify(['pantalon', 7]));
+
+			expect(recentSearches.get(FDS_NAME)).toEqual([]);
+		});
+	});
+
+	describe('remove', () => {
+		it('removes a single query and keeps the rest', () => {
+			recentSearches.add(FDS_NAME, 'blogs');
+			recentSearches.add(FDS_NAME, 'documents');
+
+			recentSearches.remove(FDS_NAME, 'blogs');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['documents']);
+		});
+
+		it('removes a query case insensitively', () => {
+			recentSearches.add(FDS_NAME, 'pantalon');
+
+			recentSearches.remove(FDS_NAME, 'Pantalon');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual([]);
+		});
+
+		it('keeps the stored queries when the query is not stored', () => {
+			recentSearches.add(FDS_NAME, 'pantalon');
+
+			recentSearches.remove(FDS_NAME, 'camiseta');
+
+			expect(recentSearches.get(FDS_NAME)).toEqual(['pantalon']);
+		});
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89791

## Goal

Give Frontend Data Set a way to show users the search queries they ran before, without depending on Analytics Cloud or any backend. The only recent searches machinery in the portal today is the Analytics Cloud suggestions contributors under modules/apps/portal-search/portal-search, which answer from the server and require Analytics Cloud to be configured. Frontend Data Set itself persists nothing in web storage; its only state is the URL config param.

This story delivers the storage layer alone. There is no UI. The Frontend Data Set search input consumes this in a later story, which is also where the corner case of a query already present in the URL on page load gets wired up.

## Technical Details

The API stores the queries on the device, keyed by Data Set, so the history is relative to the browser rather than the account. Only the query strings are kept, which makes it a functional operation that needs no explicit consent. The four operations ship as a single recentSearches namespace with add, clear, get and remove, following dateUtils and mimeTypeUtils, so that recent items can land beside it later as its own namespace instead of adding eight flat names.

It lives in frontend-data-set-web rather than in the shared frontend-js-web barrel. Its parameter is a Data Set name and its storage key is LFR_RECENT_SEARCHES_<fdsName>, so it means nothing without a Data Set, and putting it in the portal wide barrel would commit every module to an API only this one can use. Nothing outside this module consumes it either, so it is deliberately left off the module's own public barrel until something does; adding it later is one line.

Storage goes through the consent aware wrapper that frontend-js-web already exports rather than the global, since @liferay/portal/no-global-storage forbids the latter, and every call passes the functional consent type. Reads validate that the parsed value is an array of strings and writes swallow quota and private mode failures, neither of which the wrapper handles on its own.

A query that continues a stored query within the same word replaces it, so typing pant and then pantalon leaves one entry, while a query that extends a stored one at a word boundary is kept alongside it, because lego and lego star wars read as different intents. Note this is narrower than the acceptance criteria as literally written, which ask for any prefix extension to replace the existing entry.

## PR Check

**pr-check: PASS** — tested on `8bb694d276170300b32570999fd1fef538f2ff12`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8bb694d276170300b32570999fd1fef538f2ff12"} -->
