### PR TITLE
LPD-102879 Delete the Data Set the search configuration test creates

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/search.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/search.spec.ts
@@ -259,6 +259,8 @@ test('Search Bar is shown/hidden according to FDS configuration', async ({
 	const erc =
 		'com_liferay_frontend_data_set_sample_web_internal_portlet_FDSSamplePortlet-advanced';
 
+	let createdDataSet = false;
+
 	await test.step('Check that the search bar is shown by default', async () => {
 		await expect(fdsSamplePage.managementToolbar.searchInput).toBeVisible();
 	});
@@ -284,6 +286,8 @@ test('Search Bar is shown/hidden according to FDS configuration', async ({
 				showSearch: false,
 				snapshotsEnabled: true,
 			});
+
+			createdDataSet = true;
 		}
 	});
 
@@ -296,9 +300,14 @@ test('Search Bar is shown/hidden according to FDS configuration', async ({
 	});
 
 	await test.step('Reset FDS configuration', async () => {
-		await dataSetManagerApiHelpers.updateDataSet({
-			erc,
-			showSearch: true,
-		});
+		if (createdDataSet) {
+			await dataSetManagerApiHelpers.deleteDataSet({erc});
+		}
+		else {
+			await dataSetManagerApiHelpers.updateDataSet({
+				erc,
+				showSearch: true,
+			});
+		}
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102879

## What Is Being Fixed

The `Search Bar is shown/hidden according to FDS configuration` test needs a Data Set for the Advanced tab of the Frontend Data Set sample widget so it can turn the search bar off, and creates one when the bundle has none. Its teardown only turned the search bar back on, so the Data Set stayed behind.

That external reference code is the Data Set name of a system Data Set. A persisted Data Set under that name makes `CustomFDSSerializer` win over `SystemFDSSerializer`, and the sorts and actions the sample contributes in Java stop reaching the UI. Three accessibility tests then fail on every later run against the same bundle, timing out on the Order dropdown, the bulk selection toolbar and the row Actions button: `Advanced FDS is accessible during sorting interactions`, `Advanced FDS is accessible during bulk selection` and `Advanced FDS is accessible in row item actions`.

That the shadowing discards the system sorts and actions at all is a separate defect, filed as LPD-102880 and left alone here.

## How It Is Being Fixed

The test records whether it was the one that created the Data Set, and deletes it in that case. A Data Set it found already in place is left alone, since that one is not the test's to remove, and turning its search bar back on remains the right teardown for it.

## Why Are There No Tests?

The change is confined to the teardown of an existing Playwright test, so there is no product code for a new test to cover. It was verified by running the affected specs: the test now leaves no Data Set behind, and `tests/frontend-data-set-web/main/tests/advanced` goes from three failures to 9 passed.

## PR Check

**pr-check: PASS** — tested on `aeedec42ac1c5819c2ecd76ec002e076b0440842`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

Per-Module Compile and JavaScript Unit Tests matched on the changed `.ts` path but were not applicable and did not run: `modules/test/playwright` has no `bnd.bnd` or `.lfrbuild-portal`, so it is not a deployable module, and its `test` script is `playwright test` with no jest suite. Playwright runs are out of pr-check's scope.

<!-- pr-check {"result": "success", "sha": "aeedec42ac1c5819c2ecd76ec002e076b0440842"} -->

