### PR TITLE
LPD-102873 Move the jsdoc dependency to the root package.json

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
@@ -25,7 +25,6 @@
 		"dynamic-data-mapping-form-field-type": "*",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
-		"jsdoc": "3.6.3",
 		"object-hash": "2.2.0",
 		"react": "18.2.0",
 		"react-dnd": "11.1.1",

--- a/modules/frontend-sdk/node-scripts/package.json
+++ b/modules/frontend-sdk/node-scripts/package.json
@@ -4,7 +4,7 @@
 		"node-scripts": "./bin.js"
 	},
 	"com.liferay": {
-		"sha256": "8da17678fe43ee5aa29f9fb1f2c1d647c7528ec55bdfdf76e67ec6abcc1fea9c"
+		"sha256": "1d4b284b69d918b578997b22a3eefd61e72c8220c14a3a7db68aeadeca8beff8"
 	},
 	"dependencies": {
 		"@babel/preset-env": "7.24.7",

--- a/modules/frontend-sdk/node-scripts/util/format/formatters/ALLOWED_ROOT_PACKAGE_JSON_DEPENDENCIES.mjs
+++ b/modules/frontend-sdk/node-scripts/util/format/formatters/ALLOWED_ROOT_PACKAGE_JSON_DEPENDENCIES.mjs
@@ -13,4 +13,14 @@ export default [
 	// file so it belongs to the global 'package.json'.
 
 	'eslint-plugin-react-compiler',
+
+	// The jsdoc Gradle task injects a jsdoc dependency at build time and relies on the install
+	// resolving its transitive tree. On a developer machine yarn fetches the tree from the
+	// registry, so the task passes and hides the problem; CI installs offline from a mirror keyed
+	// to the lockfile, and the lockfile no longer carries the tree, so jsdoc lands without its
+	// dependencies and node dies on the first require.
+	//
+	// See https://github.com/brianchandotcom/liferay-portal/pull/180382 for more information.
+
+	'jsdoc',
 ];

--- a/modules/package.json
+++ b/modules/package.json
@@ -18,6 +18,7 @@
 		"@types/warning": "3.0.0",
 		"@types/yauzl": "2.10.3",
 		"eslint-plugin-react-compiler": "19.0.0-beta-8a03594-20241020",
+		"jsdoc": "3.6.3",
 		"typescript": "4.7.4"
 	},
 	"private": true,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102873

## What Is Being Fixed

The `jsdoc` dependency was declared in `dynamic-data-mapping-form-web/package.json`, but nothing in that module uses it. It is the Gradle `jsdoc` task that needs it, and that task runs across the whole project, so the declaration sat in a module that had no claim to it while the consumer that actually depends on it had no declaration of its own.

## How It Is Being Fixed

The dependency moves up to the root `modules/package.json`, where the project-wide tooling it serves belongs, and comes out of `dynamic-data-mapping-form-web`. Because the root `package.json` is guarded by a formatter that rejects dependencies not on an explicit allowlist, `jsdoc` is added to `ALLOWED_ROOT_PACKAGE_JSON_DEPENDENCIES.mjs` alongside a comment recording why it has to live there: the Gradle task injects `jsdoc` at build time and relies on the install resolving its transitive tree, which succeeds against the registry on a developer machine but not against CI's offline mirror unless the tree is in the lockfile. The `node-scripts` `sha256` is updated to match the changed formatter.

## Why Are There No Tests?

The change only moves a dependency declaration between `package.json` files and adds an entry to a formatter allowlist constant, so there is no runtime behavior to cover. The failure mode it addresses is the offline install itself, which CI exercises on this pull request.

## PR Check

**pr-check: PASS** — tested on `10f53d7bf27f6fec9f474326e17d20bc23ee671d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "10f53d7bf27f6fec9f474326e17d20bc23ee671d"} -->
