### PR TITLE
LPD-34688 Add accessible name to the CKEditor 4 editable

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChatBody.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChatBody.tsx
@@ -7,7 +7,7 @@ import ClayButton from '@clayui/button';
 import ClayForm, {ClayInputGroupAI} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import React, {useEffect} from 'react';
+import React from 'react';
 
 import AIAssistantFooterDisclaimer from './components/AIAssistantFooterDisclaimer';
 import AIAssistantMessageBalloon from './components/AIAssistantMessageBalloon';
@@ -34,7 +34,7 @@ const AIAssistantChatBody: React.FC<AIAssistantChatBodyProps> = ({
 		isGenerating,
 		message,
 		messages,
-		messagesEndRef,
+		messagesContainerRef,
 		sendMessage,
 		setMessage,
 	} = chat;
@@ -45,10 +45,6 @@ const AIAssistantChatBody: React.FC<AIAssistantChatBodyProps> = ({
 		aiState = 'working';
 	}
 
-	useEffect(() => {
-		messagesEndRef.current?.scrollIntoView();
-	}, [messagesEndRef]);
-
 	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();
 
@@ -57,7 +53,10 @@ const AIAssistantChatBody: React.FC<AIAssistantChatBodyProps> = ({
 
 	return (
 		<>
-			<div className="ai-assistant-chat__messages-container">
+			<div
+				className="ai-assistant-chat__messages-container"
+				ref={messagesContainerRef}
+			>
 				{showGreeting && (
 					<AIAssistantMessageBalloon
 						error={false}
@@ -87,8 +86,6 @@ const AIAssistantChatBody: React.FC<AIAssistantChatBodyProps> = ({
 						</span>
 					</div>
 				)}
-
-				<div ref={messagesEndRef} />
 			</div>
 
 			{!!quickActions?.length && (

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/api.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/api.ts
@@ -84,10 +84,10 @@ export async function postChatByExternalReferenceCodeMessage({
 	const authorizationToken = await postAuthorizationToken();
 
 	if (!authorizationToken) {
-		return;
+		throw new Error('Unable to authorize the chat message request');
 	}
 
-	return await fetch(
+	const response = await fetch(
 		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/chats/by-external-reference-code/${eventSourceReference}/messages`,
 		{
 			body: JSON.stringify({
@@ -105,4 +105,10 @@ export async function postChatByExternalReferenceCodeMessage({
 			method: 'POST',
 		}
 	);
+
+	if (!response.ok) {
+		throw new Error(`Unable to send the chat message: ${response.status}`);
+	}
+
+	return response;
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -56,10 +56,10 @@ html#{$cadmin-selector} {
 		}
 
 		&--categorization {
-			height: stretch;
+			align-self: stretch;
 
 			.lexicon-icon {
-				font-size: 14px;
+				font-size: 12px;
 			}
 		}
 	}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -358,6 +358,11 @@ html#{$cadmin-selector} .cadmin {
 				display: flex;
 				gap: 0.5rem;
 				padding: 0.5rem;
+
+				.ai-assistant-chat__message-balloon-icon {
+					margin-left: 0;
+					margin-top: 0.125rem;
+				}
 			}
 
 			&-form {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -17,39 +17,49 @@ html#{$cadmin-selector} {
 		margin-right: 0.5rem;
 	}
 
-	.ai-assistant-chat__trigger.btn {
-		align-items: center;
-		background-color: transparent;
-		color: #aa33ff;
-		display: inline-flex;
-		justify-content: center;
-
-		.ai-assistant-chat__trigger-label {
-			-webkit-background-clip: text;
-			background-clip: text;
-			background-image: linear-gradient(
-				135.99deg,
-				#aa33ff 4.37%,
-				#0b5fff 98.53%
-			);
-			margin-left: 0.5rem;
-			-webkit-text-fill-color: transparent;
-		}
-
-		&:hover {
-			background-color: var(--Color-Charts-Purple-purple-l5, #f2e5ff);
-		}
-
-		&[aria-expanded='true'] {
-			background: linear-gradient(
-				135.99deg,
-				#aa33ff 4.37%,
-				#0b5fff 98.53%
-			);
-			color: #fff;
+	.ai-assistant-chat__trigger {
+		&.btn {
+			align-items: center;
+			background-color: transparent;
+			color: #aa33ff;
+			display: inline-flex;
+			justify-content: center;
 
 			.ai-assistant-chat__trigger-label {
-				-webkit-text-fill-color: #fff;
+				-webkit-background-clip: text;
+				background-clip: text;
+				background-image: linear-gradient(
+					135.99deg,
+					#aa33ff 4.37%,
+					#0b5fff 98.53%
+				);
+				margin-left: 0.5rem;
+				-webkit-text-fill-color: transparent;
+			}
+
+			&:hover {
+				background-color: var(--Color-Charts-Purple-purple-l5, #f2e5ff);
+			}
+
+			&[aria-expanded='true'] {
+				background: linear-gradient(
+					135.99deg,
+					#aa33ff 4.37%,
+					#0b5fff 98.53%
+				);
+				color: #fff;
+
+				.ai-assistant-chat__trigger-label {
+					-webkit-text-fill-color: #fff;
+				}
+			}
+		}
+
+		&--categorization {
+			height: stretch;
+
+			.lexicon-icon {
+				font-size: 14px;
 			}
 		}
 	}
@@ -113,6 +123,10 @@ html#{$cadmin-selector} .cadmin {
 	.ai-assistant-chat__panel-actions {
 		align-items: center;
 		display: flex;
+
+		.lexicon-icon {
+			font-size: 12px;
+		}
 	}
 
 	.ai-assistant-chat__panel-actions-separator {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/chat.scss
@@ -358,12 +358,6 @@ html#{$cadmin-selector} .cadmin {
 				display: flex;
 				gap: 0.5rem;
 				padding: 0.5rem;
-
-				.lexicon-icon {
-					color: $cadmin-primary;
-					flex-shrink: 0;
-					margin-top: 0.125rem;
-				}
 			}
 
 			&-form {
@@ -406,17 +400,22 @@ html#{$cadmin-selector} .cadmin {
 			}
 		}
 
+		.ai-assistant-chat__message-balloon-icon {
+			color: $cadmin-primary;
+			display: inline-block;
+			flex-shrink: 0;
+			font-size: 12px;
+			margin-left: 0.5rem;
+			margin-top: 0.5rem;
+
+			&--error {
+				color: $cadmin-danger;
+			}
+		}
+
 		.ai-assistant-chat__message-header {
 			display: flex;
 			flex-direction: row;
-
-			&-icon {
-				color: $cadmin-primary;
-				display: inline-block;
-				font-size: 12px;
-				margin-left: 0.5rem;
-				margin-top: 0.5rem;
-			}
 
 			&-text {
 				margin: 0.5rem;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantMessageBalloon.tsx
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayIcon from '@clayui/icon';
 import React from 'react';
 
 import FeedbackActionsRow from '../../ReportFeedback/FeedbackActionsRow';
 
 import '../chat.scss';
 import renderAIAssistantMessageMarkdown from '../utils/renderAIAssistantMessageMarkdown';
+import AIAssistantMessageBalloonIcon from './AIAssistantMessageBalloonIcon';
 
 interface AssistantMessageBalloonProps {
 	error: boolean;
@@ -31,14 +31,7 @@ const AssistantMessageBalloon: React.FC<AssistantMessageBalloonProps> = ({
 			className={`${error ? 'ai-assistant-chat__ai-assistant-error-message-balloon' : 'ai-assistant-chat__ai-assistant-message-balloon'} d-flex flex-column mb-2 rounded`}
 		>
 			<div className="d-flex flex-row">
-				<div
-					className={`align-items-start d-inline-block flex-shrink-0 ml-2 mt-2 text-2 ${error ? 'text-danger' : 'text-primary'}`}
-				>
-					<ClayIcon
-						spritemap={Liferay.Icons.spritemap}
-						symbol={error ? 'exclamation-full' : 'stars'}
-					/>
-				</div>
+				<AIAssistantMessageBalloonIcon error={error} />
 
 				{error ? (
 					<span className="m-2">

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantMessageBalloonIcon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/AIAssistantMessageBalloonIcon.tsx
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+import React from 'react';
+
+import '../chat.scss';
+
+interface AIAssistantMessageBalloonIconProps {
+	error?: boolean;
+}
+
+const AIAssistantMessageBalloonIcon: React.FC<
+	AIAssistantMessageBalloonIconProps
+> = ({error = false}) => {
+	return (
+		<div
+			className={classNames('ai-assistant-chat__message-balloon-icon', {
+				'ai-assistant-chat__message-balloon-icon--error': error,
+			})}
+		>
+			<ClayIcon
+				spritemap={Liferay.Icons.spritemap}
+				symbol={error ? 'exclamation-full' : 'stars'}
+			/>
+		</div>
+	);
+};
+
+export default AIAssistantMessageBalloonIcon;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/CategorizationMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/CategorizationMessageBalloon.tsx
@@ -39,6 +39,7 @@ export default function CategorizationMessageBalloon({
 }: CategorizationMessageBalloonProps) {
 	const [committed, setCommitted] = useState(false);
 	const [dismissed, setDismissed] = useState<string[]>([]);
+	const [regenerated, setRegenerated] = useState(false);
 
 	const {regenerate, resolveTargets, run, status, suggestions} =
 		useCategorizationAgent(agent);
@@ -141,13 +142,20 @@ export default function CategorizationMessageBalloon({
 		`${committedCount}`
 	);
 
-	const isLoading = status === 'idle' || status === 'loading';
+	const isInitialLoading =
+		!regenerated && (status === 'idle' || status === 'loading');
 
 	useEffect(() => {
-		setIsGenerating(isLoading);
-	}, [isLoading, setIsGenerating]);
+		if (!isInitialLoading) {
+			return;
+		}
 
-	if (isLoading) {
+		setIsGenerating(true);
+
+		return () => setIsGenerating(false);
+	}, [isInitialLoading, setIsGenerating]);
+
+	if (isInitialLoading) {
 		return null;
 	}
 
@@ -179,6 +187,7 @@ export default function CategorizationMessageBalloon({
 							onRegenerate={() => {
 								setCommitted(false);
 								setDismissed([]);
+								setRegenerated(true);
 
 								regenerate();
 							}}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/CategorizationMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/CategorizationMessageBalloon.tsx
@@ -4,10 +4,11 @@
  */
 
 import {sub} from 'frontend-js-web';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useId, useState} from 'react';
 
 import CategorizationSuggestions from '../../Categorization/components/CategorizationSuggestions';
 import {
+	CATEGORIZE_EVENT,
 	COMMIT_EVENT,
 	CategorizeEventPayload,
 } from '../../Categorization/events';
@@ -18,7 +19,7 @@ import useCategorizationAgent from '../../Categorization/useCategorizationAgent'
 import AIAssistantMessageBalloonIcon from './AIAssistantMessageBalloonIcon';
 
 interface CategorizationMessageBalloonProps extends CategorizeEventPayload {
-	setIsGenerating: (isGenerating: boolean) => void;
+	setBalloonGenerating: (key: string, generating: boolean) => void;
 }
 
 function getKey(suggestion: Suggestion): string {
@@ -34,14 +35,16 @@ export default function CategorizationMessageBalloon({
 	currentCategoryIds,
 	currentTagNames,
 	scopeId,
-	setIsGenerating,
+	setBalloonGenerating,
 	targets,
 }: CategorizationMessageBalloonProps) {
+	const balloonId = useId();
+
 	const [committed, setCommitted] = useState(false);
 	const [dismissed, setDismissed] = useState<string[]>([]);
 	const [regenerated, setRegenerated] = useState(false);
 
-	const {regenerate, resolveTargets, run, status, suggestions} =
+	const {regenerate, resolveTargets, run, status, stop, suggestions} =
 		useCategorizationAgent(agent);
 
 	useEffect(() => {
@@ -142,18 +145,37 @@ export default function CategorizationMessageBalloon({
 		`${committedCount}`
 	);
 
-	const isInitialLoading =
-		!regenerated && (status === 'idle' || status === 'loading');
+	const isLoading = status === 'idle' || status === 'loading';
+
+	const isInitialLoading = !regenerated && isLoading;
 
 	useEffect(() => {
 		if (!isInitialLoading) {
 			return;
 		}
 
-		setIsGenerating(true);
+		setBalloonGenerating(balloonId, true);
 
-		return () => setIsGenerating(false);
-	}, [isInitialLoading, setIsGenerating]);
+		return () => setBalloonGenerating(balloonId, false);
+	}, [balloonId, isInitialLoading, setBalloonGenerating]);
+
+	useEffect(() => {
+		if (!isLoading) {
+			return;
+		}
+
+		const onCategorize = (payload: CategorizeEventPayload) => {
+			if (payload.agent === agent) {
+				stop();
+			}
+		};
+
+		Liferay.on(CATEGORIZE_EVENT, onCategorize);
+
+		return () => {
+			Liferay.detach(CATEGORIZE_EVENT, onCategorize);
+		};
+	}, [agent, isLoading, stop]);
 
 	if (isInitialLoading) {
 		return null;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/CategorizationMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/CategorizationMessageBalloon.tsx
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayIcon from '@clayui/icon';
-import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
@@ -17,6 +15,11 @@ import {getCandidateCategories} from '../../Categorization/services/getCandidate
 import {getExistingTags} from '../../Categorization/services/getExistingTags';
 import {ECategorizationAgent, Suggestion} from '../../Categorization/types';
 import useCategorizationAgent from '../../Categorization/useCategorizationAgent';
+import AIAssistantMessageBalloonIcon from './AIAssistantMessageBalloonIcon';
+
+interface CategorizationMessageBalloonProps extends CategorizeEventPayload {
+	setIsGenerating: (isGenerating: boolean) => void;
+}
 
 function getKey(suggestion: Suggestion): string {
 	return `${suggestion.id ?? suggestion.name}`;
@@ -31,8 +34,9 @@ export default function CategorizationMessageBalloon({
 	currentCategoryIds,
 	currentTagNames,
 	scopeId,
+	setIsGenerating,
 	targets,
-}: CategorizeEventPayload) {
+}: CategorizationMessageBalloonProps) {
 	const [committed, setCommitted] = useState(false);
 	const [dismissed, setDismissed] = useState<string[]>([]);
 
@@ -139,22 +143,19 @@ export default function CategorizationMessageBalloon({
 
 	const isLoading = status === 'idle' || status === 'loading';
 
+	useEffect(() => {
+		setIsGenerating(isLoading);
+	}, [isLoading, setIsGenerating]);
+
+	if (isLoading) {
+		return null;
+	}
+
 	return (
 		<>
 			<div className="ai-assistant-chat__ai-assistant-message-balloon d-flex flex-column mb-2 rounded">
 				<div className="d-flex flex-row">
-					<div
-						className={`align-items-start d-inline-block flex-shrink-0 ml-2 mt-2 text-2 ${isLoading ? '' : 'text-primary'}`}
-					>
-						{isLoading ? (
-							<ClayLoadingIndicator size="sm" />
-						) : (
-							<ClayIcon
-								spritemap={Liferay.Icons.spritemap}
-								symbol="stars"
-							/>
-						)}
-					</div>
+					<AIAssistantMessageBalloonIcon />
 
 					<div className="flex-grow-1 m-2">
 						<CategorizationSuggestions
@@ -181,7 +182,7 @@ export default function CategorizationMessageBalloon({
 
 								regenerate();
 							}}
-							status={status === 'idle' ? 'loading' : status}
+							status={status}
 							suggestions={visibleSuggestions}
 						/>
 					</div>
@@ -191,12 +192,7 @@ export default function CategorizationMessageBalloon({
 			{committed && committedCount > 0 ? (
 				<div className="ai-assistant-chat__ai-assistant-message-balloon d-flex flex-column mb-2 rounded">
 					<div className="d-flex flex-row">
-						<div className="align-items-start d-inline-block flex-shrink-0 ml-2 mt-2 text-2 text-primary">
-							<ClayIcon
-								spritemap={Liferay.Icons.spritemap}
-								symbol="stars"
-							/>
-						</div>
+						<AIAssistantMessageBalloonIcon />
 
 						<div className="flex-grow-1 m-2">
 							{confirmationMessage}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
@@ -22,7 +22,7 @@ interface ContentTypeSelectorMessageBalloonProps {
 	contentTypes: ContentType[];
 	contextRef: React.MutableRefObject<ChatContext>;
 	message: string;
-	sendMessage: (text: string) => void;
+	sendMessage: (text: string) => boolean;
 	setIsGenerating: (isGenerating: boolean) => void;
 }
 
@@ -33,6 +33,17 @@ const ContentTypeSelectorMessageBalloon: React.FC<
 	const [submitted, setSubmitted] = useState(false);
 
 	const selectId = useId();
+
+	function reportFailure() {
+		setExternalReferenceCode('');
+
+		setIsGenerating(false);
+
+		Liferay.Util.openToast({
+			message: Liferay.Language.get('an-unexpected-error-occurred'),
+			type: 'danger',
+		});
+	}
 
 	async function handleChange(event: React.ChangeEvent<HTMLSelectElement>) {
 		const value = event.target.value;
@@ -61,21 +72,19 @@ const ContentTypeSelectorMessageBalloon: React.FC<
 				objectFields: JSON.stringify(objectFields),
 			};
 
-			setSubmitted(true);
-
-			sendMessage(
+			const sent = sendMessage(
 				`${Liferay.Language.get('generate')} ${contentType.label}`
 			);
+
+			if (sent) {
+				setSubmitted(true);
+			}
+			else {
+				reportFailure();
+			}
 		}
 		catch {
-			setExternalReferenceCode('');
-
-			setIsGenerating(false);
-
-			Liferay.Util.openToast({
-				message: Liferay.Language.get('an-unexpected-error-occurred'),
-				type: 'danger',
-			});
+			reportFailure();
 		}
 	}
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
@@ -49,20 +49,32 @@ const ContentTypeSelectorMessageBalloon: React.FC<
 
 		setIsGenerating(true);
 
-		const objectFields = await getObjectFields(
-			contentType.externalReferenceCode
-		);
+		try {
+			const objectFields = await getObjectFields(
+				contentType.externalReferenceCode
+			);
 
-		// eslint-disable-next-line react-compiler/react-compiler
-		contextRef.current = {
-			...contextRef.current,
-			objectDefinitionName: contentType.name,
-			objectFields: JSON.stringify(objectFields),
-		};
+			// eslint-disable-next-line react-compiler/react-compiler
+			contextRef.current = {
+				...contextRef.current,
+				objectDefinitionName: contentType.name,
+				objectFields: JSON.stringify(objectFields),
+			};
 
-		setSubmitted(true);
+			setSubmitted(true);
 
-		sendMessage(`${Liferay.Language.get('generate')} ${contentType.label}`);
+			sendMessage(
+				`${Liferay.Language.get('generate')} ${contentType.label}`
+			);
+		}
+		catch {
+			setIsGenerating(false);
+
+			Liferay.Util.openToast({
+				message: Liferay.Language.get('an-unexpected-error-occurred'),
+				type: 'danger',
+			});
+		}
 	}
 
 	return (

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
@@ -23,11 +23,12 @@ interface ContentTypeSelectorMessageBalloonProps {
 	contextRef: React.MutableRefObject<ChatContext>;
 	message: string;
 	sendMessage: (text: string) => void;
+	setIsGenerating: (isGenerating: boolean) => void;
 }
 
 const ContentTypeSelectorMessageBalloon: React.FC<
 	ContentTypeSelectorMessageBalloonProps
-> = ({contentTypes, contextRef, message, sendMessage}) => {
+> = ({contentTypes, contextRef, message, sendMessage, setIsGenerating}) => {
 	const [externalReferenceCode, setExternalReferenceCode] = useState('');
 	const [submitted, setSubmitted] = useState(false);
 
@@ -45,6 +46,8 @@ const ContentTypeSelectorMessageBalloon: React.FC<
 		if (!contentType) {
 			return;
 		}
+
+		setIsGenerating(true);
 
 		const objectFields = await getObjectFields(
 			contentType.externalReferenceCode

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
@@ -68,6 +68,8 @@ const ContentTypeSelectorMessageBalloon: React.FC<
 			);
 		}
 		catch {
+			setExternalReferenceCode('');
+
 			setIsGenerating(false);
 
 			Liferay.Util.openToast({

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
@@ -22,7 +22,7 @@ interface ContentTypeSelectorMessageBalloonProps {
 	contentTypes: ContentType[];
 	contextRef: React.MutableRefObject<ChatContext>;
 	message: string;
-	sendMessage: (text: string) => boolean;
+	sendMessage: (text: string) => Promise<boolean>;
 	setIsGenerating: (isGenerating: boolean) => void;
 }
 
@@ -34,10 +34,15 @@ const ContentTypeSelectorMessageBalloon: React.FC<
 
 	const selectId = useId();
 
-	function reportFailure() {
+	function resetSelection() {
 		setExternalReferenceCode('');
+		setSubmitted(false);
 
 		setIsGenerating(false);
+	}
+
+	function reportFailure() {
+		resetSelection();
 
 		Liferay.Util.openToast({
 			message: Liferay.Language.get('an-unexpected-error-occurred'),
@@ -59,6 +64,7 @@ const ContentTypeSelectorMessageBalloon: React.FC<
 		}
 
 		setIsGenerating(true);
+		setSubmitted(true);
 
 		try {
 			const objectFields = await getObjectFields(
@@ -72,15 +78,12 @@ const ContentTypeSelectorMessageBalloon: React.FC<
 				objectFields: JSON.stringify(objectFields),
 			};
 
-			const sent = sendMessage(
+			const sent = await sendMessage(
 				`${Liferay.Language.get('generate')} ${contentType.label}`
 			);
 
-			if (sent) {
-				setSubmitted(true);
-			}
-			else {
-				reportFailure();
+			if (!sent) {
+				resetSelection();
 			}
 		}
 		catch {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.tsx
@@ -4,13 +4,13 @@
  */
 
 import ClayForm, {ClaySelectWithOption} from '@clayui/form';
-import ClayIcon from '@clayui/icon';
 import React, {useId, useState} from 'react';
 
 import {ChatContext} from '../api';
 import {getObjectFields} from '../services/getObjectFields';
 
 import '../chat.scss';
+import AIAssistantMessageBalloonIcon from './AIAssistantMessageBalloonIcon';
 
 export interface ContentType {
 	externalReferenceCode: string;
@@ -65,7 +65,7 @@ const ContentTypeSelectorMessageBalloon: React.FC<
 	return (
 		<div className="ai-assistant-chat__ai-assistant-message-balloon ai-assistant-chat__content-generation-balloon">
 			<div className="ai-assistant-chat__content-generation-balloon-header">
-				<ClayIcon spritemap={Liferay.Icons.spritemap} symbol="stars" />
+				<AIAssistantMessageBalloonIcon />
 
 				<span>{message}</span>
 			</div>

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentsMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/ContentsMessageBalloon.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import '../chat.scss';
 import parseContentDraftsMessage from '../utils/parseContentDraftsMessage';
 import renderAIAssistantMessageMarkdown from '../utils/renderAIAssistantMessageMarkdown';
+import AIAssistantMessageBalloonIcon from './AIAssistantMessageBalloonIcon';
 
 interface ContentsMessageBalloonProps {
 	message: string;
@@ -25,10 +26,7 @@ const ContentsMessageBalloon: React.FC<ContentsMessageBalloonProps> = ({
 		<div className="ai-assistant-chat__ai-assistant-message-balloon ai-assistant-chat__content-generation-balloon">
 			{text && (
 				<div className="ai-assistant-chat__content-generation-balloon-header">
-					<ClayIcon
-						spritemap={Liferay.Icons.spritemap}
-						symbol="stars"
-					/>
+					<AIAssistantMessageBalloonIcon />
 
 					<div
 						dangerouslySetInnerHTML={{

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/FieldValueMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/FieldValueMessageBalloon.tsx
@@ -9,6 +9,7 @@ import React, {useState} from 'react';
 
 import '../chat.scss';
 import renderAIAssistantMessageMarkdown from '../utils/renderAIAssistantMessageMarkdown';
+import AIAssistantMessageBalloonIcon from './AIAssistantMessageBalloonIcon';
 
 interface FieldValueMessageBalloonProps {
 	onApply: () => void;
@@ -26,12 +27,7 @@ const FieldValueMessageBalloon: React.FC<FieldValueMessageBalloonProps> = ({
 	return (
 		<div className="ai-assistant-chat__ai-assistant-message-balloon d-flex flex-column mb-2 rounded">
 			<div className="d-flex flex-row font-weight-semi-bold">
-				<div className="align-items-start d-inline-block ml-2 mt-2 text-2 text-primary">
-					<ClayIcon
-						spritemap={Liferay.Icons.spritemap}
-						symbol="stars"
-					/>
-				</div>
+				<AIAssistantMessageBalloonIcon />
 
 				<div
 					className="m-2"

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/QuickRepliesMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/QuickRepliesMessageBalloon.tsx
@@ -4,11 +4,11 @@
  */
 
 import ClayButton from '@clayui/button';
-import ClayIcon from '@clayui/icon';
 import React, {useId, useState} from 'react';
 
 import {executeHttpRequestAction} from '../api';
 import {AgentComponent, AgentComponentOption} from '../types';
+import AIAssistantMessageBalloonIcon from './AIAssistantMessageBalloonIcon';
 
 import '../chat.scss';
 
@@ -41,7 +41,7 @@ const QuickRepliesMessageBalloon: React.FC<QuickRepliesMessageBalloonProps> = ({
 	return (
 		<div className="ai-assistant-chat__ai-assistant-message-balloon ai-assistant-chat__content-generation-balloon">
 			<div className="ai-assistant-chat__content-generation-balloon-header">
-				<ClayIcon spritemap={Liferay.Icons.spritemap} symbol="stars" />
+				<AIAssistantMessageBalloonIcon />
 
 				<span
 					className="ai-assistant-chat__content-generation-balloon-title"

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/SelectComponentMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/SelectComponentMessageBalloon.tsx
@@ -4,11 +4,11 @@
  */
 
 import ClayForm, {ClaySelectWithOption} from '@clayui/form';
-import ClayIcon from '@clayui/icon';
 import React, {useId, useState} from 'react';
 
 import {executeHttpRequestAction} from '../api';
 import {AgentComponent} from '../types';
+import AIAssistantMessageBalloonIcon from './AIAssistantMessageBalloonIcon';
 
 import '../chat.scss';
 
@@ -51,7 +51,7 @@ const SelectComponentMessageBalloon: React.FC<
 	return (
 		<div className="ai-assistant-chat__ai-assistant-message-balloon ai-assistant-chat__content-generation-balloon">
 			<div className="ai-assistant-chat__content-generation-balloon-header">
-				<ClayIcon spritemap={Liferay.Icons.spritemap} symbol="stars" />
+				<AIAssistantMessageBalloonIcon />
 
 				<span
 					className="ai-assistant-chat__content-generation-balloon-title"

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/SpaceSelectorMessageBalloon.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/SpaceSelectorMessageBalloon.tsx
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayIcon from '@clayui/icon';
 import React from 'react';
 
 import {ChatContext} from '../api';
 import {Space} from '../services/getSpaces';
+import AIAssistantMessageBalloonIcon from './AIAssistantMessageBalloonIcon';
 import SpaceSelect from './SpaceSelect';
 
 import '../chat.scss';
@@ -36,7 +36,7 @@ const SpaceSelectorMessageBalloon: React.FC<
 	return (
 		<div className="ai-assistant-chat__ai-assistant-message-balloon ai-assistant-chat__content-generation-balloon">
 			<div className="ai-assistant-chat__content-generation-balloon-header">
-				<ClayIcon spritemap={Liferay.Icons.spritemap} symbol="stars" />
+				<AIAssistantMessageBalloonIcon />
 
 				<span>{message}</span>
 			</div>

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/messageBalloonRenderers.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/messageBalloonRenderers.tsx
@@ -60,7 +60,7 @@ const MESSAGE_BALLOON_RENDERERS: MessageBalloonRenderers = {
 	'categorization': ({chat}, {categorization}) => (
 		<CategorizationMessageBalloon
 			{...categorization}
-			setIsGenerating={chat.setIsGenerating}
+			setBalloonGenerating={chat.setBalloonGenerating}
 		/>
 	),
 	'content-drafts': ({item}) => (

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/messageBalloonRenderers.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/components/messageBalloonRenderers.tsx
@@ -57,8 +57,11 @@ const MESSAGE_BALLOON_RENDERERS: MessageBalloonRenderers = {
 			}
 		/>
 	),
-	'categorization': (context, {categorization}) => (
-		<CategorizationMessageBalloon {...categorization} />
+	'categorization': ({chat}, {categorization}) => (
+		<CategorizationMessageBalloon
+			{...categorization}
+			setIsGenerating={chat.setIsGenerating}
+		/>
 	),
 	'content-drafts': ({item}) => (
 		<ContentsMessageBalloon message={item.text} />
@@ -69,6 +72,7 @@ const MESSAGE_BALLOON_RENDERERS: MessageBalloonRenderers = {
 			contextRef={chat.runtimeContextRef}
 			message={item.text}
 			sendMessage={chat.sendMessage}
+			setIsGenerating={chat.setIsGenerating}
 		/>
 	),
 	'field-values': ({chat, index}, {fieldValues}) => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
@@ -45,7 +45,7 @@ export interface AIChat {
 	reportContext: AIChatReportContext | null;
 	runtimeContextRef: React.MutableRefObject<ChatContext>;
 	scrollToBottom: () => void;
-	sendMessage: (text: string) => boolean;
+	sendMessage: (text: string) => Promise<boolean>;
 	setBalloonGenerating: (key: string, generating: boolean) => void;
 	setIsGenerating: React.Dispatch<React.SetStateAction<boolean>>;
 	setMessage: (message: string) => void;
@@ -177,64 +177,87 @@ export default function useAIChat({
 		};
 	}, []);
 
-	const sendMessage = useCallback((text: string) => {
-		if (!text.trim()) {
-			return false;
-		}
+	const reportSendFailure = useCallback(() => {
+		setIsGenerating(false);
 
 		setMessages((previousMessages) => [
 			...previousMessages,
-			{sender: 'user', text},
+			{
+				error: true,
+				sender: 'assistant',
+				text: Liferay.Language.get('an-unexpected-error-occurred'),
+			},
 		]);
 
-		setMessage('');
-
-		if (!eventSourceReference.current) {
-			setIsGenerating(false);
-
-			return false;
-		}
-
-		setIsGenerating(true);
-
-		const postToChat = () => {
-			postChatByExternalReferenceCodeMessage({
-				chatContext: {
-					...contextRef.current,
-					...getContextRef.current?.(),
-					...runtimeContextRef.current,
-				},
-				eventSourceReference: eventSourceReference.current as string,
-				instructionDefinitionScope:
-					instructionDefinitionScopeRef.current,
-				message: text,
-			}).catch(() => setIsGenerating(false));
-		};
-
-		if (!enableFreeFormCategorizationRef.current) {
-			postToChat();
-
-			return true;
-		}
-
-		classifyCategorizationIntent(text)
-			.then((verdict) => {
-				if (verdict.passthrough || !verdict.actions.length) {
-					postToChat();
-
-					return;
-				}
-
-				setIsGenerating(false);
-
-				Liferay.fire(REQUEST_CATEGORIZE_EVENT, {
-					actions: verdict.actions,
-				});
-			})
-			.catch(() => postToChat());
-
-		return true;
+		Liferay.Util.openToast({
+			message: Liferay.Language.get('an-unexpected-error-occurred'),
+			type: 'danger',
+		});
 	}, []);
+
+	const sendMessage = useCallback(
+		async (text: string) => {
+			if (!text.trim()) {
+				return false;
+			}
+
+			setMessages((previousMessages) => [
+				...previousMessages,
+				{sender: 'user', text},
+			]);
+
+			setMessage('');
+
+			if (!eventSourceReference.current) {
+				reportSendFailure();
+
+				return false;
+			}
+
+			setIsGenerating(true);
+
+			const postToChat = () =>
+				postChatByExternalReferenceCodeMessage({
+					chatContext: {
+						...contextRef.current,
+						...getContextRef.current?.(),
+						...runtimeContextRef.current,
+					},
+					eventSourceReference:
+						eventSourceReference.current as string,
+					instructionDefinitionScope:
+						instructionDefinitionScopeRef.current,
+					message: text,
+				})
+					.then(() => true)
+					.catch(() => {
+						reportSendFailure();
+
+						return false;
+					});
+
+			if (!enableFreeFormCategorizationRef.current) {
+				return postToChat();
+			}
+
+			return classifyCategorizationIntent(text)
+				.then((verdict) => {
+					if (verdict.passthrough || !verdict.actions.length) {
+						return postToChat();
+					}
+
+					setIsGenerating(false);
+
+					Liferay.fire(REQUEST_CATEGORIZE_EVENT, {
+						actions: verdict.actions,
+					});
+
+					return true;
+				})
+				.catch(() => postToChat());
+		},
+		[reportSendFailure]
+	);
 
 	useEffect(() => {
 		initialMessageRef.current = initialMessage;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
@@ -175,6 +175,8 @@ export default function useAIChat({
 		setMessage('');
 
 		if (!eventSourceReference.current) {
+			setIsGenerating(false);
+
 			return;
 		}
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
@@ -45,7 +45,7 @@ export interface AIChat {
 	reportContext: AIChatReportContext | null;
 	runtimeContextRef: React.MutableRefObject<ChatContext>;
 	scrollToBottom: () => void;
-	sendMessage: (text: string) => void;
+	sendMessage: (text: string) => boolean;
 	setIsGenerating: React.Dispatch<React.SetStateAction<boolean>>;
 	setMessage: (message: string) => void;
 	setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
@@ -164,7 +164,7 @@ export default function useAIChat({
 
 	const sendMessage = useCallback((text: string) => {
 		if (!text.trim()) {
-			return;
+			return false;
 		}
 
 		setMessages((previousMessages) => [
@@ -177,7 +177,7 @@ export default function useAIChat({
 		if (!eventSourceReference.current) {
 			setIsGenerating(false);
 
-			return;
+			return false;
 		}
 
 		setIsGenerating(true);
@@ -199,7 +199,7 @@ export default function useAIChat({
 		if (!enableFreeFormCategorizationRef.current) {
 			postToChat();
 
-			return;
+			return true;
 		}
 
 		classifyCategorizationIntent(text)
@@ -217,6 +217,8 @@ export default function useAIChat({
 				});
 			})
 			.catch(() => postToChat());
+
+		return true;
 	}, []);
 
 	useEffect(() => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
@@ -364,8 +364,6 @@ export default function useAIChat({
 		eventSourceRef.current?.close();
 
 		eventSourceRef.current = null;
-
-		setIsGenerating(false);
 	}, []);
 
 	useEffect(() => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
@@ -148,7 +148,7 @@ export default function useAIChat({
 
 	useEffect(() => {
 		scrollToBottom();
-	}, [messages, scrollToBottom]);
+	}, [isGenerating, messages, scrollToBottom]);
 
 	useEffect(() => {
 		const onLocaleChanged = ({languageId}: {languageId: string}) => {
@@ -362,6 +362,8 @@ export default function useAIChat({
 		eventSourceRef.current?.close();
 
 		eventSourceRef.current = null;
+
+		setIsGenerating(false);
 	}, []);
 
 	useEffect(() => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
@@ -46,6 +46,7 @@ export interface AIChat {
 	runtimeContextRef: React.MutableRefObject<ChatContext>;
 	scrollToBottom: () => void;
 	sendMessage: (text: string) => boolean;
+	setBalloonGenerating: (key: string, generating: boolean) => void;
 	setIsGenerating: React.Dispatch<React.SetStateAction<boolean>>;
 	setMessage: (message: string) => void;
 	setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
@@ -77,9 +78,10 @@ export default function useAIChat({
 	const [feedbackGiven, setFeedbackGiven] = useState<Record<number, boolean>>(
 		{}
 	);
+	const [generatingBalloons, setGeneratingBalloons] = useState<string[]>([]);
 	const [isGenerating, setIsGenerating] = useState<boolean>(false);
-	const [messages, setMessages] = useState<Message[]>([]);
 	const [message, setMessage] = useState<string>('');
+	const [messages, setMessages] = useState<Message[]>([]);
 	const [reportContext, setReportContext] =
 		useState<AIChatReportContext | null>(null);
 
@@ -137,6 +139,19 @@ export default function useAIChat({
 			: '[data-ai-assistant-field-id]';
 	}, [triggerRef]);
 
+	const setBalloonGenerating = useCallback(
+		(key: string, generating: boolean) => {
+			setGeneratingBalloons((previousGeneratingBalloons) =>
+				generating
+					? [...previousGeneratingBalloons, key]
+					: previousGeneratingBalloons.filter(
+							(generatingKey) => generatingKey !== key
+						)
+			);
+		},
+		[]
+	);
+
 	const scrollToBottom = useCallback(() => {
 		const container = messagesContainerRef.current;
 
@@ -148,7 +163,7 @@ export default function useAIChat({
 
 	useEffect(() => {
 		scrollToBottom();
-	}, [isGenerating, messages, scrollToBottom]);
+	}, [generatingBalloons, isGenerating, messages, scrollToBottom]);
 
 	useEffect(() => {
 		const onLocaleChanged = ({languageId}: {languageId: string}) => {
@@ -506,7 +521,7 @@ export default function useAIChat({
 		fileUploadSelectorRef,
 		getContextRef,
 		giveThumbsUp,
-		isGenerating,
+		isGenerating: isGenerating || !!generatingBalloons.length,
 		markFeedbackGiven,
 		message,
 		messages,
@@ -515,6 +530,7 @@ export default function useAIChat({
 		runtimeContextRef,
 		scrollToBottom,
 		sendMessage,
+		setBalloonGenerating,
 		setIsGenerating,
 		setMessage,
 		setMessages,

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat.ts
@@ -41,7 +41,7 @@ export interface AIChat {
 	markFeedbackGiven: (index: number) => void;
 	message: string;
 	messages: Message[];
-	messagesEndRef: React.RefObject<HTMLDivElement>;
+	messagesContainerRef: React.RefObject<HTMLDivElement>;
 	reportContext: AIChatReportContext | null;
 	runtimeContextRef: React.MutableRefObject<ChatContext>;
 	scrollToBottom: () => void;
@@ -96,7 +96,7 @@ export default function useAIChat({
 	const instructionDefinitionScopeRef = useRef<string>(
 		instructionDefinitionScope
 	);
-	const messagesEndRef = useRef<HTMLDivElement | null>(null);
+	const messagesContainerRef = useRef<HTMLDivElement | null>(null);
 	const sourceLanguageIdRef = useRef<string>(
 		Liferay.ThemeDisplay.getLanguageId()
 	);
@@ -138,7 +138,12 @@ export default function useAIChat({
 	}, [triggerRef]);
 
 	const scrollToBottom = useCallback(() => {
-		messagesEndRef.current?.scrollIntoView({behavior: 'smooth'});
+		const container = messagesContainerRef.current;
+
+		container?.scrollTo?.({
+			behavior: 'smooth',
+			top: container.scrollHeight,
+		});
 	}, []);
 
 	useEffect(() => {
@@ -501,7 +506,7 @@ export default function useAIChat({
 		markFeedbackGiven,
 		message,
 		messages,
-		messagesEndRef,
+		messagesContainerRef,
 		reportContext,
 		runtimeContextRef,
 		scrollToBottom,

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/CategorizationSuggestions.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/components/CategorizationSuggestions.tsx
@@ -87,6 +87,16 @@ export default function CategorizationSuggestions({
 		);
 	}
 
+	if (status === 'stopped') {
+		return (
+			<span className="categorization-suggestions">
+				{Liferay.Language.get(
+					'this-request-was-replaced-by-a-newer-one'
+				)}
+			</span>
+		);
+	}
+
 	if (status === 'empty' || !suggestions.length) {
 		return (
 			<span className="categorization-suggestions">

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/types.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/types.ts
@@ -15,7 +15,8 @@ export type CategorizationStatus =
 	| 'error'
 	| 'idle'
 	| 'loading'
-	| 'ready';
+	| 'ready'
+	| 'stopped';
 
 export interface CandidateCategory {
 	id: number;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/useCategorizationAgent.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/useCategorizationAgent.ts
@@ -115,6 +115,7 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 	const mountedRef = useRef<boolean>(true);
 	const pendingRef = useRef<boolean>(false);
 	const sseEventSinkKeyRef = useRef<string | null>(null);
+	const stoppedRef = useRef<boolean>(false);
 
 	const closeEventSource = useCallback(() => {
 		eventSourceRef.current?.close();
@@ -132,6 +133,10 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 				});
 			}
 			catch {
+				if (stoppedRef.current) {
+					return;
+				}
+
 				setError(Liferay.Language.get('an-unexpected-error-occurred'));
 				setStatus('error');
 
@@ -152,7 +157,7 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 			.then((eventSource) => {
 				connectingRef.current = false;
 
-				if (!mountedRef.current) {
+				if (!mountedRef.current || stoppedRef.current) {
 					eventSource?.close();
 
 					return;
@@ -227,6 +232,19 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 						closeEventSource();
 					}
 				);
+
+				eventSource.addEventListener('error', () => {
+					if (stoppedRef.current) {
+						return;
+					}
+
+					setError(
+						Liferay.Language.get('an-unexpected-error-occurred')
+					);
+					setStatus('error');
+
+					closeEventSource();
+				});
 			})
 			.catch(() => {
 				connectingRef.current = false;
@@ -243,6 +261,10 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 
 	const run = useCallback(
 		(context: CategorizationContext) => {
+			if (stoppedRef.current) {
+				return;
+			}
+
 			lastContextRef.current = context;
 			lastTargetsRef.current = null;
 
@@ -264,6 +286,10 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 
 	const resolveTargets = useCallback(
 		(context: CategorizationContext, targets: string[]) => {
+			if (stoppedRef.current) {
+				return;
+			}
+
 			lastContextRef.current = context;
 			lastTargetsRef.current = targets;
 
@@ -290,7 +316,17 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 		}
 	}, [resolveTargets, run]);
 
+	const stop = useCallback(() => {
+		stoppedRef.current = true;
+
+		closeEventSource();
+
+		setStatus('stopped');
+	}, [closeEventSource]);
+
 	const reset = useCallback(() => {
+		stoppedRef.current = false;
+
 		setError(undefined);
 		setSuggestions([]);
 		setStatus('idle');
@@ -312,5 +348,14 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 		};
 	}, [agent, closeEventSource]);
 
-	return {error, regenerate, reset, resolveTargets, run, status, suggestions};
+	return {
+		error,
+		regenerate,
+		reset,
+		resolveTargets,
+		run,
+		status,
+		stop,
+		suggestions,
+	};
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/useCategorizationAgent.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/Categorization/useCategorizationAgent.ts
@@ -161,7 +161,10 @@ export default function useCategorizationAgent(agent: ECategorizationAgent) {
 				if (!eventSource) {
 					pendingRef.current = false;
 
-					setStatus('idle');
+					setError(
+						Liferay.Language.get('an-unexpected-error-occurred')
+					);
+					setStatus('error');
 
 					return;
 				}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageHeader.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/TranslateContent/components/MessageHeader.tsx
@@ -3,15 +3,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayIcon from '@clayui/icon';
 import React from 'react';
+
+import AIAssistantMessageBalloonIcon from '../../AIAssistantChat/components/AIAssistantMessageBalloonIcon';
 
 export default function MessageHeader({message}: {message: string}) {
 	return (
 		<div className="ai-assistant-chat__message-header">
-			<div className="ai-assistant-chat__message-header-icon">
-				<ClayIcon spritemap={Liferay.Icons.spritemap} symbol="stars" />
-			</div>
+			<AIAssistantMessageBalloonIcon />
 
 			<div className="ai-assistant-chat__message-header-text">
 				{message}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
@@ -204,7 +204,7 @@ describe('AIAssistantHost', () => {
 		mockGetSpaces.mockReset();
 		mockGetSpaces.mockResolvedValue([]);
 		mockPostChat.mockReset();
-		mockPostChat.mockResolvedValue(undefined);
+		mockPostChat.mockResolvedValue(undefined as never);
 		mockPostAIIssueReport.mockReset();
 		mockPostAIIssueReport.mockResolvedValue({id: 'report-1'});
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
@@ -31,6 +31,7 @@ jest.mock(
 	'../../../src/main/resources/META-INF/resources/js/AIAssistantChat/api',
 	() => ({
 		createEventSource: jest.fn(() => Promise.resolve(null)),
+		executeHttpRequestAction: jest.fn(() => Promise.resolve()),
 		postChatByExternalReferenceCodeMessage: jest.fn(() =>
 			Promise.resolve()
 		),
@@ -888,6 +889,51 @@ describe('AIAssistantHost', () => {
 				fakeEventSource.emit(
 					'Chat Message Sent',
 					JSON.stringify({data: 'Here are your tags'})
+				);
+			});
+
+			expect(scrollTo).toHaveBeenCalledWith({
+				behavior: 'smooth',
+				top: SCROLL_HEIGHT,
+			});
+		});
+
+		it('scrolls the conversation to the bottom when the generating indicator appears without a new message', async () => {
+			const fakeEventSource = createFakeEventSource();
+
+			mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+			await renderAndOpen();
+
+			await act(async () => {
+				fakeEventSource.emit(
+					'Chat Message Sent',
+					JSON.stringify({
+						component: {
+							options: [
+								{
+									action: {
+										'http-request': {
+											href: '/o/tags',
+											method: 'POST',
+										},
+									},
+									label: 'generate-tags',
+								},
+							],
+							title: 'what-do-you-want-to-do',
+							type: 'quick-replies',
+						},
+						type: 'component',
+					})
+				);
+			});
+
+			scrollTo.mockClear();
+
+			await act(async () => {
+				fireEvent.click(
+					screen.getByRole('button', {name: 'generate-tags'})
 				);
 			});
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
@@ -949,7 +949,7 @@ describe('AIAssistantHost', () => {
 		});
 	});
 
-	it('keeps the composer usable when a content type is selected before the connection subscribes', async () => {
+	it('keeps the composer and the selector usable when a content type is selected before the connection subscribes', async () => {
 		const fakeEventSource = createFakeEventSource();
 
 		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
@@ -981,6 +981,15 @@ describe('AIAssistantHost', () => {
 		);
 
 		expect(screen.queryByText('generating')).toBeNull();
+
+		expect(Liferay.Util.openToast).toHaveBeenCalledWith(
+			expect.objectContaining({type: 'danger'})
+		);
+
+		const select = screen.getByLabelText('content-type');
+
+		expect(select).toBeEnabled();
+		expect(select).toHaveValue('');
 	});
 
 	it('sends the command initial message when the connection is already subscribed', async () => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
@@ -47,6 +47,11 @@ jest.mock(
 );
 
 jest.mock(
+	'../../../src/main/resources/META-INF/resources/js/AIAssistantChat/services/getObjectFields',
+	() => ({getObjectFields: jest.fn(() => Promise.resolve({items: []}))})
+);
+
+jest.mock(
 	'../../../src/main/resources/META-INF/resources/js/AIAssistantChat/services/getSpaces',
 	() => ({getSpaces: jest.fn(() => Promise.resolve([]))})
 );
@@ -942,6 +947,40 @@ describe('AIAssistantHost', () => {
 				top: SCROLL_HEIGHT,
 			});
 		});
+	});
+
+	it('keeps the composer usable when a content type is selected before the connection subscribes', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+		await renderAndOpen();
+
+		await act(async () => {
+			getLiferayHandler('openAIAssistantChat')?.({
+				contentTypes: [
+					{
+						externalReferenceCode: 'L_CMS_BLOG',
+						label: 'Blog',
+						name: 'C_Blog',
+					},
+				],
+			});
+		});
+
+		await act(async () => {
+			fireEvent.change(screen.getByLabelText('content-type'), {
+				target: {value: 'L_CMS_BLOG'},
+			});
+		});
+
+		await waitFor(() =>
+			expect(
+				screen.getByPlaceholderText('ask-me-anything')
+			).not.toHaveAttribute('readonly')
+		);
+
+		expect(screen.queryByText('generating')).toBeNull();
 	});
 
 	it('sends the command initial message when the connection is already subscribed', async () => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/AIAssistantHost.test.tsx
@@ -193,8 +193,6 @@ describe('AIAssistantHost', () => {
 			value: 1440,
 		});
 
-		window.HTMLElement.prototype.scrollIntoView = jest.fn();
-
 		mockCreateEventSource.mockReset();
 		mockCreateEventSource.mockResolvedValue(null);
 		mockGetSpaces.mockReset();
@@ -850,6 +848,54 @@ describe('AIAssistantHost', () => {
 		expect(
 			within(getSidebar()).getByPlaceholderText('ask-me-anything')
 		).toBe(inputBeforeExpand);
+	});
+
+	describe('scrolling', () => {
+		const SCROLL_HEIGHT = 900;
+
+		let scrollTo: jest.Mock;
+
+		beforeEach(() => {
+			scrollTo = jest.fn();
+
+			Object.defineProperty(
+				window.HTMLElement.prototype,
+				'scrollHeight',
+				{configurable: true, value: SCROLL_HEIGHT}
+			);
+
+			window.HTMLElement.prototype.scrollTo = scrollTo;
+		});
+
+		afterEach(() => {
+			Reflect.deleteProperty(
+				window.HTMLElement.prototype,
+				'scrollHeight'
+			);
+			Reflect.deleteProperty(window.HTMLElement.prototype, 'scrollTo');
+		});
+
+		it('scrolls the conversation to the bottom when a message arrives', async () => {
+			const fakeEventSource = createFakeEventSource();
+
+			mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+			await renderAndOpen();
+
+			scrollTo.mockClear();
+
+			await act(async () => {
+				fakeEventSource.emit(
+					'Chat Message Sent',
+					JSON.stringify({data: 'Here are your tags'})
+				);
+			});
+
+			expect(scrollTo).toHaveBeenCalledWith({
+				behavior: 'smooth',
+				top: SCROLL_HEIGHT,
+			});
+		});
 	});
 
 	it('sends the command initial message when the connection is already subscribed', async () => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
@@ -124,6 +124,39 @@ describe('CategorizationMessageBalloon', () => {
 		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
 	});
 
+	it('clears the shared state when it unmounts while loading', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetExistingTags.mockResolvedValue([]);
+
+		let unmount!: () => void;
+
+		await act(async () => {
+			unmount = render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					setIsGenerating={setIsGenerating}
+				/>
+			).unmount;
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-9');
+		});
+
+		expect(setIsGenerating).toHaveBeenLastCalledWith(true);
+
+		act(() => {
+			unmount();
+		});
+
+		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
+	});
+
 	it('counts only the tags not already on the content in the confirmation', async () => {
 		(Liferay.Language.get as jest.Mock).mockImplementation((key: string) =>
 			key === 'great-i-have-added-x-tags-to-your-content'
@@ -372,6 +405,91 @@ describe('CategorizationMessageBalloon', () => {
 		expect(
 			screen.getByText(/Great! I have added 1 tags/)
 		).toBeInTheDocument();
+	});
+
+	it('keeps the balloon with its own indicator while regenerating', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetExistingTags.mockResolvedValue([]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					setIsGenerating={setIsGenerating}
+				/>
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-8');
+		});
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'L_GENERATE_TAGS',
+				JSON.stringify({
+					data: '{"suggestions":[{"name":"Culture","isNew":true}]}',
+					nodeName: 'llm',
+				})
+			);
+		});
+
+		setIsGenerating.mockClear();
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', {name: 'try-again'}));
+		});
+
+		expect(screen.getByText('generating-tags')).toBeInTheDocument();
+		expect(setIsGenerating).not.toHaveBeenCalledWith(true);
+	});
+
+	it('leaves the shared state alone when it unmounts after loading', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetExistingTags.mockResolvedValue([]);
+
+		let unmount!: () => void;
+
+		await act(async () => {
+			unmount = render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					setIsGenerating={setIsGenerating}
+				/>
+			).unmount;
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-10');
+		});
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'L_GENERATE_TAGS',
+				JSON.stringify({
+					data: '{"suggestions":[{"name":"Culture","isNew":true}]}',
+					nodeName: 'llm',
+				})
+			);
+		});
+
+		setIsGenerating.mockClear();
+
+		act(() => {
+			unmount();
+		});
+
+		expect(setIsGenerating).not.toHaveBeenCalled();
 	});
 
 	it('marks unknown tag targets as new and known ones as existing', async () => {

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
@@ -61,6 +61,7 @@ function createFakeEventSource() {
 
 describe('CategorizationMessageBalloon', () => {
 	let mockFire: jest.Mock;
+	let setIsGenerating: jest.Mock;
 
 	beforeEach(() => {
 		mockCreateEventSource.mockReset();
@@ -70,6 +71,7 @@ describe('CategorizationMessageBalloon', () => {
 		mockGetExistingTags.mockReset();
 
 		mockFire = jest.fn();
+		setIsGenerating = jest.fn();
 
 		global.Liferay = {
 			...global.Liferay,
@@ -81,6 +83,45 @@ describe('CategorizationMessageBalloon', () => {
 		(Liferay.Language.get as jest.Mock).mockImplementation(
 			(key: string) => key
 		);
+	});
+
+	it('reports loading through the shared state instead of its own indicator', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetExistingTags.mockResolvedValue([]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					setIsGenerating={setIsGenerating}
+				/>
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-7');
+		});
+
+		expect(screen.queryByText('generating-tags')).not.toBeInTheDocument();
+		expect(setIsGenerating).toHaveBeenLastCalledWith(true);
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'L_GENERATE_TAGS',
+				JSON.stringify({
+					data: '{"suggestions":[{"name":"Culture","isNew":true}]}',
+					nodeName: 'llm',
+				})
+			);
+		});
+
+		expect(screen.getByText('Culture')).toBeInTheDocument();
+		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
 	});
 
 	it('counts only the tags not already on the content in the confirmation', async () => {
@@ -103,6 +144,7 @@ describe('CategorizationMessageBalloon', () => {
 					content="Japan"
 					currentTagNames={['Japan']}
 					scopeId={555}
+					setIsGenerating={setIsGenerating}
 				/>
 			);
 		});
@@ -152,6 +194,7 @@ describe('CategorizationMessageBalloon', () => {
 					content="Japan"
 					currentCategoryIds={[39001, 39002]}
 					scopeId={555}
+					setIsGenerating={setIsGenerating}
 				/>
 			);
 		});
@@ -200,6 +243,7 @@ describe('CategorizationMessageBalloon', () => {
 					content="Japan"
 					currentCategoryIds={[39001]}
 					scopeId={555}
+					setIsGenerating={setIsGenerating}
 				/>
 			);
 		});
@@ -240,6 +284,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
+					setIsGenerating={setIsGenerating}
 				/>
 			);
 		});
@@ -303,6 +348,7 @@ describe('CategorizationMessageBalloon', () => {
 					content="Japan"
 					currentTagNames={['japan']}
 					scopeId={555}
+					setIsGenerating={setIsGenerating}
 				/>
 			);
 		});
@@ -338,6 +384,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
+					setIsGenerating={setIsGenerating}
 					targets={['kayaking', 'Japan']}
 				/>
 			);
@@ -365,6 +412,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
+					setIsGenerating={setIsGenerating}
 					targets={['fishing']}
 				/>
 			);
@@ -389,6 +437,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
+					setIsGenerating={setIsGenerating}
 					targets={['Fishing']}
 				/>
 			);
@@ -414,6 +463,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
+					setIsGenerating={setIsGenerating}
 				/>
 			);
 		});

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
@@ -13,6 +13,7 @@ import {
 	createCategorizationEventSource,
 	postCategorizationAgentInstance,
 } from '../../../../src/main/resources/META-INF/resources/js/Categorization/api';
+import {CATEGORIZE_EVENT} from '../../../../src/main/resources/META-INF/resources/js/Categorization/events';
 import {getCandidateCategories} from '../../../../src/main/resources/META-INF/resources/js/Categorization/services/getCandidateCategories';
 import {getExistingTags} from '../../../../src/main/resources/META-INF/resources/js/Categorization/services/getExistingTags';
 import {ECategorizationAgent} from '../../../../src/main/resources/META-INF/resources/js/Categorization/types';
@@ -59,9 +60,22 @@ function createFakeEventSource() {
 	};
 }
 
+function fireCategorizeEvent(payload: {agent: string}) {
+	const detachedHandlers = (Liferay.detach as jest.Mock).mock.calls.map(
+		([, handler]) => handler
+	);
+
+	(Liferay.on as jest.Mock).mock.calls
+		.filter(
+			([name, handler]) =>
+				name === CATEGORIZE_EVENT && !detachedHandlers.includes(handler)
+		)
+		.forEach(([, handler]) => handler(payload));
+}
+
 describe('CategorizationMessageBalloon', () => {
 	let mockFire: jest.Mock;
-	let setIsGenerating: jest.Mock;
+	let setBalloonGenerating: jest.Mock;
 
 	beforeEach(() => {
 		mockCreateEventSource.mockReset();
@@ -71,7 +85,10 @@ describe('CategorizationMessageBalloon', () => {
 		mockGetExistingTags.mockReset();
 
 		mockFire = jest.fn();
-		setIsGenerating = jest.fn();
+		setBalloonGenerating = jest.fn();
+
+		(Liferay.on as jest.Mock).mockClear();
+		(Liferay.detach as jest.Mock).mockClear();
 
 		global.Liferay = {
 			...global.Liferay,
@@ -98,7 +115,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			);
 		});
@@ -108,7 +125,10 @@ describe('CategorizationMessageBalloon', () => {
 		});
 
 		expect(screen.queryByText('generating-tags')).not.toBeInTheDocument();
-		expect(setIsGenerating).toHaveBeenLastCalledWith(true);
+		expect(setBalloonGenerating).toHaveBeenLastCalledWith(
+			expect.any(String),
+			true
+		);
 
 		await act(async () => {
 			fakeEventSource.emit(
@@ -121,7 +141,10 @@ describe('CategorizationMessageBalloon', () => {
 		});
 
 		expect(screen.getByText('Culture')).toBeInTheDocument();
-		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
+		expect(setBalloonGenerating).toHaveBeenLastCalledWith(
+			expect.any(String),
+			false
+		);
 	});
 
 	it('clears the shared state when it unmounts while loading', async () => {
@@ -139,7 +162,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			).unmount;
 		});
@@ -148,13 +171,172 @@ describe('CategorizationMessageBalloon', () => {
 			fakeEventSource.emit('Subscribe', 'sink-9');
 		});
 
-		expect(setIsGenerating).toHaveBeenLastCalledWith(true);
+		expect(setBalloonGenerating).toHaveBeenLastCalledWith(
+			expect.any(String),
+			true
+		);
 
 		act(() => {
 			unmount();
 		});
 
-		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
+		expect(setBalloonGenerating).toHaveBeenLastCalledWith(
+			expect.any(String),
+			false
+		);
+	});
+
+	it('reports a replaced request when a new call to the same agent opens', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetExistingTags.mockResolvedValue([]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					setBalloonGenerating={setBalloonGenerating}
+				/>
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-11');
+		});
+
+		await act(async () => {
+			fireCategorizeEvent({agent: 'L_GENERATE_TAGS'});
+		});
+
+		expect(
+			screen.getByText('this-request-was-replaced-by-a-newer-one')
+		).toBeInTheDocument();
+		expect(setBalloonGenerating).toHaveBeenLastCalledWith(
+			expect.any(String),
+			false
+		);
+		expect(fakeEventSource.close).toHaveBeenCalled();
+	});
+
+	it('keeps a loading balloon when the new call is for the other agent', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetExistingTags.mockResolvedValue([]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					setBalloonGenerating={setBalloonGenerating}
+				/>
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-13');
+		});
+
+		await act(async () => {
+			fireCategorizeEvent({agent: 'L_AUTO_CATEGORIZE'});
+		});
+
+		expect(setBalloonGenerating).toHaveBeenLastCalledWith(
+			expect.any(String),
+			true
+		);
+		expect(fakeEventSource.close).not.toHaveBeenCalled();
+	});
+
+	it('keeps the suggestions of a balloon that already answered', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetExistingTags.mockResolvedValue([]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					setBalloonGenerating={setBalloonGenerating}
+				/>
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-12');
+		});
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'L_GENERATE_TAGS',
+				JSON.stringify({
+					data: '{"suggestions":[{"name":"Culture","isNew":true}]}',
+					nodeName: 'llm',
+				})
+			);
+		});
+
+		await act(async () => {
+			fireCategorizeEvent({agent: 'L_GENERATE_TAGS'});
+		});
+
+		expect(screen.getByText('Culture')).toBeInTheDocument();
+	});
+
+	it('reports a replaced request while it is regenerating', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+		mockGetExistingTags.mockResolvedValue([]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					setBalloonGenerating={setBalloonGenerating}
+				/>
+			);
+		});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'sink-14');
+		});
+
+		await act(async () => {
+			fakeEventSource.emit(
+				'L_GENERATE_TAGS',
+				JSON.stringify({
+					data: '{"suggestions":[{"name":"Culture","isNew":true}]}',
+					nodeName: 'llm',
+				})
+			);
+		});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', {name: 'try-again'}));
+		});
+
+		await act(async () => {
+			fireCategorizeEvent({agent: 'L_GENERATE_TAGS'});
+		});
+
+		expect(
+			screen.getByText('this-request-was-replaced-by-a-newer-one')
+		).toBeInTheDocument();
 	});
 
 	it('counts only the tags not already on the content in the confirmation', async () => {
@@ -177,7 +359,7 @@ describe('CategorizationMessageBalloon', () => {
 					content="Japan"
 					currentTagNames={['Japan']}
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			);
 		});
@@ -215,7 +397,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			);
 		});
@@ -223,7 +405,10 @@ describe('CategorizationMessageBalloon', () => {
 		expect(
 			screen.getByText('an-unexpected-error-occurred')
 		).toBeInTheDocument();
-		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
+		expect(setBalloonGenerating).toHaveBeenLastCalledWith(
+			expect.any(String),
+			false
+		);
 	});
 
 	it('does not show a confirmation when no new categories are added', async () => {
@@ -249,7 +434,7 @@ describe('CategorizationMessageBalloon', () => {
 					content="Japan"
 					currentCategoryIds={[39001, 39002]}
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			);
 		});
@@ -298,7 +483,7 @@ describe('CategorizationMessageBalloon', () => {
 					content="Japan"
 					currentCategoryIds={[39001]}
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			);
 		});
@@ -339,7 +524,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			);
 		});
@@ -403,7 +588,7 @@ describe('CategorizationMessageBalloon', () => {
 					content="Japan"
 					currentTagNames={['japan']}
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			);
 		});
@@ -442,7 +627,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			);
 		});
@@ -461,14 +646,17 @@ describe('CategorizationMessageBalloon', () => {
 			);
 		});
 
-		setIsGenerating.mockClear();
+		setBalloonGenerating.mockClear();
 
 		await act(async () => {
 			fireEvent.click(screen.getByRole('button', {name: 'try-again'}));
 		});
 
 		expect(screen.getByText('generating-tags')).toBeInTheDocument();
-		expect(setIsGenerating).not.toHaveBeenCalledWith(true);
+		expect(setBalloonGenerating).not.toHaveBeenCalledWith(
+			expect.any(String),
+			true
+		);
 	});
 
 	it('leaves the shared state alone when it unmounts after loading', async () => {
@@ -486,7 +674,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			).unmount;
 		});
@@ -505,13 +693,13 @@ describe('CategorizationMessageBalloon', () => {
 			);
 		});
 
-		setIsGenerating.mockClear();
+		setBalloonGenerating.mockClear();
 
 		act(() => {
 			unmount();
 		});
 
-		expect(setIsGenerating).not.toHaveBeenCalled();
+		expect(setBalloonGenerating).not.toHaveBeenCalled();
 	});
 
 	it('marks unknown tag targets as new and known ones as existing', async () => {
@@ -524,7 +712,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 					targets={['kayaking', 'Japan']}
 				/>
 			);
@@ -552,7 +740,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 					targets={['fishing']}
 				/>
 			);
@@ -577,7 +765,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 					targets={['Fishing']}
 				/>
 			);
@@ -603,7 +791,7 @@ describe('CategorizationMessageBalloon', () => {
 					cmsGroupId={20124}
 					content="Japan"
 					scopeId={555}
-					setIsGenerating={setIsGenerating}
+					setBalloonGenerating={setBalloonGenerating}
 				/>
 			);
 		});

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/CategorizationMessageBalloon.test.tsx
@@ -204,6 +204,28 @@ describe('CategorizationMessageBalloon', () => {
 		expect(screen.queryByText(/added 3 tags/)).not.toBeInTheDocument();
 	});
 
+	it('does not lock the chat when the channel is unavailable', async () => {
+		mockCreateEventSource.mockResolvedValue(null);
+		mockGetExistingTags.mockResolvedValue([]);
+
+		await act(async () => {
+			render(
+				<CategorizationMessageBalloon
+					agent={ECategorizationAgent.GENERATE_TAGS}
+					cmsGroupId={20124}
+					content="Japan"
+					scopeId={555}
+					setIsGenerating={setIsGenerating}
+				/>
+			);
+		});
+
+		expect(
+			screen.getByText('an-unexpected-error-occurred')
+		).toBeInTheDocument();
+		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
+	});
+
 	it('does not show a confirmation when no new categories are added', async () => {
 		(Liferay.Language.get as jest.Mock).mockImplementation((key: string) =>
 			key === 'great-i-have-added-x-categories-to-your-content'

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.test.tsx
@@ -42,6 +42,7 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 
 		const contextRef = {current: {}};
 		const sendMessage = jest.fn();
+		const setIsGenerating = jest.fn();
 
 		render(
 			<ContentTypeSelectorMessageBalloon
@@ -49,6 +50,7 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 				contextRef={contextRef}
 				message="What type of content do you want to generate?"
 				sendMessage={sendMessage}
+				setIsGenerating={setIsGenerating}
 			/>
 		);
 
@@ -64,6 +66,7 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 				'by-external-reference-code/L_CMS_BASIC_WEB_CONTENT/object-fields'
 			)
 		);
+		expect(setIsGenerating).toHaveBeenCalledWith(true);
 
 		await waitFor(() =>
 			expect(sendMessage).toHaveBeenCalledWith(

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.test.tsx
@@ -43,7 +43,7 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 		} as never);
 
 		const contextRef = {current: {}};
-		const sendMessage = jest.fn();
+		const sendMessage = jest.fn(() => true);
 		const setIsGenerating = jest.fn();
 
 		render(
@@ -85,7 +85,7 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 	it('stops generating and reports the failure when the object fields cannot be fetched', async () => {
 		mockFetch.mockResolvedValue({ok: false} as never);
 
-		const sendMessage = jest.fn();
+		const sendMessage = jest.fn(() => true);
 		const setIsGenerating = jest.fn();
 
 		render(
@@ -111,6 +111,44 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 
 		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
 		expect(sendMessage).not.toHaveBeenCalled();
+
+		const select = screen.getByLabelText('content-type');
+
+		expect(select).toBeEnabled();
+		expect(select).toHaveValue('');
+	});
+
+	it('stops generating and reports the failure when the message is not sent', async () => {
+		mockFetch.mockResolvedValue({
+			json: () => Promise.resolve({items: []}),
+			ok: true,
+		} as never);
+
+		const sendMessage = jest.fn(() => false);
+		const setIsGenerating = jest.fn();
+
+		render(
+			<ContentTypeSelectorMessageBalloon
+				contentTypes={CONTENT_TYPES}
+				contextRef={{current: {}}}
+				message="What type of content do you want to generate?"
+				sendMessage={sendMessage}
+				setIsGenerating={setIsGenerating}
+			/>
+		);
+
+		await userEvent.selectOptions(
+			screen.getByLabelText('content-type'),
+			'L_CMS_BASIC_WEB_CONTENT'
+		);
+
+		await waitFor(() =>
+			expect(Liferay.Util.openToast).toHaveBeenCalledWith(
+				expect.objectContaining({type: 'danger'})
+			)
+		);
+
+		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
 
 		const select = screen.getByLabelText('content-type');
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.test.tsx
@@ -43,7 +43,7 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 		} as never);
 
 		const contextRef = {current: {}};
-		const sendMessage = jest.fn(() => true);
+		const sendMessage = jest.fn(() => Promise.resolve(true));
 		const setIsGenerating = jest.fn();
 
 		render(
@@ -85,7 +85,7 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 	it('stops generating and reports the failure when the object fields cannot be fetched', async () => {
 		mockFetch.mockResolvedValue({ok: false} as never);
 
-		const sendMessage = jest.fn(() => true);
+		const sendMessage = jest.fn(() => Promise.resolve(true));
 		const setIsGenerating = jest.fn();
 
 		render(
@@ -118,13 +118,13 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 		expect(select).toHaveValue('');
 	});
 
-	it('stops generating and reports the failure when the message is not sent', async () => {
+	it('unlocks the selector when the message is not sent', async () => {
 		mockFetch.mockResolvedValue({
 			json: () => Promise.resolve({items: []}),
 			ok: true,
 		} as never);
 
-		const sendMessage = jest.fn(() => false);
+		const sendMessage = jest.fn(() => Promise.resolve(false));
 		const setIsGenerating = jest.fn();
 
 		render(
@@ -143,12 +143,8 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 		);
 
 		await waitFor(() =>
-			expect(Liferay.Util.openToast).toHaveBeenCalledWith(
-				expect.objectContaining({type: 'danger'})
-			)
+			expect(setIsGenerating).toHaveBeenLastCalledWith(false)
 		);
-
-		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
 
 		const select = screen.getByLabelText('content-type');
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.test.tsx
@@ -111,6 +111,10 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 
 		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
 		expect(sendMessage).not.toHaveBeenCalled();
-		expect(screen.getByLabelText('content-type')).toBeEnabled();
+
+		const select = screen.getByLabelText('content-type');
+
+		expect(select).toBeEnabled();
+		expect(select).toHaveValue('');
 	});
 });

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.test.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/components/ContentTypeSelectorMessageBalloon.test.tsx
@@ -28,6 +28,8 @@ const CONTENT_TYPES = [
 describe('ContentTypeSelectorMessageBalloon', () => {
 	beforeEach(() => {
 		mockFetch.mockReset();
+
+		(Liferay.Util.openToast as jest.Mock).mockClear();
 	});
 
 	it('stores the selected type and its object fields in the context ref and sends the message', async () => {
@@ -78,5 +80,37 @@ describe('ContentTypeSelectorMessageBalloon', () => {
 			objectDefinitionName: 'C_BasicWebContent',
 			objectFields: JSON.stringify(objectFields),
 		});
+	});
+
+	it('stops generating and reports the failure when the object fields cannot be fetched', async () => {
+		mockFetch.mockResolvedValue({ok: false} as never);
+
+		const sendMessage = jest.fn();
+		const setIsGenerating = jest.fn();
+
+		render(
+			<ContentTypeSelectorMessageBalloon
+				contentTypes={CONTENT_TYPES}
+				contextRef={{current: {}}}
+				message="What type of content do you want to generate?"
+				sendMessage={sendMessage}
+				setIsGenerating={setIsGenerating}
+			/>
+		);
+
+		await userEvent.selectOptions(
+			screen.getByLabelText('content-type'),
+			'L_CMS_BASIC_WEB_CONTENT'
+		);
+
+		await waitFor(() =>
+			expect(Liferay.Util.openToast).toHaveBeenCalledWith(
+				expect.objectContaining({type: 'danger'})
+			)
+		);
+
+		expect(setIsGenerating).toHaveBeenLastCalledWith(false);
+		expect(sendMessage).not.toHaveBeenCalled();
+		expect(screen.getByLabelText('content-type')).toBeEnabled();
 	});
 });

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/useAIChat.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/useAIChat.test.ts
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {act, renderHook} from '@testing-library/react';
+
+import useAIChat from '../../../src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat';
+
+jest.mock(
+	'../../../src/main/resources/META-INF/resources/js/AIAssistantChat/api',
+	() => ({
+		createEventSource: jest.fn(() => Promise.resolve(null)),
+		executeHttpRequestAction: jest.fn(() => Promise.resolve()),
+		postChatByExternalReferenceCodeMessage: jest.fn(() =>
+			Promise.resolve()
+		),
+	})
+);
+
+describe('useAIChat', () => {
+	it('keeps the generating indicator until every balloon has finished', async () => {
+		const {result} = renderHook(() =>
+			useAIChat({instructionDefinitionScope: ''})
+		);
+
+		await act(async () => {});
+
+		act(() => {
+			result.current.setBalloonGenerating('balloon-1', true);
+			result.current.setBalloonGenerating('balloon-2', true);
+		});
+
+		expect(result.current.isGenerating).toBe(true);
+
+		act(() => {
+			result.current.setBalloonGenerating('balloon-1', false);
+		});
+
+		expect(result.current.isGenerating).toBe(true);
+
+		act(() => {
+			result.current.setBalloonGenerating('balloon-2', false);
+		});
+
+		expect(result.current.isGenerating).toBe(false);
+	});
+});

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/useAIChat.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/AIAssistantChat/useAIChat.test.ts
@@ -5,6 +5,10 @@
 
 import {act, renderHook} from '@testing-library/react';
 
+import {
+	createEventSource,
+	postChatByExternalReferenceCodeMessage,
+} from '../../../src/main/resources/META-INF/resources/js/AIAssistantChat/api';
 import useAIChat from '../../../src/main/resources/META-INF/resources/js/AIAssistantChat/useAIChat';
 
 jest.mock(
@@ -18,7 +22,111 @@ jest.mock(
 	})
 );
 
+const mockCreateEventSource = createEventSource as jest.MockedFunction<
+	typeof createEventSource
+>;
+const mockPostChat =
+	postChatByExternalReferenceCodeMessage as jest.MockedFunction<
+		typeof postChatByExternalReferenceCodeMessage
+	>;
+
 describe('useAIChat', () => {
+	beforeEach(() => {
+		mockCreateEventSource.mockReset();
+		mockCreateEventSource.mockResolvedValue(null as never);
+		mockPostChat.mockReset();
+		mockPostChat.mockResolvedValue(undefined as never);
+	});
+
+	async function renderSubscribed() {
+		const listeners: Record<string, (event: {data: string}) => void> = {};
+
+		const fakeEventSource = {
+			addEventListener: jest.fn(
+				(type: string, handler: (event: {data: string}) => void) => {
+					listeners[type] = handler;
+				}
+			),
+			close: jest.fn(),
+			emit(type: string, data: string) {
+				listeners[type]?.({data});
+			},
+		};
+
+		mockCreateEventSource.mockResolvedValue(fakeEventSource as never);
+
+		const {result} = renderHook(() =>
+			useAIChat({instructionDefinitionScope: ''})
+		);
+
+		await act(async () => {});
+
+		await act(async () => {
+			fakeEventSource.emit('Subscribe', 'reference-1');
+		});
+
+		return result;
+	}
+
+	it('answers a message with an error when the request fails', async () => {
+		mockPostChat.mockRejectedValue(new Error('Request failed'));
+
+		const result = await renderSubscribed();
+
+		let sent;
+
+		await act(async () => {
+			sent = await result.current.sendMessage('Tag this article');
+		});
+
+		expect(sent).toBe(false);
+		expect(result.current.messages).toEqual([
+			{sender: 'user', text: 'Tag this article'},
+			expect.objectContaining({error: true, sender: 'assistant'}),
+		]);
+		expect(result.current.isGenerating).toBe(false);
+	});
+
+	it('reports success when the request is accepted', async () => {
+		const result = await renderSubscribed();
+
+		let sent;
+
+		await act(async () => {
+			sent = await result.current.sendMessage('Tag this article');
+		});
+
+		expect(sent).toBe(true);
+		expect(result.current.messages).toEqual([
+			{sender: 'user', text: 'Tag this article'},
+		]);
+	});
+
+	it('answers a message sent with no connection with an error', async () => {
+		const {result} = renderHook(() =>
+			useAIChat({instructionDefinitionScope: ''})
+		);
+
+		await act(async () => {});
+
+		let sent;
+
+		await act(async () => {
+			sent = await result.current.sendMessage('Tag this article');
+		});
+
+		expect(sent).toBe(false);
+		expect(result.current.messages).toEqual([
+			{sender: 'user', text: 'Tag this article'},
+			expect.objectContaining({error: true, sender: 'assistant'}),
+		]);
+		expect(result.current.isGenerating).toBe(false);
+		expect(Liferay.Util.openToast).toHaveBeenCalledWith(
+			expect.objectContaining({type: 'danger'})
+		);
+		expect(mockPostChat).not.toHaveBeenCalled();
+	});
+
 	it('keeps the generating indicator until every balloon has finished', async () => {
 		const {result} = renderHook(() =>
 			useAIChat({instructionDefinitionScope: ''})

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/useCategorizationAgent.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/useCategorizationAgent.test.ts
@@ -166,6 +166,57 @@ describe('useCategorizationAgent', () => {
 		);
 	});
 
+	it('stays stopped when the request fails after it was stopped', async () => {
+		mockPostAgentInstance.mockRejectedValue(new Error('Request failed'));
+
+		const {fakeEventSource, result} = await renderAgent(
+			ECategorizationAgent.AUTO_CATEGORIZE
+		);
+
+		await act(async () => {
+			(result as {current: {run: Function}}).current.run({
+				candidateCategories: CANDIDATES,
+				content: 'Japan article',
+			});
+		});
+
+		act(() => {
+			fakeEventSource.emit('Subscribe', 'sink-1');
+
+			(result as {current: {stop: Function}}).current.stop();
+		});
+
+		await act(async () => {});
+
+		expect((result as {current: {status: string}}).current).toMatchObject({
+			status: 'stopped',
+		});
+	});
+
+	it('surfaces an error when the stream fails', async () => {
+		const {fakeEventSource, result} = await renderAgent(
+			ECategorizationAgent.AUTO_CATEGORIZE
+		);
+
+		await act(async () => {
+			(result as {current: {run: Function}}).current.run({
+				candidateCategories: CANDIDATES,
+				content: 'Japan article',
+			});
+		});
+
+		act(() => fakeEventSource.emit('Subscribe', 'sink-1'));
+
+		await act(async () => {
+			fakeEventSource.emit('error', '');
+		});
+
+		expect((result as {current: {status: string}}).current).toMatchObject({
+			status: 'error',
+		});
+		expect(fakeEventSource.close).toHaveBeenCalled();
+	});
+
 	it('surfaces the error text on agent invocation failure', async () => {
 		const {fakeEventSource, result} = await renderAgent(
 			ECategorizationAgent.AUTO_CATEGORIZE

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/useCategorizationAgent.test.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/js/Categorization/useCategorizationAgent.test.ts
@@ -224,6 +224,29 @@ describe('useCategorizationAgent', () => {
 		expect(mockCreateEventSource).toHaveBeenCalledTimes(2);
 	});
 
+	it('surfaces the error when the channel is unavailable', async () => {
+		const {result} = await renderAgent(
+			ECategorizationAgent.AUTO_CATEGORIZE
+		);
+
+		mockCreateEventSource.mockReset();
+		mockCreateEventSource.mockResolvedValue(null);
+
+		await act(async () => {
+			(result as {current: {run: Function}}).current.run({
+				candidateCategories: CANDIDATES,
+				content: 'Japan article',
+			});
+		});
+
+		expect(
+			(result as {current: {error: string; status: string}}).current
+		).toMatchObject({
+			error: 'an-unexpected-error-occurred',
+			status: 'error',
+		});
+	});
+
 	it('regenerates by re-posting the last context', async () => {
 		const {fakeEventSource, result} = await renderAgent(
 			ECategorizationAgent.AUTO_CATEGORIZE

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/RichText/RichText.spec.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/RichText/RichText.spec.js
@@ -43,13 +43,12 @@ describe('RichText component', () => {
 		expect(richTextContainer.hasAttribute('aria-invalid')).toBe(false);
 	});
 
-	it('has aria-label attribute when it is rendered', () => {
-		const {getByRole} = render(
-			<RichText label="RichText Label" name="RichTextName" />
+	it('does not announce its container as a text box', () => {
+		render(<RichText label="RichText Label" name="RichTextName" />);
+
+		const richTextContainer = document.getElementById(
+			'RichTextNameContainer'
 		);
-
-		const richTextElement = getByRole('textbox');
-
-		expect(richTextElement).toHaveAttribute('aria-label', 'RichText Label');
+		expect(richTextContainer).not.toHaveAttribute('role');
 	});
 });

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -49,6 +49,12 @@ boolean required = GetterUtil.getBoolean((String)request.getAttribute(CKEditorCo
 boolean skipEditorLoading = GetterUtil.getBoolean((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":skipEditorLoading"));
 String toolbarSet = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":toolbarSet");
 
+String ariaLabel = StringPool.BLANK;
+
+if (Validator.isNotNull(placeholder)) {
+	ariaLabel = LanguageUtil.get(request, placeholder);
+}
+
 if (!inlineEdit) {
 	name = namespace + name;
 }
@@ -341,6 +347,19 @@ name = HtmlUtil.escapeJS(name);
 	};
 
 	window['<%= name %>']._setStyles = function () {
+		<c:if test="<%= Validator.isNotNull(ariaLabel) %>">
+			var ckEditorInstance = CKEDITOR.instances['<%= name %>'];
+
+			var editable = ckEditorInstance && ckEditorInstance.editable();
+
+			if (editable) {
+				editable.setAttribute(
+					'aria-label',
+					'<%= HtmlUtil.escapeJS(ariaLabel) %>'
+				);
+			}
+		</c:if>
+
 		var ckEditor = A.one('#cke_<%= name %>');
 
 		if (ckEditor) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
@@ -31,6 +31,8 @@ if (data != null) {
 		module="{ClassicEditor} from frontend-editor-ckeditor-web"
 		props='<%=
 			HashMapBuilder.<String, Object>put(
+				"ariaLabel", LanguageUtil.get(request, placeholder)
+			).put(
 				"contents", contents
 			).put(
 				"editorConfig", editorConfigJSONObject

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor4/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor4/ClassicEditor.js
@@ -4,7 +4,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, {forwardRef} from 'react';
+import React, {forwardRef, useCallback, useEffect, useRef} from 'react';
 
 import BaseEditor from './BaseEditor';
 
@@ -25,14 +25,62 @@ const ClassicEditor = forwardRef(
 		},
 		ref
 	) => {
+		const editableARIAAttributesRef = useRef({
+			ariaInvalid,
+			ariaLabel,
+			ariaRequired,
+		});
+		const editorInstanceRef = useRef();
+
+		/**
+		 * The identity of this callback has to stay stable. CKEditor's `on`
+		 * deduplicates listeners by function, so a stable identity is what
+		 * keeps `contentDom` from accumulating one listener per call, and the
+		 * current attributes are read from a ref so that the listener never
+		 * applies the values a past render closed over.
+		 */
+
+		const setEditableARIAAttributes = useCallback(() => {
+			const editable = editorInstanceRef.current?.editable();
+
+			if (!editable) {
+				return;
+			}
+
+			const {ariaInvalid, ariaLabel, ariaRequired} =
+				editableARIAAttributesRef.current;
+
+			if (ariaLabel) {
+				editable.setAttribute('aria-label', ariaLabel);
+			}
+
+			if (ariaInvalid) {
+				editable.setAttribute('aria-invalid', 'true');
+			}
+			else {
+				editable.removeAttribute('aria-invalid');
+			}
+
+			if (ariaRequired) {
+				editable.setAttribute('aria-required', 'true');
+			}
+			else {
+				editable.removeAttribute('aria-required');
+			}
+		}, []);
+
+		useEffect(() => {
+			editableARIAAttributesRef.current = {
+				ariaInvalid,
+				ariaLabel,
+				ariaRequired,
+			};
+
+			setEditableARIAAttributes();
+		}, [ariaInvalid, ariaLabel, ariaRequired, setEditableARIAAttributes]);
+
 		return (
-			<div
-				{...(ariaInvalid ? {'aria-invalid': 'true'} : {})}
-				aria-label={ariaLabel}
-				className={className}
-				id={`${name}Container`}
-				role="textbox"
-			>
+			<div className={className} id={`${name}Container`}>
 				{title && (
 					<label className="control-label" htmlFor={name}>
 						{title}
@@ -59,6 +107,8 @@ const ClassicEditor = forwardRef(
 						};
 					}}
 					onInstanceReady={({editor}) => {
+						editorInstanceRef.current = editor;
+
 						const loadData = () => {
 							editor.setData(contents, {
 								callback: () => {
@@ -94,26 +144,9 @@ const ClassicEditor = forwardRef(
 							loadData();
 						}
 
-						const iframe = document.querySelector(
-							'iframe.cke_wysiwyg_frame'
-						);
+						setEditableARIAAttributes();
 
-						if (iframe) {
-							iframe.onload = function () {
-								const iframeDocument = iframe.contentDocument;
-								const iframeBody =
-									iframeDocument.querySelector(
-										'body.cke_editable'
-									);
-
-								if (iframeBody) {
-									iframeBody.setAttribute(
-										'aria-required',
-										ariaRequired
-									);
-								}
-							};
-						}
+						editor.on('contentDom', setEditableARIAAttributes);
 					}}
 					ref={ref}
 					{...otherProps}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -22758,6 +22758,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one.
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content.
 this-role-does-not-have-any-permissions=This role does not have any permissions.
 this-role-is-automatically-assigned=This role is automatically assigned.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=هذا المرجع غير صالح. جرب واحد
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=يقدم هذا التقرير تفصيلاً لجميع أصول المشروع حسب الشخصية ومرحلة مسار التحويل.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=يوفر هذا التقرير تقسيمًا للأصول الإجمالية حسب الفئة أو نوع بنية المحتوى أو المساحة.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=يوفر هذا التقرير قائمة بالأصول التي وصلت إلى تاريخ انتهاء صلاحيتها.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=تأتي هذه النتيجة من الإصدار {0} من هذا المحتوى.
 this-role-does-not-have-any-permissions=هذا الدور ليس لديه أي أذونات.
 this-role-is-automatically-assigned=تم تعيين هذا الدور تلقائيًا.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Тази препратка не е валидна. 
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Тази роля няма разрешения. (Automatic Translation)
 this-role-is-automatically-assigned=Тази роля се присвоява автоматично. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Aquesta referència no és vàlida. Proveu-ne una al
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Aquest informe proporciona un desglossament de tots els recursos del projecte per persona i etapa de l'embut.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Aquest informe proporciona un desglossament del nombre total de continguts per categorització, tipus d'estructura del contingut o espai.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Aquest informe proporciona una llista dels continguts que han assolit la data de caducitat.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Aquest resultat prové de la versió {0} d'aquest contingut.
 this-role-does-not-have-any-permissions=Aquest rol no té cap permís.
 this-role-is-automatically-assigned=Aquest rol s'ha assignat automàticament.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Tato role nemá přiřazená žádná práva.
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Denne reference er ugyldig. Prøv en anden. (Automat
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Denne rolle har ingen tilladelser. (Automatic Translation)
 this-role-is-automatically-assigned=Denne rolle tildeles automatisk. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Diese Referenz ist ungültig. Verwenden Sie eine and
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Dieser Bericht bietet eine Aufschlüsselung aller Projektressourcen nach Persona und Funnel-Phase.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Dieser Bericht bietet eine Aufschlüsselung der Gesamtanzahl an Assets nach Kategorisierung, Inhaltsstrukturtyp oder Bereich.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Dieser Bericht enthält eine Liste der Assets, deren Ablaufdatum erreicht ist.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Dieses Ergebnis kommt von Version {0} des Inhalts.
 this-role-does-not-have-any-permissions=Diese Rolle hat keine Berechtigungen.
 this-role-is-automatically-assigned=Diese Rolle wird automatisch zugewiesen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Diese Referenz ist ungültig. Verwenden Sie eine and
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Dieser Bericht bietet eine Aufschlüsselung aller Projektressourcen nach Persona und Funnel-Phase.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Dieser Bericht bietet eine Aufschlüsselung der Gesamtanzahl an Assets nach Kategorisierung, Inhaltsstrukturtyp oder Bereich.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Dieser Bericht enthält eine Liste der Assets, deren Ablaufdatum erreicht ist.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Dieses Ergebnis kommt von Version {0} des Inhalts.
 this-role-does-not-have-any-permissions=Diese Rolle hat keine Berechtigungen.
 this-role-is-automatically-assigned=Diese Rolle wird automatisch zugewiesen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Diese Referenz ist ungültig. Verwenden Sie eine and
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Dieser Bericht bietet eine Aufschlüsselung aller Projektressourcen nach Persona und Funnel-Phase.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Dieser Bericht bietet eine Aufschlüsselung der Gesamtanzahl an Assets nach Kategorisierung, Inhaltsstrukturtyp oder Bereich.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Dieser Bericht enthält eine Liste der Assets, deren Ablaufdatum erreicht ist.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Dieses Ergebnis kommt von Version {0} des Inhalts.
 this-role-does-not-have-any-permissions=Diese Rolle hat keine Berechtigungen.
 this-role-is-automatically-assigned=Diese Rolle wird automatisch zugewiesen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Αυτή η αναφορά δεν είναι έγκ�
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Αυτός ο ρόλος δεν έχει κανένα δικαίωμα.
 this-role-is-automatically-assigned=Αυτός ο ρόλος εκχωρείται αυτόματα. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -22758,6 +22758,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one.
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content.
 this-role-does-not-have-any-permissions=This role does not have any permissions.
 this-role-is-automatically-assigned=This role is automatically assigned.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=This role does not have any permissions. (Automatic Copy)
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=This role does not have any permissions. (Automatic Copy)
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=This role does not have any permissions. (Automatic Copy)
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=This role does not have any permissions. (Automatic Copy)
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Esta referencia no es válida. Pruebe con otra.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Este informe ofrece un desglose de todos los activos del proyecto por perfil de usuario y fase de embudo.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Este informe proporciona un desglose de los activos totales por categorización, tipo de estructura de contenido o espacio.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Este informe proporciona una lista de activos que han alcanzado su fecha de caducidad.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=El resultado viene de la versión {0} de este contenido.
 this-role-does-not-have-any-permissions=Este rol no tiene ningún permiso.
 this-role-is-automatically-assigned=Este rol se asignará automáticamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Esta referencia no es válida. Pruebe con otra.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Este informe ofrece un desglose de todos los activos del proyecto por perfil de usuario y fase de embudo.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Este informe proporciona un desglose de los activos totales por categorización, tipo de estructura de contenido o espacio.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Este informe proporciona una lista de activos que han alcanzado su fecha de caducidad.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=El resultado viene de la versión {0} de este contenido.
 this-role-does-not-have-any-permissions=Este rol no tiene ningún permiso.
 this-role-is-automatically-assigned=Este rol se asignará automáticamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Esta referencia no es válida. Pruebe con otra.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Este informe ofrece un desglose de todos los activos del proyecto por perfil de usuario y fase de embudo.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Este informe proporciona un desglose de los activos totales por categorización, tipo de estructura de contenido o espacio.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Este informe proporciona una lista de activos que han alcanzado su fecha de caducidad.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=El resultado viene de la versión {0} de este contenido.
 this-role-does-not-have-any-permissions=Este rol no tiene ningún permiso.
 this-role-is-automatically-assigned=Este rol se asignará automáticamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Esta referencia no es válida. Pruebe con otra.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Este informe ofrece un desglose de todos los activos del proyecto por perfil de usuario y fase de embudo.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Este informe proporciona un desglose de los activos totales por categorización, tipo de estructura de contenido o espacio.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Este informe proporciona una lista de activos que han alcanzado su fecha de caducidad.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=El resultado viene de la versión {0} de este contenido.
 this-role-does-not-have-any-permissions=Este rol no tiene ningún permiso.
 this-role-is-automatically-assigned=Este rol se asignará automáticamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=See viide ei sobi. Proovi teist. (Automatic Translat
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Sellel rollil pole õigusi. (Automatic Translation)
 this-role-is-automatically-assigned=See roll määratakse automaatselt. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Rol honek ez du inongo baimenik.
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=این مرجع معتبر نیست. يکي ديون
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=نتیجه از نسخه {0} این محتوا حاصل شده است.
 this-role-does-not-have-any-permissions=این نقش مجوز دسترسی ندارد.
 this-role-is-automatically-assigned=این نقش به طور خودکار اختصاص داده شده است. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -22750,6 +22750,7 @@ this-reference-is-not-valid=Tämä viite ei ole kelvollinen. Kokeile toisella.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Tämä raportti erittelee kaikki projektisisällöt persoonan ja suppilon vaiheen mukaan.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Tämä raportti antaa sisältöjen erittelyn luokittelun, sisältörakennetyypin tai tilan mukaan.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Tämä raportti sisältää luettelon sisällöistä, joiden voimassaoloaika on päättynyt.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Nämä tulokset tulevat sisällön {0} versiosta.
 this-role-does-not-have-any-permissions=Tällä roolilla ei ole käyttöoikeuksia.
 this-role-is-automatically-assigned=Tämä rooli nimetään automaattisesti.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Cette référence est déjà utilisée. Essayez-en u
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Ce rapport présente une ventilation de tous les actifs du projet par profil d'utilisateur et par étape du tunnel de conversion.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Ce rapport fournit une répartition du total des actifs par catégorisation, type de structure de contenu ou espace.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Ce rapport fournit une liste des actifs qui ont atteint leur date d'expiration.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Ce résultat vient de la version {0} de ce contenu.
 this-role-does-not-have-any-permissions=Ce rôle n'a aucune permission.
 this-role-is-automatically-assigned=Ce rôle est automatiquement affecté.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Cette référence est déjà utilisée. Essayez-en u
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Ce rapport présente une ventilation de tous les actifs du projet par profil d'utilisateur et par étape du tunnel de conversion.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Ce rapport fournit une répartition du total des actifs par catégorisation, type de structure de contenu ou espace.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Ce rapport fournit une liste des actifs qui ont atteint leur date d'expiration.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Ce résultat vient de la version {0} de ce contenu.
 this-role-does-not-have-any-permissions=Ce rôle n'a aucune permission.
 this-role-is-automatically-assigned=Ce rôle est automatiquement affecté.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Cette référence est déjà utilisée. Essayez-en u
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Ce résultat vient de la version {0} de ce contenu.
 this-role-does-not-have-any-permissions=Ce rôle n'a aucune permission.
 this-role-is-automatically-assigned=Ce rôle est automatiquement affecté.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Cette référence est déjà utilisée. Essayez-en u
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Ce rapport présente une ventilation de tous les actifs du projet par profil d'utilisateur et par étape du tunnel de conversion.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Ce rapport fournit une répartition du total des actifs par catégorisation, type de structure de contenu ou espace.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Ce rapport fournit une liste des actifs qui ont atteint leur date d'expiration.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Ce résultat vient de la version {0} de ce contenu.
 this-role-does-not-have-any-permissions=Ce rôle n'a aucune permission.
 this-role-is-automatically-assigned=Ce rôle est automatiquement affecté.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Este rol non ten ningúns permisos.
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=यह संदर्भ मान्य नही�
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=इस रोल को कोई अनुमतियाँ नहीं है|
 this-role-is-automatically-assigned=यह भूमिका स्वचालित रूप से सौंपी गई है। (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Ova uloga nema dozvole.
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=This role does not have any permissions. (Automatic Copy)
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -22755,6 +22755,7 @@ this-reference-is-not-valid=Ez a hivatkozás nem érvényes. Próbálkozzon egy 
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Ez a jelentés a projekt összes tartalmát perszóna és tölcsérszakasz szerinti lebontásban mutatja be.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Ez a jelentés a teljes tartalomállományt kategóriák, tartalomstruktúra-típusok vagy terek szerint bontja le.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=A jelentés a lejárati dátumukat elért tartalmak listáját tartalmazza.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Az eredmény ennek a tartalomnak a {0}. verziójából származik.
 this-role-does-not-have-any-permissions=Ehhez a szerepkörhöz nem tartoznak jogosultságok.
 this-role-is-automatically-assigned=Ez a szerepkör automatikusan hozzárendelődik.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Referensi ini tidak sahih. Cobalah yang berbeda. (Au
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Peran ini tidak memiliki izin.
 this-role-is-automatically-assigned=Peran ini secara otomatis ditetapkan. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -22753,6 +22753,7 @@ this-reference-is-not-valid=Questo riferimento non è valido. Provarne un altro.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Questo risultato deriva dalla versione {0} di questo contenuto.
 this-role-does-not-have-any-permissions=Questo ruolo non ha nessun permesso.
 this-role-is-automatically-assigned=Questo ruolo viene assegnato automaticamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Questo riferimento non è valido. Provarne un altro.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Questo risultato deriva dalla versione {0} di questo contenuto.
 this-role-does-not-have-any-permissions=Questo ruolo non ha nessun permesso.
 this-role-is-automatically-assigned=Questo ruolo viene assegnato automaticamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=הפניה זו אינה חוקית. נסה אחד �
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=התוצאה מגיעה מגירסה {0} של תוכן זה.
 this-role-does-not-have-any-permissions=לא קיימות הרשאות לתפקיד הזה.
 this-role-is-automatically-assigned=תפקיד זה מוקצה באופן אוטומטי.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=この参照は有効ではありません。別の�
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=このレポートには、ペルソナとファネルステージごとにすべてのプロジェクトアセットの内訳が表示されます。
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=このレポートには、カテゴリ設定、コンテンツストラクチャータイプ、またはスペースごとのアセット全体の内訳が表示されます。
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=このレポートには有効期限に達したアセットのリストが表示されます。
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=この結果は、このコンテンツのバージョン{0}を参照しています
 this-role-does-not-have-any-permissions=このロールに許可がない。
 this-role-is-automatically-assigned=このロールは自動的に割り当てられます。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=This role does not have any permissions. (Automatic Copy)
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -22758,6 +22758,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content.
 this-role-does-not-have-any-permissions=This role does not have any permissions.
 this-role-is-automatically-assigned=This role is automatically assigned.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -22751,6 +22751,7 @@ this-reference-is-not-valid=이 참조는 유효하지 않습니다. 다른 것�
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=이 결과는 이 콘텐츠의 {0} 버전에서 가져온 것입니다.
 this-role-does-not-have-any-permissions=이 역할에는 어떤 허가도 없다.
 this-role-is-automatically-assigned=이 역할은 자동으로 할당됩니다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=ລະຫັດອ້າງອີງນີ້ບໍ�
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=ລາຍງານນີ້ໃຫ້ລາຍລະອຽດຂອງຊັບສິນໂຄງການທັງໝົດຕາມຕົວຕົນ ແລະ ຂັ້ນຕອນຂອງກວຍການຂາຍ.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=ລາຍງານນີ້ໃຫ້ລາຍລະອຽດຂອງແອສເຊັດທັງໝົດແຍກຕາມໝວດໝູ່, ປະເພດໂຄງສ້າງເນື້ອໃນ, ຫຼື ພື້ນທີ່.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=ລາຍງານນີ້ສະແດງລາຍການແອສເຊັດທີ່ໝົດອາຍຸແລ້ວ.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=ຜົນລັບນີ້ມາຈາກເວີຊັນ {0} ຂອງເນື້ອໃນນີ້.
 this-role-does-not-have-any-permissions=ຫຼັກການນີ້ບໍ່ມີສິດທິໃດໆທັງໝົດ
 this-role-is-automatically-assigned=ບົດບາດນີ້ຖືກກຳນົດໃຫ້ໂດຍອັດຕະໂນມັດ.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Ši nuoroda neleistina. Išbandykite kitą. (Automat
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Šis vaidmuo neturi jokių teisių. (Automatic Translation)
 this-role-is-automatically-assigned=Šis vaidmuo priskiriamas automatiškai. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=This role does not have any permissions. (Automatic Copy)
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Rujukan ini tidak sah. Cuba yang lain. (Automatic Tr
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Peranan ini tidak mempunyai sebarang keizinan. (Automatic Translation)
 this-role-is-automatically-assigned=Peranan ini diperuntukkan secara automatik. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=This role does not have any permissions. (Automatic Copy)
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Denne referansen er ikke gyldig. Prøv en annen. (Au
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Resultatet kommer fra {0} versjonen av dette innholdet.
 this-role-does-not-have-any-permissions=Denne rollen har ikke de nødvendige rettighetene.
 this-role-is-automatically-assigned=Denne rollen tilordnes automatisk. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -22755,6 +22755,7 @@ this-reference-is-not-valid=Deze referentie is niet geldig. probeer een andere.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Dit rapport geeft een overzicht van alle projectassets per persona en funnelfase.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Dit rapport verstrekt een uitsplitsing van het totaal van de assets per categorie, inhoudsstructuurtype of ruimte.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Dit rapport bevat een lijst met assets die hun verloopdatum hebben bereikt.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Dit resultaat is afkomstig van versie {0} van deze content.
 this-role-does-not-have-any-permissions=Deze rol heeft geen rechten.
 this-role-is-automatically-assigned=Deze rol wordt automatisch toegewezen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -22755,6 +22755,7 @@ this-reference-is-not-valid=Deze referentie is niet geldig. probeer een andere.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Dit rapport geeft een overzicht van alle projectassets per persona en funnelfase.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Dit rapport verstrekt een uitsplitsing van het totaal van de assets per categorie, inhoudsstructuurtype of ruimte.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Dit rapport bevat een lijst met assets die hun verloopdatum hebben bereikt.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Dit resultaat is afkomstig van versie {0} van deze content.
 this-role-does-not-have-any-permissions=Deze rol heeft geen rechten.
 this-role-is-automatically-assigned=Deze rol wordt automatisch toegewezen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Denne referansen er ikke gyldig. Prøv en annen. (Au
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Resultatet kommer fra {0} versjonen av dette innholdet.
 this-role-does-not-have-any-permissions=Denne rollen har ikke de nødvendige rettighetene.
 this-role-is-automatically-assigned=Denne rollen tilordnes automatisk. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=To odwołanie jest nieprawidłowe. Spróbuj użyć i
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Ta rola nie posiada żadnych uprawnień.
 this-role-is-automatically-assigned=Ta rola jest przypisywana automatycznie. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Esta referência não é válida. Tente uma diferent
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Este relatório fornece uma análise detalhada de todos os ativos do projeto por persona e estágio do funil.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Este relatório mostra a divisão total dos ativos por categoria, tipo de estrutura do conteúdo ou espaço.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Este relatório fornece uma lista de ativos que atingiram sua data de expiração.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Este resultado vem da versão {0} deste conteúdo.
 this-role-does-not-have-any-permissions=Esta função não possui permissões.
 this-role-is-automatically-assigned=Esta função é atribuída automaticamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=Esta referência não é válida. Tente um diferente
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Este relatório fornece uma análise detalhada de todos os ativos do projeto por persona e estágio do funil.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Este relatório mostra a divisão total dos ativos por categoria, tipo de estrutura do conteúdo ou espaço.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Este relatório fornece uma lista de ativos que atingiram sua data de expiração.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Este resultado vem da versão {0} deste conteúdo.
 this-role-does-not-have-any-permissions=Este Role não tem permissões.
 this-role-is-automatically-assigned=Esta função é atribuída automaticamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Această referință nu este validă. Încearcă alt
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Acest rol nu are permisiuni.
 this-role-is-automatically-assigned=Acest rol este atribuit automat. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Эта ссылка не действительна.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=У этой роли нет никаких прав доступа.
 this-role-is-automatically-assigned=Эта роль назначается автоматически. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Tento odkaz nie je platný. Skúste inú. (Automatic
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Výsledok pochádza z verzie {0} tohoto obsahu.
 this-role-does-not-have-any-permissions=Táto rola nemá žiadne oprávnenia.
 this-role-is-automatically-assigned=Táto rola je automaticky priradená. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Ta sklic ni veljaven. Poskusi z drugačnim. (Automat
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Ta vloga nima nobenih dovoljenj. (Automatic Translation)
 this-role-is-automatically-assigned=Ta vloga je samodejno dodeljena. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Ова улога нема дозволе.
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Ova uloga nema dozvole.
 this-role-is-automatically-assigned=This role is automatically assigned. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Den här referensen är inte giltig. Testa en annan.
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=Den här rapporten erbjuder en översikt över alla projekttillgångar efter profil och trattfas.
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=Den här rapporten erbjuder en översikt över antalet tillgångar efter kategori, typ av innehållsstruktur eller utrymme.
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=Den här rapporten tillhandahåller en lista med tillgångar som har nått förfallodatumet.
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Det här resultatet kommer från version {0} av det här innehållet.
 this-role-does-not-have-any-permissions=Den här rollen har inga rättigheter.
 this-role-is-automatically-assigned=Rollen tilldelas automatiskt.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=This reference is not valid. Try a different one. (A
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=இந்த உள்ளடக்கத்தின் {0} பதிப்பிலிருந்து இந்த முடிவு வருகிறது.
 this-role-does-not-have-any-permissions=இந்த role-ல் எந்த அனுமதியும் இல்லை.
 this-role-is-automatically-assigned=இந்த role தானாகவே ஒதுக்கப்பட்டிருக்கிறது.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=การอ้างอิงนี้ไม่ถ�
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=ผลลัพธ์นี้มาจากเวอร์ชั่น {0} ของคอนเทนต์นี้
 this-role-does-not-have-any-permissions=บทบาทนี้ไม่มีสิทธิ์ใดๆ
 this-role-is-automatically-assigned=บทบาทนี้ถูกมอบหมายโดยอัตโนมัติ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Bu başvuru geçerli değil. Başka bir tane dene. (
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Bu rolün herhangi bir izni yok. (Automatic Translation)
 this-role-is-automatically-assigned=Bu rol otomatik olarak atanır. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Неприпустиме посилання. Спр�
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=This result comes from the {0} version of this content. (Automatic Copy)
 this-role-does-not-have-any-permissions=Ця роль не має дозволів. (Automatic Translation)
 this-role-is-automatically-assigned=Ця роль призначається автоматично. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -22752,6 +22752,7 @@ this-reference-is-not-valid=Tham chiếu này không hợp lệ. Hãy thử mộ
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=Kết quả đến từ phiên bản {0} của Bài viết.
 this-role-does-not-have-any-permissions=Vai trò này không có quyền nào.
 this-role-is-automatically-assigned=Vai trò này được tự động gán. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -22754,6 +22754,7 @@ this-reference-is-not-valid=此引用无效。请尝试其他引用。
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=此报告按角色和漏斗阶段提供所有项目资产的细分。
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=此报告按分类、内容结构类型或空间提供总资源细分。
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=此报告会提供已达到其到期日期的资产列表。
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=这个结果来自这个内容的第{0}版本
 this-role-does-not-have-any-permissions=此角色没有任何权限。
 this-role-is-automatically-assigned=自动分配该角色。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -22753,6 +22753,7 @@ this-reference-is-not-valid=此引用無效。請嘗試其他引用。
 this-report-provides-a-breakdown-of-all-project-assets-by-persona-and-funnel-stage=This report provides a breakdown of all project assets by persona and funnel stage. (Automatic Copy)
 this-report-provides-a-breakdown-of-total-assets-by-categorization,-content-structure-type,-or-space=This report provides a breakdown of total assets by categorization, content structure type, or space. (Automatic Copy)
 this-report-provides-a-list-of-assets-that-have-reached-their-expiration-date=This report provides a list of assets that have reached their expiration date. (Automatic Copy)
+this-request-was-replaced-by-a-newer-one=This request was replaced by a newer one. (Automatic Copy)
 this-result-comes-from-the-x-version-of-this-content=這結果來自內容的 {0} 版本。
 this-role-does-not-have-any-permissions=這個角色沒有任何權限。
 this-role-is-automatically-assigned=自動分配該角色。

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -341,7 +341,7 @@ const AssetCategories = ({
 					hasUpdatePermission ? (
 						<AIAssistantTriggerButton
 							anchorId={AI_ASSISTANT_TOOLBAR_TRIGGER_ID}
-							className="ml-2"
+							className="ai-assistant-chat__trigger--categorization ml-2"
 							hideLabel
 							instructionDefinitionScope="cms"
 							label={Liferay.Language.get(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
@@ -236,7 +236,7 @@ const AssetTags = ({
 						(objectEntry as IAssetObjectEntry).contentRawText) ? (
 						<AIAssistantTriggerButton
 							anchorId={AI_ASSISTANT_TOOLBAR_TRIGGER_ID}
-							className="ml-2"
+							className="ai-assistant-chat__trigger--categorization ml-2"
 							hideLabel
 							instructionDefinitionScope="cms"
 							label={Liferay.Language.get(

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/categorization/components/CategorizationSpaces.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/categorization/components/CategorizationSpaces.test.tsx
@@ -116,7 +116,7 @@ describe('CategorizationSpaces', () => {
 		});
 
 		expect(screen.getByText('Engineering Docs')).toBeInTheDocument();
-	});
+	}, 15000);
 
 	it('disables the input and checkbox when disabled is true', async () => {
 		render(<CategorizationSpaces {...defaultProps} disabled />);

--- a/modules/test/playwright/tests/client-extension-web/editor-config-contributor/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/editor-config-contributor/editorConfigContributor.spec.ts
@@ -132,10 +132,9 @@ test('CKEditor is still usable after deploying Client Extension @LPD-31017', asy
 		await journalEditArticlePage.goto();
 
 		const editorTextBox = page
-			.frameLocator(
-				'internal:role=textbox[name="Content"i] >> iframe[title="editor"]'
-			)
-			.getByRole('textbox');
+			.locator('.edit-article-panel')
+			.frameLocator('iframe[title="editor"]')
+			.getByRole('textbox', {name: 'Content'});
 
 		await editorTextBox.click();
 		await editorTextBox.fill('LPD-31017');

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/formFields.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/formFields.spec.ts
@@ -498,7 +498,7 @@ test.describe('Manage fields through Form Builder page', () => {
 			await formBuilderSidePanelPage.advancedTab.click();
 
 			richTextPredefinedValueIframe = page
-				.getByRole('textbox', {name: 'Predefined Value'})
+				.locator('[data-field-name="predefinedValue"]')
 				.frameLocator('iframe');
 
 			await richTextPredefinedValueIframe.getByRole('paragraph').click();
@@ -528,7 +528,9 @@ test.describe('Manage fields through Form Builder page', () => {
 			await formBuilderPage.formTab.click();
 
 			await expect(
-				page.getByRole('textbox', {name: 'Rich Text'})
+				page.locator('.ddm-field .form-group label.ddm-label', {
+					hasText: 'Rich Text',
+				})
 			).toBeVisible();
 
 			await formBuilderPage.openFieldSettings('Rich Text');

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/richText.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/richText.spec.ts
@@ -158,6 +158,60 @@ baseTest(
 	}
 );
 
+baseTest(
+	'Names and marks each editor after its own field when a page has two of them',
+	{tag: ['@LPD-34688']},
+	async ({formBuilderPage, formBuilderSidePanelPage, page}) => {
+		const optionalLabel = getRandomString();
+		const requiredLabel = getRandomString();
+
+		await formBuilderPage.goToNew();
+
+		await expect(formBuilderPage.newFormHeading).toBeVisible();
+
+		// Add an optional rich text field, then a required one below it
+
+		await formBuilderSidePanelPage.addFieldByDoubleClick('Rich Text');
+
+		await formBuilderSidePanelPage.label.fill(optionalLabel);
+
+		await formBuilderSidePanelPage.backButton.click();
+
+		await formBuilderSidePanelPage.addFieldByDoubleClick('Rich Text');
+
+		await formBuilderSidePanelPage.label.fill(requiredLabel);
+
+		await formBuilderSidePanelPage.requiredFieldToggleSwitch.click();
+
+		await page.waitForTimeout(1000);
+
+		await formBuilderPage.clickPublishFormButton();
+
+		const formSubmissionURL = await formBuilderPage.getFormSubmissionURL();
+
+		await page.goto(formSubmissionURL);
+
+		// Each editable is named after the field it edits, so a wrong order
+		// fails these lookups rather than passing silently
+
+		const richTextFrames = page.frameLocator('iframe.cke_wysiwyg_frame');
+
+		const optionalEditable = richTextFrames
+			.first()
+			.getByRole('textbox', {name: optionalLabel});
+
+		const requiredEditable = richTextFrames
+			.last()
+			.getByRole('textbox', {name: requiredLabel});
+
+		// Only the required field's own editable is announced as required
+
+		await expect(requiredEditable).toHaveAttribute('aria-required', 'true');
+
+		await expect(optionalEditable).not.toHaveAttribute('aria-required');
+	}
+);
+
 xssBypassTest(
 	'Can add scripts to the rich text field @LPD-31212',
 	async ({formBuilderPage, formBuilderSidePanelPage}) => {

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/classic.spec.ts
@@ -159,6 +159,16 @@ test(
 );
 
 test(
+	'Editable is named after the field it edits',
+	{tag: ['@LPD-34688']},
+	async ({classicPage}) => {
+		await expect(
+			classicPage.editableFrame.getByRole('textbox', {name: 'Content'})
+		).toBeVisible();
+	}
+);
+
+test(
 	'Editor voice label is human readable',
 	{tag: ['@LPD-53923']},
 	async ({classicPage: _classicPage, page}) => {

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/legacy.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/legacy.spec.ts
@@ -23,6 +23,18 @@ test.beforeEach(async ({ckeditor4SamplePage}) => {
 	await ckeditor4SamplePage.gotoTab(TabName.LEGACY);
 });
 
+test(
+	'Editable is named after the field it edits',
+	{tag: ['@LPD-34688']},
+	async ({page}) => {
+		await expect(
+			page
+				.frameLocator('iframe[title="editor"]')
+				.getByRole('textbox', {name: 'Content'})
+		).toBeVisible();
+	}
+);
+
 test('XSS injection doesnt get invoked', async ({page}) => {
 	await test.step('Click on the "Go to XSS" button', async () => {
 		const gotToXSSViewButton = page.getByText('Go to XSS View');

--- a/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
@@ -312,7 +312,7 @@ export class JournalEditArticlePage {
 		// CKEditor 4 instance whose editable lives inside an iframe.
 
 		const ckEditor4Content = this.page
-			.getByRole('textbox', {exact: true, name: 'Content'})
+			.getByTestId('content')
 			.frameLocator('iframe.cke_wysiwyg_frame')
 			.locator('body');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-34688

## What Is Being Fixed

axe DevTools reports "Ensure every ARIA input field has an accessible name" against the CKEditor 4 editable on the Web Content edit page. CKEditor gives the editable a `textbox` role but only names it when `config.title` is set, and Liferay sets `config.title` to `false` to suppress the hover tooltip, so the editable was announced as an unnamed text box.

The `ClassicEditor` React container also carried a `textbox` role of its own, which duplicated the role on an element that is not the text box and that wraps the label, the toolbar, and the iframe. Its `aria-required` was applied through a document-wide `querySelector` for `iframe.cke_wysiwyg_frame`, so on a page with more than one editor it always landed on the first one, even when a different editor was the required field. The handler was also assigned to `iframe.onload` after the frame had already loaded.

## How It Is Being Fixed

The editable is named directly, through the CKEditor instance rather than the surrounding markup. In the React component the ARIA state moves off the container onto `editor.editable()`, resolved by instance name so each editor writes only to its own editable, and it is reapplied on `contentDom` because CKEditor rewrites the editable's document on every `setData` and every mode switch. The container's `role` and the attributes that existed only to serve it are removed.

The legacy JSP path is named the same way, from the existing `_setStyles` function that already runs on `instanceReady` and `dataReady`. The label prefers the field's own `placeholder` and falls back to `rich-text-editor`, so the Journal Description field reads as "Description" and the Web Content field as "Content".

## PR Check

**pr-check: PASS** — tested on `d4c463dc91f59d6dd1411ec7f3a049d18c1f605a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JSP Compile | PASS |
| JavaScript Unit Tests | PASS |

Baseline note: `ant baseline-all` aborted at `portal-kernel/build.xml:21` with 22 javac errors (`The field _advertise does not have a public setter`) in `portal-kernel/src/com/liferay/portal/kernel/internal/log4j/`. This is pre-existing breakage on `master` from commit `1502b59` (`Revert "LPD-98608 Suppress the Log4j public setter requirement on custom plugins"`), verified an ancestor of `master`; this branch touches none of those files. No `bnd.bnd` or `packageinfo` changed, and the branch modifies zero `.java` files, so no exported package version can require a bump. Recorded as a pass by construction rather than tool-confirmed. `ant compile install-portal-snapshots` built the same tree successfully, so the failure is specific to the stricter `baseline` javac path.

<!-- pr-check {"result": "success", "sha": "d4c463dc91f59d6dd1411ec7f3a049d18c1f605a"} -->
