### PR TITLE
LPD-97504 Keep the filter action button visible when items stack

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FilterResume.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FilterResume.tsx
@@ -88,6 +88,7 @@ function FilterResume({
 				<ClayDropDown
 					active={open}
 					className="d-inline-flex"
+					menuElementAttrs={{className: 'filter-dropdown-menu'}}
 					onActiveChange={setOpen}
 					trigger={
 						<ClayButton

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.tsx
@@ -73,6 +73,7 @@ const FiltersDropdown = () => {
 		<ClayDropDown
 			active={active}
 			className="filters-dropdown"
+			menuElementAttrs={{className: 'filter-dropdown-menu'}}
 			onActiveChange={setActive}
 			trigger={
 				<Button

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -406,23 +406,25 @@ function SelectionFilter({
 	return (
 		<>
 			{autocompleteEnabled && (
-				<>
-					<ClayDropDown.Caption className="pb-0">
-						<ClayAutocomplete>
-							<ClayAutocomplete.Input
-								onChange={(
-									event: ChangeEvent<HTMLInputElement>
-								) =>
-									handleAutocompleteQuery(event.target.value)
-								}
-								placeholder={inputPlaceholder}
-							/>
+				<ClayDropDown.Caption className="filter-header">
+					<ClayAutocomplete>
+						<ClayAutocomplete.Input
+							onChange={(event: ChangeEvent<HTMLInputElement>) =>
+								handleAutocompleteQuery(event.target.value)
+							}
+							placeholder={inputPlaceholder}
+						/>
 
-							{loading && <ClayAutocomplete.LoadingIndicator />}
-						</ClayAutocomplete>
+						{loading && <ClayAutocomplete.LoadingIndicator />}
+					</ClayAutocomplete>
+				</ClayDropDown.Caption>
+			)}
 
-						{selectedItems.length ? (
-							<div className="mt-2 selected-elements-wrapper">
+			<div className="filter-body" ref={setScrollingArea}>
+				{autocompleteEnabled && !!selectedItems.length ? (
+					<>
+						<ClayDropDown.Caption className="pt-0">
+							<div className="selected-elements-wrapper">
 								{selectedItems.map((selectedItem) => (
 									<ClayLabel
 										closeButtonProps={{
@@ -441,97 +443,95 @@ function SelectionFilter({
 									</ClayLabel>
 								))}
 							</div>
-						) : null}
-					</ClayDropDown.Caption>
+						</ClayDropDown.Caption>
 
-					<Divider />
-				</>
-			)}
+						<Divider />
+					</>
+				) : null}
 
-			<ClayDropDown.Caption className="pb-0">
-				<div className="row">
-					<div className="col">
-						<label htmlFor={`autocomplete-exclude-${id}`}>
-							{Liferay.Language.get('exclude')}
-						</label>
+				<ClayDropDown.Caption className="pb-0">
+					<div className="row">
+						<div className="col">
+							<label htmlFor={`autocomplete-exclude-${id}`}>
+								{Liferay.Language.get('exclude')}
+							</label>
+						</div>
+
+						<div className="col-auto">
+							<ClayToggle
+								id={`autocomplete-exclude-${id}`}
+								onToggle={() => setExclude(!exclude)}
+								toggled={exclude}
+							/>
+						</div>
 					</div>
+				</ClayDropDown.Caption>
 
-					<div className="col-auto">
-						<ClayToggle
-							id={`autocomplete-exclude-${id}`}
-							onToggle={() => setExclude(!exclude)}
-							toggled={exclude}
-						/>
-					</div>
-				</div>
-			</ClayDropDown.Caption>
+				<Divider />
 
-			<Divider />
+				<div className="pb-1 pl-3 pr-3 pt-1">
+					{items && !!items.length ? (
+						<ul className="filter-items mx-n2 px-2">
+							{items.map(({label, value}, index) => {
+								const newValue = {
+									label,
+									value,
+								};
 
-			<div className="pb-1 pl-3 pr-3 pt-1">
-				{items && !!items.length ? (
-					<ul
-						className="inline-scroller mx-n2 px-2"
-						ref={setScrollingArea}
-					>
-						{items.map(({label, value}, index) => {
-							const newValue = {
-								label,
-								value,
-							};
-
-							return (
-								<Item
-									aria-label={label}
-									checked={Boolean(
-										selectedItems.find(
-											(element) => element.value === value
-										)
-									)}
-									key={`${value}-${index}`}
-									label={label.toString()}
-									multiple={multiple}
-									onChange={() => {
-										setSelectedItems(
+								return (
+									<Item
+										aria-label={label}
+										checked={Boolean(
 											selectedItems.find(
 												(element) =>
 													element.value === value
 											)
-												? selectedItems.filter(
-														(element) =>
-															element.value !==
-															value
-													)
-												: multiple
-													? [
-															...selectedItems,
-															newValue,
-														]
-													: [newValue]
-										);
-									}}
-									value={value}
-								/>
-							);
-						})}
+										)}
+										key={`${value}-${index}`}
+										label={label.toString()}
+										multiple={multiple}
+										onChange={() => {
+											setSelectedItems(
+												selectedItems.find(
+													(element) =>
+														element.value === value
+												)
+													? selectedItems.filter(
+															(element) =>
+																element.value !==
+																value
+														)
+													: multiple
+														? [
+																...selectedItems,
+																newValue,
+															]
+														: [newValue]
+											);
+										}}
+										value={value}
+									/>
+								);
+							})}
 
-						{loaderVisible && (
-							<ClayLoadingIndicator
-								ref={setInfiniteLoader}
-								size="sm"
-							/>
-						)}
-					</ul>
-				) : (
-					<div className="mt-2 p-2 text-muted">
-						{Liferay.Language.get('no-items-were-found')}
-					</div>
-				)}
+							{loaderVisible && (
+								<ClayLoadingIndicator
+									ref={setInfiniteLoader}
+									size="sm"
+								/>
+							)}
+						</ul>
+					) : (
+						<div className="mt-2 p-2 text-muted">
+							{Liferay.Language.get('no-items-were-found')}
+						</div>
+					)}
+				</div>
 			</div>
 
 			<Divider />
 
-			<ClayDropDown.Caption>
+			<ClayDropDown.Caption className="filter-footer">
 				<ClayButton
 					disabled={submitDisabled}
 					onClick={() => {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_filter_dropdown.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_filter_dropdown.scss
@@ -1,0 +1,59 @@
+// A filter panel is rendered in a dropdown menu, which Clay renders in a
+// portal, outside of the `.fds` wrapper, so these styles cannot be nested under
+// it.
+
+.filter-dropdown-menu {
+	// A selection filter renders its item list inside `.filter-body`, which is
+	// the only scrolling region of the panel. The panel is laid out as a flex
+	// column so that `.filter-body` absorbs the leftover space instead of
+	// overflowing the menu, which would add a second, nested scrollbar and push
+	// the action button below the fold.
+
+	// `.show` keeps `display` from overriding the closed state of the menu,
+	// which Clay implements with `display: none`.
+
+	&.show:has(.filter-body) {
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+
+		.data-set-filter {
+			display: flex;
+			flex: 1 1 auto;
+			flex-direction: column;
+			min-height: 0;
+		}
+
+		.filter-body {
+			flex: 1 1 auto;
+			min-height: 0;
+			overflow-y: auto;
+		}
+
+		.dropdown-subheader,
+		.filter-footer,
+		.filter-header {
+			flex: 0 0 auto;
+		}
+	}
+
+	.filter-body {
+		.custom-control-label {
+			display: flex;
+
+			&::before {
+				flex-shrink: 0;
+			}
+		}
+
+		.form-control {
+			padding-left: map-get($spacers, 2);
+			padding-right: map-get($spacers, 2);
+		}
+	}
+
+	.filter-items {
+		list-style: none;
+		margin-bottom: 0;
+	}
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_management_bar.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_management_bar.scss
@@ -97,25 +97,6 @@
 		}
 	}
 
-	.filter-body {
-		.inline-scroller {
-			max-height: 200px;
-		}
-
-		.form-control {
-			padding-left: map-get($spacers, 2);
-			padding-right: map-get($spacers, 2);
-		}
-
-		.custom-control-label {
-			display: flex;
-
-			&::before {
-				flex-shrink: 0;
-			}
-		}
-	}
-
 	.filter-resume {
 		align-items: center;
 		color: inherit;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_management_bar.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_management_bar.scss
@@ -55,48 +55,6 @@
 		}
 	}
 
-	.data-set-filter .simple-toggle-switch {
-		$toggle-height: 24px;
-		$toggle-width: 40px;
-		$toggle-padding: 3px;
-
-		.toggle-switch-bar {
-			height: $toggle-height;
-			line-height: $toggle-height;
-		}
-
-		.toggle-switch-handle {
-			min-width: $toggle-width;
-		}
-
-		.toggle-switch-check {
-			height: $toggle-height;
-			width: $toggle-width;
-
-			&:empty ~ .toggle-switch-bar {
-				&::after {
-					bottom: $toggle-padding;
-					height: $toggle-height - ($toggle-padding * 2);
-					left: $toggle-padding;
-					top: $toggle-padding;
-					width: $toggle-height - ($toggle-padding * 2);
-				}
-
-				&::before {
-					width: $toggle-width;
-				}
-
-				.toggle-switch-handle:after {
-					margin-left: $toggle-width;
-				}
-			}
-
-			&:checked ~ .toggle-switch-bar::after {
-				left: $toggle-height - ($toggle-padding * 2);
-			}
-		}
-	}
-
 	.filter-resume {
 		align-items: center;
 		color: inherit;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/main.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/main.scss
@@ -2,6 +2,7 @@
 
 @import 'data_renderers/tooltip_summary';
 @import 'drag_drop';
+@import 'filter_dropdown';
 @import 'main_search';
 @import 'modal';
 @import 'side_panel';

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
@@ -13,6 +13,11 @@ import {clickAndExpectToBeVisible} from '../../../../../utils/clickAndExpectToBe
 import {waitForFDS} from '../../../../../utils/waitFor';
 import {fdsSamplePageTest} from '../../fixtures/fdsSamplePageTest';
 
+// The Title filter is backed by an API, which the selection filter pages ten
+// items at a time.
+
+const SELECTION_FILTER_PAGE_SIZE = 10;
+
 const test = mergeTests(
 	apiHelpersTest,
 	fdsSamplePageTest,
@@ -701,6 +706,72 @@ test(
 					name: 'Red',
 				})
 			).not.toBeChecked();
+		});
+	}
+);
+
+test(
+	'Selection filter keeps a single scrolling area and a visible action button',
+	{
+		tag: ['@LPD-97504'],
+	},
+	async ({fdsSamplePage, page}) => {
+		const openFilterMenu = page.locator(
+			'.dropdown-menu.show:has(.data-set-filter)'
+		);
+
+		await test.step('Open the Title filter', async () => {
+			await fdsSamplePage.managementToolbar.filterButton.click();
+
+			await fdsSamplePage.filterMenu
+				.getByRole('menuitem', {name: 'Title'})
+				.click();
+
+			await expect(
+				openFilterMenu.getByRole('checkbox', {
+					exact: true,
+					name: 'Sample1',
+				})
+			).toBeVisible();
+		});
+
+		await test.step('Select every item of the first page, which used to overflow the dropdown', async () => {
+			for (let index = 1; index <= SELECTION_FILTER_PAGE_SIZE; index++) {
+				const checkbox = openFilterMenu.getByRole('checkbox', {
+					exact: true,
+					name: `Sample${index}`,
+				});
+
+				await checkbox.scrollIntoViewIfNeeded();
+
+				await checkbox.check();
+			}
+
+			await expect(
+				openFilterMenu.locator('.label-dismissible')
+			).toHaveCount(SELECTION_FILTER_PAGE_SIZE);
+		});
+
+		await test.step('Check the item list is the only scrolling area', async () => {
+			expect(
+				await openFilterMenu.evaluate((menu: HTMLElement) =>
+					[menu, ...menu.querySelectorAll<HTMLElement>('*')]
+						.filter(
+							(element) =>
+								['auto', 'scroll'].includes(
+									getComputedStyle(element).overflowY
+								) &&
+								element.scrollHeight > element.clientHeight + 1
+						)
+						.map((element) => element.className)
+				)
+			).toEqual(['filter-body']);
+		});
+
+		await test.step('Check the Add Filter button is visible', async () => {
+			await expect(
+				openFilterMenu.getByRole('button', {name: 'Add Filter'})
+			).toBeInViewport();
 		});
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97504

## What Is Being Fixed

The Filter dropdown of a Frontend Data Set showed two scrollbars at once and hid its action button. The selection filter panel had two independent scrolling areas: the dropdown menu, capped at 500px, and the item list, capped at 200px. Selected items stacked above the list without any bound, so once around ten of them were selected the panel measured 563px inside the 500px menu. The menu then started scrolling as well, and the action button, being the last child, was pushed below the fold where it could no longer be reached.

## How It Is Being Fixed

The panel is now a flex column that always fits the menu. The search input stays pinned at the top and the action button at the bottom, while everything between them lives in a single scrolling region that absorbs whatever space is left, so the button stays reachable no matter how many items are selected. The infinite scroll observer follows that region.

The layout is scoped to panels that render an item list, which leaves the date range and client extension filters exactly as they were, since their inline date picker has to overflow the menu.

The class that carries the layout is applied through `menuElementAttrs` rather than `className`, because `className` lands on the container of the trigger and the menu is rendered in a portal outside of it. For the same reason the styles live outside the `.fds` block, where the rules they replace never matched. The active filter pills open the same panel, so they carry the class too.

A second commit deletes the Exclude toggle sizing rule that the portal made unreachable. Measuring the toggle with and without it gives identical dimensions, because Clay's own defaults already produce the 24px bar the rule asked for.

## UI

https://github.com/user-attachments/assets/0e2aac4e-3c37-4925-8e6d-71bc4635caff

## PR Check

**pr-check: PASS** — tested on `22785425f81ef2cbbbc8f1c44f304d9779e1d2e4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

Baseline's only finding is an `EXCESSIVE VERSION INCREASE` on `com.liferay.headless.cms.resource.v1_0` (3.1.0 against a released 3.0.0). It is pre-existing and outside this branch's diff: it reproduces on plain `master`, and no headless file is touched here.

<!-- pr-check {"result": "success", "sha": "22785425f81ef2cbbbc8f1c44f304d9779e1d2e4"} -->
