### PR TITLE
LPD-103098 Fix document item selector search on staging sites

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -473,11 +473,11 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 		if (_isEverywhereScopeFilter()) {
 			return SiteConnectedGroupGroupProviderUtil.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
-					_themeDisplay.getScopeGroupId());
+					_getStagingAwareGroupId());
 		}
 
 		return PortalUtil.getCurrentAndAncestorSiteGroupIds(
-			_themeDisplay.getScopeGroupId());
+			_getStagingAwareGroupId());
 	}
 
 	private Hits _getHits() throws PortalException {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103098

## What Is Being Fixed

When a site has Local Staging enabled and Documents and Media is not one of the staged asset types, browsing for a document from any Document Library item selector opened while editing content in CKEditor (for example, the Insert Image button) returns no results on the first attempt. The search silently filters by the staging group ID instead of the live group ID, and since Documents and Media is not staged, no file entries are indexed under that group. Reselecting the same site in the item selector's "Sites and Libraries" dropdown happens to switch the scope to the live group, which is why the identical search then finds the document.

## How It Is Being Fixed

`DLItemSelectorViewDisplayContext` already has a `_getStagingAwareGroupId()` helper that correctly resolves a staging group ID to its live equivalent when the portlet in question is not staged, and it is used by `_getRepository()` and `_getHits()`. However, `_getGroupIds()`, which builds the actual search filter (`searchContext.setGroupIds(...)`), used the raw `_themeDisplay.getScopeGroupId()` directly instead of that helper. This change makes `_getGroupIds()` reuse `_getStagingAwareGroupId()`, matching the pattern already used elsewhere in the same class and mirroring the equivalent, already-correct implementation in `JournalArticleItemSelectorViewDisplayContext` for the Web Content item selector.

## PR Check

**pr-check: PASS** — tested on `e4de79e96dcc8478da732142760bcea538e0d945`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e4de79e96dcc8478da732142760bcea538e0d945"} -->
