### PR TITLE
LPD-96941 Map remaining CKEditor 5 colors to Clay variables

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
@@ -104,7 +104,11 @@
 	--ck-color-panel-background: var(--ck-color-base-background);
 	--ck-color-panel-border: var(--ck-color-base-border);
 
-	--ck-color-toolbar-background: var(--ck-color-base-background);
+	--ck-color-table-caption-highlighted-background: #{$yellow};
+	--ck-color-table-focused-cell-background: #{unquote(
+			'hsl(from #{$blue-l3} h s l / 0.3)'
+		)};
+
 	--ck-color-toolbar-border: var(--ck-color-base-border);
 
 	--ck-color-tooltip-background: var(--ck-color-base-text);
@@ -121,6 +125,38 @@
 
 	--ck-color-highlight-background: #{$yellow};
 	--ck-color-light-red: #{$pink-l4};
+
+	--ck-color-widget-hover-border: #{$yellow};
+	--ck-color-widget-blurred-border: #{$light-d2};
+
+	--ck-color-image-upload-icon: #{$white};
+	--ck-color-image-upload-icon-background: #{$green};
+	--ck-color-image-caption-highlighted-background: #{$yellow};
+
+	--ck-color-upload-placeholder-loader: #{$gray-500};
+
+	--ck-content-font-color: #{$black};
+
+	--ck-content-color-image-caption-background: #{$gray-100};
+	--ck-content-color-image-caption-text: #{$gray-900};
+	--ck-content-color-mention-background: #{unquote(
+			'hsl(from #{$pink-d3} h s l / 0.1)'
+		)};
+	--ck-content-color-mention-text: #{$pink-d3};
+	--ck-content-color-table-caption-background: #{$gray-100};
+	--ck-content-color-table-caption-text: #{$gray-900};
+
+	--ck-style-panel-button-label-background: #{$gray-200};
+
+	--ck-style-panel-button-hover-label-background: #{$gray-300};
+
+	--ck-style-panel-button-hover-border-color: #{$gray-500};
+
+	--ck-table-content-default-border-color: #{$gray-400};
+	--ck-table-layout-default-border-color: #{$gray-400};
+	--ck-table-selected-cell-background: #{unquote(
+			'hsl(from #{$blue-l3} h s l / 0.3)'
+		)};
 }
 
 .lfr-ck {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96941

## What Is Being Fixed

CKEditor 5's stylesheet ships its own hardcoded color palette. An earlier pass mapped the editor chrome — base colors, buttons, panels, tooltips — onto Clay variables, but a number of custom properties were left on CKEditor's defaults: the table and table-layout borders, the selected and focused cell backgrounds, the widget hover and blurred borders, the image upload icon and placeholder loader, the style panel button labels, and the content-area colors for mentions and for image and table captions. Because those values are literal colors rather than Clay tokens, they do not follow the active color scheme, so they stay light when the surrounding page switches to dark mode or dark-high-contrast.

## How It Is Being Fixed

The remaining custom properties are declared alongside the existing ones and pointed at the corresponding Clay variables, so each resolves to a `var(--…)` reference that tracks whatever scheme is active. The translucent values — the focused and selected cell backgrounds and the mention background — are built with `hsl(from …)` so the alpha applies to the Clay color rather than to a fixed hex, and each is wrapped in `unquote()` so Sass emits the relative-color function untouched instead of evaluating it.

The `--ck-color-toolbar-background` override is dropped deliberately, letting the toolbar take CKEditor's own default rather than pinning it to `--ck-color-base-background`.

## Why Are There No Tests?

The change is a token substitution in a single SCSS file with no behavior change. Correctness is verified by the compiled CSS output, which pr-check confirmed resolves every variable with no unresolved Sass tokens.

## PR Check

**pr-check: PASS** — tested on `c1b42d9d76f622032bf9fd7094c9f39ad112e263`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "c1b42d9d76f622032bf9fd7094c9f39ad112e263"} -->
