### PR TITLE
LPD-103445 Resolve the Yarn script directory for the Windows Node layout

### DIFF
--- a/modules/frontend-sdk/node-scripts/util/locations.mjs
+++ b/modules/frontend-sdk/node-scripts/util/locations.mjs
@@ -40,14 +40,7 @@ export const TSC_DIR = path.resolve(MODULES_DIR, '.tsc');
 export const TSC_BUILDINFO_DIR = path.resolve(TSC_DIR, 'buildinfo');
 export const TSC_TYPES_DIR = path.resolve(TSC_DIR, 'types');
 
-export const YARN_SCRIPT_DIR = path.resolve(
-	PORTAL_DIR,
-	'build',
-	'node',
-	'lib',
-	'node_modules',
-	'yarn'
-);
+export const YARN_SCRIPT_DIR = resolveYarnScriptDir();
 
 //
 // Files
@@ -120,3 +113,22 @@ export const WORK_IMPORT_PATH = path.join(WORK_PATH, 'import');
 //
 
 export const BUNDLE_REPORTS_PATH = path.join('build', 'bundle-reports');
+
+//
+// Helpers
+//
+
+function resolveYarnScriptDir() {
+	const nodeDir = path.resolve(PORTAL_DIR, 'build', 'node');
+
+	// Node's Windows distribution installs global packages directly inside
+	// `node_modules`, whereas the other distributions use `lib/node_modules`.
+
+	const nodeModulesDir = path.resolve(nodeDir, 'node_modules');
+
+	if (fs.existsSync(nodeModulesDir)) {
+		return path.join(nodeModulesDir, 'yarn');
+	}
+
+	return path.resolve(nodeDir, 'lib', 'node_modules', 'yarn');
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103445

## What Is Being Fixed

`YARN_SCRIPT_DIR` in `modules/frontend-sdk/node-scripts/util/locations.mjs` hard-coded the POSIX layout of the downloaded Node distribution, `build/node/lib/node_modules/yarn`. Node's Windows distribution has no `lib` directory — it installs global packages directly under `build/node/node_modules/yarn` — so on Windows that path never exists.

The constant is consumed one line below by `YARN_SCRIPT_FILE`, which calls `fs.readdirSync` on it at module scope. Because the throw happens while the module is being imported, every `node-scripts` command failed on Windows regardless of whether it used Yarn, including `node-scripts setup` and `node-scripts format`.

`node-scripts setup` is the `install` script of `@liferay/node-scripts`, so `:portalYarnInstall` only reaches it when Yarn relinks that package at the `[4/4] Building fresh packages` step. Steady-state installs report "Already up-to-date" and skip the hook, which is why `ant all` failed intermittently — after `modules/node_modules` was wiped, or after a change to `yarn.lock` — rather than on every build. Diagnosis is slowed further by the Ant target capturing the Gradle output into a property, so the reported failure is a bare non-zero exit value with Yarn's actual error nowhere in the log.

## How It Is Being Fixed

The constant is now resolved at runtime with the same fallback the Gradle node plugin already applies in `NodePluginUtil.getYarnDir`: prefer `build/node/node_modules/yarn` when `build/node/node_modules` exists, and fall back to `build/node/lib/node_modules/yarn` otherwise. Keeping the two in agreement means the JavaScript side and the Gradle side locate the same Yarn script on every platform, and no caller has to know which distribution layout is on disk.

## Why Are There No Tests?

This is build tooling whose only consumer is the build itself, so the verification is the build: `:portalYarnInstall` now completes the `node-scripts setup` hook on Windows, which is the exact step that failed.

## PR Check

**pr-check: PASS** — tested on `be6f4a6f07979797b355407799f2ceed3df2033f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Baseline matched (its trigger is unconditional) but was trimmed: the diff is one `.mjs` file in a directory that is not an OSGi bundle, so there is no exported package for bnd to baseline.

<!-- pr-check {"result": "success", "sha": "be6f4a6f07979797b355407799f2ceed3df2033f"} -->
