### PR TITLE
LPD-101365 Fix invalid box-shadow and background-size CSS output

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -415,6 +415,10 @@ $btn-ai: () !default;
 $btn-ai: map-deep-merge(
 	(
 		box-shadow: c-unset,
+
+		focus: (
+			box-shadow: c-unset,
+		),
 	),
 	$btn-ai
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_form-validation.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_form-validation.scss
@@ -69,13 +69,17 @@
 	.was-validated .form-control.is-valid {
 		background-color: $input-success-bg;
 		border-color: $input-success-border-color;
-		box-shadow: $input-success-box-shadow;
+
+		@include box-shadow($input-success-box-shadow);
+
 		color: $input-success-color;
 
 		&:focus {
 			background-color: $input-success-focus-bg;
 			border-color: $input-success-focus-border-color;
-			box-shadow: $input-success-focus-box-shadow;
+
+			@include box-shadow($input-success-focus-box-shadow);
+
 			color: $input-success-focus-color;
 		}
 	}
@@ -84,13 +88,17 @@
 	.was-validated .form-control.is-invalid {
 		background-color: $input-danger-bg;
 		border-color: $input-danger-border-color;
-		box-shadow: $input-danger-box-shadow;
+
+		@include box-shadow($input-danger-box-shadow);
+
 		color: $input-danger-color;
 
 		&:focus {
 			background-color: $input-danger-focus-bg;
 			border-color: $input-danger-focus-border-color;
-			box-shadow: $input-danger-focus-box-shadow;
+
+			@include box-shadow($input-danger-focus-box-shadow);
+
 			color: $input-danger-focus-color;
 		}
 	}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_forms.scss
@@ -335,10 +335,10 @@ textarea.form-control-plaintext,
 	padding: 0;
 
 	&:focus {
-		box-shadow: none;
+		@include box-shadow(none);
 
 		&::-webkit-slider-thumb {
-			box-shadow: $input-focus-box-shadow;
+			@include box-shadow($input-focus-box-shadow);
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_multi-step-nav.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_multi-step-nav.scss
@@ -191,7 +191,7 @@
 				&.focus,
 				#{$focus-visible-selector},
 				.c-prefers-focus &:focus {
-					box-shadow: $multi-step-icon-disabled-focus-box-shadow;
+					@include box-shadow($multi-step-icon-disabled-focus-box-shadow);
 				}
 			}
 		}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_multi-step-nav.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_multi-step-nav.scss
@@ -191,7 +191,9 @@
 				&.focus,
 				#{$focus-visible-selector},
 				.c-prefers-focus &:focus {
-					@include box-shadow($multi-step-icon-disabled-focus-box-shadow);
+					@include box-shadow(
+						$multi-step-icon-disabled-focus-box-shadow
+					);
 				}
 			}
 		}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/functions/_global-functions.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/functions/_global-functions.scss
@@ -303,13 +303,10 @@
 }
 
 /// A function that returns a shadow for use with the `box-shadow` property. This function returns `null` if `$enable-shadows` is set to `false`. This is a workaround for complying with Bootstrap's `$enable-shadows` setting.
-/// @param {List} $shadows - The box shadow. Pass in a single shadow or two shadows using `[$shadow1, $shadow2]` if you need a default shadow even if `$enable-shadows` is `false`. A focus shadow for example.
+/// @param {List} $shadows - The box shadow. Pass a single shadow, or a comma separated list of shadows. Shadows set to `c-unset`, `clay-unset`, `null`, or an empty list are dropped. Wrap the value in brackets, `[$shadow]`, to force it to be treated as a single shadow.
 
 @function clay-enable-shadows($shadows, $enable: null) {
 	$ret-val: null;
-
-	$length: length($shadows);
-	$separator: list-separator($shadows);
 
 	$enable: if(
 		variable-exists(enable-shadows),
@@ -317,15 +314,38 @@
 		if(variable-exists(cadmin-enable-shadows), $cadmin-enable-shadows, true)
 	);
 
-	@if ($length == 2 and $separator == 'comma') {
-		@if ($enable) {
-			$ret-val: nth($shadows, 1);
-		} @else {
-			$ret-val: nth($shadows, 2);
+	@if ($enable) {
+		// Unwrap `[$shadow]` so the brackets don't reach the generated CSS
+
+		@if (type-of($shadows) == 'list') and is-bracketed($shadows) {
+			$shadows: join((), $shadows, list-separator($shadows), false);
 		}
-	} @else if ($separator == 'space') {
-		@if ($enable) {
-			$ret-val: $shadows;
+
+		// A space separated list is a single shadow, not a list of shadows.
+		// Only a comma separated list may be iterated, otherwise the parts of
+		// the shadow get rejoined with commas.
+
+		$list: if(
+			(type-of($shadows) == 'list') and
+				(list-separator($shadows) == 'comma'),
+			$shadows,
+			append((), $shadows, comma)
+		);
+
+		$s: ();
+
+		@each $value in $list {
+			@if (
+				(not clay-is-map-unset($value)) and
+					($value != null) and
+					($value != ())
+			) {
+				$s: append($s, $value, comma);
+			}
+		}
+
+		@if (length($s) > 0) {
+			$ret-val: $s;
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_box-shadow.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_box-shadow.scss
@@ -2,7 +2,9 @@
 /// @group utilities
 ////
 
-/// A mixin that overwrites Bootstrap 4's `box-shadow` mixin.
+/// A mixin that overwrites Bootstrap 4's `box-shadow` mixin. Shadows set to
+/// `c-unset`, `clay-unset`, `null`, or an empty list are dropped from the
+/// arglist. The remaining shadows are joined into a comma separated list.
 /// @param {Arglist} $shadow
 
 @mixin box-shadow($shadow...) {
@@ -13,15 +15,20 @@
 	);
 
 	@if ($enable) {
-		@if (
-			nth($shadow, 1) !=
-				null and
-				nth($shadow, 1) !=
-				() and
-				length($shadow) <=
-				1
-		) {
-			box-shadow: $shadow;
+		$shadows: ();
+
+		@each $value in $shadow {
+			@if (
+				(not clay-is-map-unset($value)) and
+					($value != null) and
+					($value != ())
+			) {
+				$shadows: append($shadows, $value, comma);
+			}
+		}
+
+		@if (length($shadows) > 0) {
+			box-shadow: $shadows;
 		}
 	}
 }

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss
@@ -960,6 +960,11 @@
 			$_aspect-ratio: map-get($map, aspect-ratio);
 
 			@if ($_aspect-ratio) {
+				$_aspect-ratio: map-remove(
+					$_aspect-ratio,
+					'checkered-foreground-color'
+				);
+
 				.aspect-ratio {
 					@include clay-aspect-ratio-variant($_aspect-ratio);
 
@@ -1662,6 +1667,8 @@
 		checkered-foreground-color
 	);
 
+	$aspect-ratio: map-remove($aspect-ratio, 'checkered-foreground-color');
+
 	$asset-icon: setter(map-get($map, asset-icon), ());
 	$asset-icon: map-merge(
 		$asset-icon,
@@ -1710,6 +1717,7 @@
 		$map,
 		'aspect-ratio-bg',
 		'aspect-ratio-checkered-bg',
+		'aspect-ratio-checkered-fg',
 		'asset-icon-color',
 		'asset-icon-lexicon-icon-height',
 		'asset-icon-lexicon-icon-width',

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_forms.scss
@@ -90,8 +90,7 @@
 				background-image: escape-svg($icon);
 				background-position: right $input-height-inner-quarter center;
 				background-repeat: no-repeat;
-				background-size: $input-height-inner-half
-					$input-height-inner-half;
+				background-size: $input-height-inner-half;
 				padding-right: $input-height-inner;
 			}
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_buttons.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_buttons.scss
@@ -1,8 +1,8 @@
 $btn-border-radius: $border-radius !default;
 $btn-border-width: $input-btn-border-width !default;
 $btn-box-shadow:
-	#{inset 0 1px 0 rgba($white, 0.15),
-	0 1px 1px rgba($black, 0.075)} !default;
+	inset 0 1px 0 rgba($white, 0.15),
+	0 1px 1px rgba($black, 0.075) !default;
 $btn-cursor: $link-cursor !default;
 $btn-font-family: $input-btn-font-family !default;
 $btn-font-size: $input-btn-font-size !default;
@@ -497,11 +497,11 @@ $btn-primary: map-deep-merge(
 			border-color: clay-darken($primary, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					#{$btn-box-shadow,
+					($btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($primary), $primary, 15%), 0.5)},
+						rgba(clay-mix(color-yiq($primary), $primary, 15%), 0.5),
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($primary), $primary, 15%), 0.5)
+						rgba(clay-mix(color-yiq($primary), $primary, 15%), 0.5))
 				),
 			color: color-yiq(clay-darken($primary, 7.5%)),
 		),
@@ -514,17 +514,17 @@ $btn-primary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
+						($btn-active-box-shadow,
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($primary), $primary, 15%),
 								0.5
-							)},
+							),
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($primary), $primary, 15%),
 								0.5
-							)
+							))
 					),
 			),
 		),
@@ -562,17 +562,17 @@ $btn-secondary: map-deep-merge(
 			border-color: clay-darken($secondary, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					#{$btn-box-shadow,
+					($btn-box-shadow,
 					0 0 0 $btn-focus-width
 						rgba(
 							clay-mix(color-yiq($secondary), $secondary, 15%),
 							0.5
-						)},
+						),
 					0 0 0 $btn-focus-width
 						rgba(
 							clay-mix(color-yiq($secondary), $secondary, 15%),
 							0.5
-						)
+						))
 				),
 			color: color-yiq(clay-darken($secondary, 7.5%)),
 		),
@@ -585,7 +585,7 @@ $btn-secondary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
+						($btn-active-box-shadow,
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(
@@ -594,7 +594,7 @@ $btn-secondary: map-deep-merge(
 									15%
 								),
 								0.5
-							)},
+							),
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(
@@ -603,7 +603,7 @@ $btn-secondary: map-deep-merge(
 									15%
 								),
 								0.5
-							)
+							))
 					),
 			),
 		),
@@ -639,11 +639,11 @@ $btn-success: map-deep-merge(
 			border-color: clay-darken($success, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					#{$btn-box-shadow,
+					($btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($success), $success, 15%), 0.5)},
+						rgba(clay-mix(color-yiq($success), $success, 15%), 0.5),
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($success), $success, 15%), 0.5)
+						rgba(clay-mix(color-yiq($success), $success, 15%), 0.5))
 				),
 			color: color-yiq(clay-darken($success, 7.5%)),
 		),
@@ -656,17 +656,17 @@ $btn-success: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
+						($btn-active-box-shadow,
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($success), $success, 15%),
 								0.5
-							)},
+							),
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($success), $success, 15%),
 								0.5
-							)
+							))
 					),
 			),
 		),
@@ -702,11 +702,11 @@ $btn-info: map-deep-merge(
 			border-color: clay-darken($info, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					#{$btn-box-shadow,
+					($btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)},
+						rgba(clay-mix(color-yiq($info), $info, 15%), 0.5),
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)
+						rgba(clay-mix(color-yiq($info), $info, 15%), 0.5))
 				),
 			color: color-yiq(clay-darken($info, 7.5%)),
 		),
@@ -719,11 +719,11 @@ $btn-info: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
+						($btn-active-box-shadow,
 						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)},
+							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5),
 						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)
+							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5))
 					),
 			),
 		),
@@ -759,11 +759,11 @@ $btn-warning: map-deep-merge(
 			border-color: clay-darken($warning, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					#{$btn-box-shadow,
+					($btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($warning), $warning, 15%), 0.5)},
+						rgba(clay-mix(color-yiq($warning), $warning, 15%), 0.5),
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($warning), $warning, 15%), 0.5)
+						rgba(clay-mix(color-yiq($warning), $warning, 15%), 0.5))
 				),
 			color: color-yiq(clay-darken($warning, 7.5%)),
 		),
@@ -776,17 +776,17 @@ $btn-warning: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
+						($btn-active-box-shadow,
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($warning), $warning, 15%),
 								0.5
-							)},
+							),
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($warning), $warning, 15%),
 								0.5
-							)
+							))
 					),
 			),
 		),
@@ -822,11 +822,11 @@ $btn-danger: map-deep-merge(
 			border-color: clay-darken($danger, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					#{$btn-box-shadow,
+					($btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5)},
+						rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5),
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5)
+						rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5))
 				),
 			color: color-yiq(clay-darken($danger, 7.5%)),
 		),
@@ -839,17 +839,17 @@ $btn-danger: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
+						($btn-active-box-shadow,
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($danger), $danger, 15%),
 								0.5
-							)},
+							),
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($danger), $danger, 15%),
 								0.5
-							)
+							))
 					),
 			),
 		),
@@ -885,11 +885,11 @@ $btn-light: map-deep-merge(
 			border-color: clay-darken($light, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					#{$btn-box-shadow,
+					($btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)},
+						rgba(clay-mix(color-yiq($light), $light, 15%), 0.5),
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)
+						rgba(clay-mix(color-yiq($light), $light, 15%), 0.5))
 				),
 			color: color-yiq(clay-darken($light, 7.5%)),
 		),
@@ -902,11 +902,11 @@ $btn-light: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
+						($btn-active-box-shadow,
 						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)},
+							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5),
 						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)
+							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5))
 					),
 			),
 		),
@@ -942,11 +942,11 @@ $btn-dark: map-deep-merge(
 			border-color: clay-darken($dark, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					#{$btn-box-shadow,
+					($btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)},
+						rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5),
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)
+						rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5))
 				),
 			color: color-yiq(clay-darken($dark, 7.5%)),
 		),
@@ -959,11 +959,11 @@ $btn-dark: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
+						($btn-active-box-shadow,
 						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)},
+							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5),
 						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)
+							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5))
 					),
 			),
 		),
@@ -1024,9 +1024,9 @@ $btn-ai: map-deep-merge(
 		focus: (
 			box-shadow:
 				clay-enable-shadows(
-					#{$btn-box-shadow,
-					0 0 0 $btn-focus-width rgba($primary-l0, 0.5)},
-					0 0 0 $btn-focus-width rgba($primary-l0, 0.5)
+					($btn-box-shadow,
+					0 0 0 $btn-focus-width rgba($primary-l0, 0.5),
+					0 0 0 $btn-focus-width rgba($primary-l0, 0.5))
 				),
 		),
 
@@ -1037,9 +1037,9 @@ $btn-ai: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($primary-l0, 0.5)},
-						0 0 0 $btn-focus-width rgba($primary-l0, 0.5)
+						($btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($primary-l0, 0.5),
+						0 0 0 $btn-focus-width rgba($primary-l0, 0.5))
 					),
 			),
 		),
@@ -1456,9 +1456,9 @@ $btn-outline-primary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($primary, 0.5)},
-						$c-unset
+						($btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($primary, 0.5),
+						$c-unset)
 					),
 			),
 		),
@@ -1494,9 +1494,9 @@ $btn-outline-secondary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($secondary, 0.5)},
-						0 0 0 $btn-focus-width rgba($secondary, 0.5)
+						($btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($secondary, 0.5),
+						0 0 0 $btn-focus-width rgba($secondary, 0.5))
 					),
 			),
 		),
@@ -1532,9 +1532,9 @@ $btn-outline-success: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($success, 0.5)},
-						0 0 0 $btn-focus-width rgba($success, 0.5)
+						($btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($success, 0.5),
+						0 0 0 $btn-focus-width rgba($success, 0.5))
 					),
 			),
 		),
@@ -1570,9 +1570,9 @@ $btn-outline-info: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($info, 0.5)},
-						0 0 0 $btn-focus-width rgba($info, 0.5)
+						($btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($info, 0.5),
+						0 0 0 $btn-focus-width rgba($info, 0.5))
 					),
 			),
 		),
@@ -1608,9 +1608,9 @@ $btn-outline-warning: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($warning, 0.5)},
-						0 0 0 $btn-focus-width rgba($warning, 0.5)
+						($btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($warning, 0.5),
+						0 0 0 $btn-focus-width rgba($warning, 0.5))
 					),
 			),
 		),
@@ -1646,9 +1646,9 @@ $btn-outline-danger: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($danger, 0.5)},
-						0 0 0 $btn-focus-width rgba($danger, 0.5)
+						($btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($danger, 0.5),
+						0 0 0 $btn-focus-width rgba($danger, 0.5))
 					),
 			),
 		),
@@ -1684,9 +1684,9 @@ $btn-outline-light: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($light, 0.5)},
-						0 0 0 $btn-focus-width rgba($light, 0.5)
+						($btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($light, 0.5),
+						0 0 0 $btn-focus-width rgba($light, 0.5))
 					),
 			),
 		),
@@ -1722,9 +1722,9 @@ $btn-outline-dark: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($dark, 0.5)},
-						0 0 0 $btn-focus-width rgba($dark, 0.5)
+						($btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($dark, 0.5),
+						0 0 0 $btn-focus-width rgba($dark, 0.5))
 					),
 			),
 		),
@@ -1784,9 +1784,9 @@ $btn-outline-ai: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						#{$btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($primary, 0.5)},
-						$c-unset
+						($btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($primary, 0.5),
+						$c-unset)
 					),
 			),
 		),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_buttons.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_buttons.scss
@@ -497,11 +497,19 @@ $btn-primary: map-deep-merge(
 			border-color: clay-darken($primary, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					($btn-box-shadow,
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($primary), $primary, 15%), 0.5),
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($primary), $primary, 15%), 0.5))
+					(
+						$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($primary), $primary, 15%),
+								0.5
+							),
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($primary), $primary, 15%),
+								0.5
+							)
+					)
 				),
 			color: color-yiq(clay-darken($primary, 7.5%)),
 		),
@@ -514,17 +522,27 @@ $btn-primary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width
-							rgba(
-								clay-mix(color-yiq($primary), $primary, 15%),
-								0.5
-							),
-						0 0 0 $btn-focus-width
-							rgba(
-								clay-mix(color-yiq($primary), $primary, 15%),
-								0.5
-							))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($primary),
+										$primary,
+										15%
+									),
+									0.5
+								),
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($primary),
+										$primary,
+										15%
+									),
+									0.5
+								)
+						)
 					),
 			),
 		),
@@ -562,30 +580,8 @@ $btn-secondary: map-deep-merge(
 			border-color: clay-darken($secondary, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					($btn-box-shadow,
-					0 0 0 $btn-focus-width
-						rgba(
-							clay-mix(color-yiq($secondary), $secondary, 15%),
-							0.5
-						),
-					0 0 0 $btn-focus-width
-						rgba(
-							clay-mix(color-yiq($secondary), $secondary, 15%),
-							0.5
-						))
-				),
-			color: color-yiq(clay-darken($secondary, 7.5%)),
-		),
-
-		active: (
-			background-color: clay-darken($secondary, 10%),
-			background-image: clay-enable-gradients(none),
-			border-color: clay-darken($secondary, 12.5%),
-			color: color-yiq(clay-darken($secondary, 10%)),
-			focus: (
-				box-shadow:
-					clay-enable-shadows(
-						($btn-active-box-shadow,
+					(
+						$btn-box-shadow,
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(
@@ -603,7 +599,41 @@ $btn-secondary: map-deep-merge(
 									15%
 								),
 								0.5
-							))
+							)
+					)
+				),
+			color: color-yiq(clay-darken($secondary, 7.5%)),
+		),
+
+		active: (
+			background-color: clay-darken($secondary, 10%),
+			background-image: clay-enable-gradients(none),
+			border-color: clay-darken($secondary, 12.5%),
+			color: color-yiq(clay-darken($secondary, 10%)),
+			focus: (
+				box-shadow:
+					clay-enable-shadows(
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($secondary),
+										$secondary,
+										15%
+									),
+									0.5
+								),
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($secondary),
+										$secondary,
+										15%
+									),
+									0.5
+								)
+						)
 					),
 			),
 		),
@@ -639,11 +669,19 @@ $btn-success: map-deep-merge(
 			border-color: clay-darken($success, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					($btn-box-shadow,
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($success), $success, 15%), 0.5),
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($success), $success, 15%), 0.5))
+					(
+						$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($success), $success, 15%),
+								0.5
+							),
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($success), $success, 15%),
+								0.5
+							)
+					)
 				),
 			color: color-yiq(clay-darken($success, 7.5%)),
 		),
@@ -656,17 +694,27 @@ $btn-success: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width
-							rgba(
-								clay-mix(color-yiq($success), $success, 15%),
-								0.5
-							),
-						0 0 0 $btn-focus-width
-							rgba(
-								clay-mix(color-yiq($success), $success, 15%),
-								0.5
-							))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($success),
+										$success,
+										15%
+									),
+									0.5
+								),
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($success),
+										$success,
+										15%
+									),
+									0.5
+								)
+						)
 					),
 			),
 		),
@@ -702,11 +750,13 @@ $btn-info: map-deep-merge(
 			border-color: clay-darken($info, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					($btn-box-shadow,
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($info), $info, 15%), 0.5),
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($info), $info, 15%), 0.5))
+					(
+						$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5),
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)
+					)
 				),
 			color: color-yiq(clay-darken($info, 7.5%)),
 		),
@@ -719,11 +769,19 @@ $btn-info: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5),
-						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($info), $info, 15%),
+									0.5
+								),
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($info), $info, 15%),
+									0.5
+								)
+						)
 					),
 			),
 		),
@@ -759,11 +817,19 @@ $btn-warning: map-deep-merge(
 			border-color: clay-darken($warning, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					($btn-box-shadow,
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($warning), $warning, 15%), 0.5),
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($warning), $warning, 15%), 0.5))
+					(
+						$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($warning), $warning, 15%),
+								0.5
+							),
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($warning), $warning, 15%),
+								0.5
+							)
+					)
 				),
 			color: color-yiq(clay-darken($warning, 7.5%)),
 		),
@@ -776,17 +842,27 @@ $btn-warning: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width
-							rgba(
-								clay-mix(color-yiq($warning), $warning, 15%),
-								0.5
-							),
-						0 0 0 $btn-focus-width
-							rgba(
-								clay-mix(color-yiq($warning), $warning, 15%),
-								0.5
-							))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($warning),
+										$warning,
+										15%
+									),
+									0.5
+								),
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($warning),
+										$warning,
+										15%
+									),
+									0.5
+								)
+						)
 					),
 			),
 		),
@@ -822,11 +898,19 @@ $btn-danger: map-deep-merge(
 			border-color: clay-darken($danger, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					($btn-box-shadow,
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5),
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5))
+					(
+						$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($danger), $danger, 15%),
+								0.5
+							),
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($danger), $danger, 15%),
+								0.5
+							)
+					)
 				),
 			color: color-yiq(clay-darken($danger, 7.5%)),
 		),
@@ -839,17 +923,19 @@ $btn-danger: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width
-							rgba(
-								clay-mix(color-yiq($danger), $danger, 15%),
-								0.5
-							),
-						0 0 0 $btn-focus-width
-							rgba(
-								clay-mix(color-yiq($danger), $danger, 15%),
-								0.5
-							))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($danger), $danger, 15%),
+									0.5
+								),
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($danger), $danger, 15%),
+									0.5
+								)
+						)
 					),
 			),
 		),
@@ -885,11 +971,13 @@ $btn-light: map-deep-merge(
 			border-color: clay-darken($light, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					($btn-box-shadow,
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($light), $light, 15%), 0.5),
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($light), $light, 15%), 0.5))
+					(
+						$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5),
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)
+					)
 				),
 			color: color-yiq(clay-darken($light, 7.5%)),
 		),
@@ -902,11 +990,19 @@ $btn-light: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5),
-						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($light), $light, 15%),
+									0.5
+								),
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($light), $light, 15%),
+									0.5
+								)
+						)
 					),
 			),
 		),
@@ -942,11 +1038,13 @@ $btn-dark: map-deep-merge(
 			border-color: clay-darken($dark, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					($btn-box-shadow,
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5),
-					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5))
+					(
+						$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5),
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)
+					)
 				),
 			color: color-yiq(clay-darken($dark, 7.5%)),
 		),
@@ -959,11 +1057,19 @@ $btn-dark: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5),
-						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($dark), $dark, 15%),
+									0.5
+								),
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($dark), $dark, 15%),
+									0.5
+								)
+						)
 					),
 			),
 		),
@@ -1024,9 +1130,11 @@ $btn-ai: map-deep-merge(
 		focus: (
 			box-shadow:
 				clay-enable-shadows(
-					($btn-box-shadow,
-					0 0 0 $btn-focus-width rgba($primary-l0, 0.5),
-					0 0 0 $btn-focus-width rgba($primary-l0, 0.5))
+					(
+						$btn-box-shadow,
+						0 0 0 $btn-focus-width rgba($primary-l0, 0.5),
+						0 0 0 $btn-focus-width rgba($primary-l0, 0.5)
+					)
 				),
 		),
 
@@ -1037,9 +1145,11 @@ $btn-ai: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($primary-l0, 0.5),
-						0 0 0 $btn-focus-width rgba($primary-l0, 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($primary-l0, 0.5),
+							0 0 0 $btn-focus-width rgba($primary-l0, 0.5)
+						)
 					),
 			),
 		),
@@ -1456,9 +1566,11 @@ $btn-outline-primary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($primary, 0.5),
-						$c-unset)
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($primary, 0.5),
+							$c-unset
+						)
 					),
 			),
 		),
@@ -1494,9 +1606,11 @@ $btn-outline-secondary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($secondary, 0.5),
-						0 0 0 $btn-focus-width rgba($secondary, 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($secondary, 0.5),
+							0 0 0 $btn-focus-width rgba($secondary, 0.5)
+						)
 					),
 			),
 		),
@@ -1532,9 +1646,11 @@ $btn-outline-success: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($success, 0.5),
-						0 0 0 $btn-focus-width rgba($success, 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($success, 0.5),
+							0 0 0 $btn-focus-width rgba($success, 0.5)
+						)
 					),
 			),
 		),
@@ -1570,9 +1686,11 @@ $btn-outline-info: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($info, 0.5),
-						0 0 0 $btn-focus-width rgba($info, 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($info, 0.5),
+							0 0 0 $btn-focus-width rgba($info, 0.5)
+						)
 					),
 			),
 		),
@@ -1608,9 +1726,11 @@ $btn-outline-warning: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($warning, 0.5),
-						0 0 0 $btn-focus-width rgba($warning, 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($warning, 0.5),
+							0 0 0 $btn-focus-width rgba($warning, 0.5)
+						)
 					),
 			),
 		),
@@ -1646,9 +1766,11 @@ $btn-outline-danger: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($danger, 0.5),
-						0 0 0 $btn-focus-width rgba($danger, 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($danger, 0.5),
+							0 0 0 $btn-focus-width rgba($danger, 0.5)
+						)
 					),
 			),
 		),
@@ -1684,9 +1806,11 @@ $btn-outline-light: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($light, 0.5),
-						0 0 0 $btn-focus-width rgba($light, 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($light, 0.5),
+							0 0 0 $btn-focus-width rgba($light, 0.5)
+						)
 					),
 			),
 		),
@@ -1722,9 +1846,11 @@ $btn-outline-dark: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($dark, 0.5),
-						0 0 0 $btn-focus-width rgba($dark, 0.5))
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($dark, 0.5),
+							0 0 0 $btn-focus-width rgba($dark, 0.5)
+						)
 					),
 			),
 		),
@@ -1784,9 +1910,11 @@ $btn-outline-ai: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						($btn-active-box-shadow,
-						0 0 0 $btn-focus-width rgba($primary, 0.5),
-						$c-unset)
+						(
+							$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($primary, 0.5),
+							$c-unset
+						)
 					),
 			),
 		),

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_deprecated_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_deprecated_clay_variables.scss
@@ -685,7 +685,7 @@ $btn-link: () !default;
 $btn-link: map-deep-merge(
 	(
 		active: (
-			box-shadow: clay-enable-shadows([none]),
+			box-shadow: clay-enable-shadows(none),
 		),
 
 		border-radius: 1px,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101365

## What Is Being Fixed

Classic theme's compiled `clay.css` contained declarations that no browser accepts: `box-shadow: [none]`, `box-shadow: c-unset`, and a `background-size` with four values instead of two.

All three trace back to `clay-enable-shadows()` and the `box-shadow` mixin being unable to handle the shapes callers actually pass them. `clay-enable-shadows()` recognized only two forms — a two-element comma list, where it returned the first shadow when shadows were enabled and the second when they were not, and a space-separated list treated as one shadow. Anything else, such as three shadows or a list holding a `c-unset` sentinel, fell through and returned the input unfiltered. The `box-shadow` mixin had the mirror problem: its `length($shadow) <= 1` guard silently dropped every multi-shadow arglist.

Call sites worked around this with `#{...}` string interpolation to glue shadow lists together. That is what let the invalid output through: interpolation collapses the value into an unquoted string before either helper sees it, so the `c-unset` and `null` checks never fired and the sentinels reached the stylesheet as literal text. Bracket wrapping, `[none]`, was the other workaround, and its brackets leaked into the output the same way.

## How It Is Being Fixed

Both helpers now filter values instead of pattern-matching list shapes. `clay-enable-shadows()` accepts a comma-separated list of any length, unwraps a bracketed `[$shadow]` so brackets never reach the CSS, drops any entry that is `c-unset`, `clay-unset`, `null`, or an empty list, and returns `null` when nothing survives. A space-separated list is still treated as a single shadow rather than iterated, so the parts of one shadow are not rejoined with commas. The `box-shadow` mixin applies the same filter to its arglist and joins the survivors into a comma-separated list, so a multi-shadow call is no longer discarded.

With the helpers doing the filtering, the workarounds at the call sites come out. The `#{}` interpolation is removed from `$btn-box-shadow` and from every `clay-enable-shadows()` call in `variables/_buttons.scss`, and the raw `box-shadow:` declarations in `components/_forms.scss`, `components/_form-validation.scss`, and `components/_multi-step-nav.scss` are switched to `@include box-shadow(...)` so their values pass through the filter too. Classic theme's `clay-enable-shadows([none])` becomes `clay-enable-shadows(none)`. `$btn-ai` gains an explicit `focus: (box-shadow: c-unset)` so the AI button no longer inherits a default focus shadow it is not meant to have.

The four-value `background-size` is a separate slip in the same area: `clay-form-validation-icon-variant()` passed `$input-height-inner-half` twice, but that variable is already a two-value pair (`18px 18px`), so the shorthand received four values. It now passes it once.

Finally, `checkered-foreground-color` was being forwarded into `clay-aspect-ratio-variant()`, which has no such property and printed it verbatim. It is now stripped with `map-remove` before the variant is called, and `aspect-ratio-checkered-fg` is registered among the deprecated card keys.

## Why Are There No Tests?

`clay-css` has no unit test infrastructure — it is SCSS compiled by a build script, with no Jest config or test directory, so there is no layer at which to assert on the generated declarations. Correctness of the compiled output was verified instead through the `pr-check` theme builds: `clay-css`, `frontend-theme-classic`, `-admin`, `-cms`, and `-dialect` all compile cleanly against the rewritten helpers.

## PR Check

**pr-check: PASS** — tested on `39f894eb7e8e1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| Theme Build | PASS |

<!-- pr-check {"result": "success", "sha": "39f894eb7e8e1dad5648420b9ba547dc27eb3cea"} -->
