### PR TITLE
LPD-103049 Allow hiding the Exclude toggle in FDS selection filters

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FDSSampleFDSNames.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FDSSampleFDSNames.java
@@ -28,6 +28,9 @@ public class FDSSampleFDSNames {
 	public static final String EMPTY =
 		FDSSamplePortletKeys.FDS_SAMPLE + "-empty";
 
+	public static final String HIDDEN_EXCLUDE_TOGGLE =
+		FDSSamplePortletKeys.FDS_SAMPLE + "-hiddenExcludeToggle";
+
 	public static final String MINIMUM =
 		FDSSamplePortletKeys.FDS_SAMPLE + "-minimum";
 

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/ColorSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/ColorSelectionFDSFilter.java
@@ -22,7 +22,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Marko Cikos
  */
 @Component(
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.ADVANCED,
+	property = {
+		"frontend.data.set.name=" + FDSSampleFDSNames.ADVANCED,
+		"frontend.data.set.name=" + FDSSampleFDSNames.HIDDEN_EXCLUDE_TOGGLE
+	},
 	service = FDSFilter.class
 )
 public class ColorSelectionFDSFilter extends BaseSelectionFDSFilter {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/HiddenExcludeToggleTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/HiddenExcludeToggleTableFDSView.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.view;
+
+import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames;
+import com.liferay.frontend.data.set.view.FDSView;
+import com.liferay.frontend.data.set.view.table.BaseTableFDSView;
+import com.liferay.frontend.data.set.view.table.FDSTableSchema;
+import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilder;
+import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Miguel Arroyo
+ */
+@Component(
+	enabled = true,
+	property = "frontend.data.set.name=" + FDSSampleFDSNames.HIDDEN_EXCLUDE_TOGGLE,
+	service = FDSView.class
+)
+public class HiddenExcludeToggleTableFDSView extends BaseTableFDSView {
+
+	@Override
+	public FDSTableSchema getFDSTableSchema(Locale locale) {
+		FDSTableSchemaBuilder fdsTableSchemaBuilder =
+			_fdsTableSchemaBuilderFactory.create();
+
+		return fdsTableSchemaBuilder.add(
+			"id", "id"
+		).add(
+			"title", "title"
+		).add(
+			"color", "color"
+		).add(
+			"size", "size"
+		).build();
+	}
+
+	@Reference
+	private FDSTableSchemaBuilderFactory _fdsTableSchemaBuilderFactory;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/HiddenExcludeTogglePropsTransformer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/HiddenExcludeTogglePropsTransformer.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import type {ISelectionFilterState} from '@liferay/frontend-data-set-web';
+
+export default function propsTransformer({filters, ...otherProps}: any) {
+	return {
+		...otherProps,
+		filters: filters.map((filter: ISelectionFilterState) => {
+			if (filter.id !== 'color') {
+				return filter;
+			}
+
+			return {
+				...filter,
+				preloadedData: {
+					exclude: true,
+					selectedItems: [{label: 'Blue', value: 'Blue'}],
+				},
+				showExcludeToggle: false,
+			};
+		}),
+	};
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/index.ts
@@ -10,6 +10,7 @@ import CustomAuthorTableCell from './CustomAuthorTableCell';
 import CustomInternalViewPropsTransformer from './CustomInternalViewPropsTransformer';
 import EmptyPropsTransformer from './EmptyPropsTransformer';
 import GreenCheckColorTableCell from './GreenCheckColorTableCell';
+import HiddenExcludeTogglePropsTransformer from './HiddenExcludeTogglePropsTransformer';
 import ReactFrontendDataSet from './ReactFrontendDataSet';
 import SingleSelectionPropsTransformer from './SingleSelectionPropsTransformer';
 import AdvancedFilters from './fragments/AdvancedFilters';
@@ -27,6 +28,7 @@ export {
 	CustomInternalViewPropsTransformer,
 	EmptyPropsTransformer,
 	GreenCheckColorTableCell,
+	HiddenExcludeTogglePropsTransformer,
 	ReactFrontendDataSet,
 	SingleSelectionPropsTransformer,
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/hidden_exclude_toggle.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/hidden_exclude_toggle.jsp
@@ -1,0 +1,19 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+FDSSampleDisplayContext fdsSampleDisplayContext = (FDSSampleDisplayContext)request.getAttribute(FDSSampleWebKeys.FDS_SAMPLE_DISPLAY_CONTEXT);
+%>
+
+<frontend-data-set:headless-display
+	apiURL="<%= fdsSampleDisplayContext.getAPIURL() %>"
+	id="<%= FDSSampleFDSNames.HIDDEN_EXCLUDE_TOGGLE %>"
+	propsTransformer="{HiddenExcludeTogglePropsTransformer} from frontend-data-set-sample-web"
+	style="fluid"
+/>

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -60,6 +60,12 @@ String navigation = ParamUtil.getString(request, "navigation", "advanced");
 						});
 					add(
 						navigationItem -> {
+							navigationItem.setActive(navigation.equals("hidden-exclude-toggle"));
+							navigationItem.setHref(renderResponse.createRenderURL(), "navigation", "hidden-exclude-toggle");
+							navigationItem.setLabel("Hidden Exclude Toggle");
+						});
+					add(
+						navigationItem -> {
 							navigationItem.setActive(navigation.equals("minimum"));
 							navigationItem.setHref(renderResponse.createRenderURL(), "navigation", "minimum");
 							navigationItem.setLabel("Minimum");
@@ -99,6 +105,9 @@ String navigation = ParamUtil.getString(request, "navigation", "advanced");
 		</c:when>
 		<c:when test='<%= navigation.equals("empty") %>'>
 			<liferay-util:include page="/partials/empty.jsp" servletContext="<%= application %>" />
+		</c:when>
+		<c:when test='<%= navigation.equals("hidden-exclude-toggle") %>'>
+			<liferay-util:include page="/partials/hidden_exclude_toggle.jsp" servletContext="<%= application %>" />
 		</c:when>
 		<c:when test='<%= navigation.equals("minimum") %>'>
 			<liferay-util:include page="/partials/minimum.jsp" servletContext="<%= application %>" />

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -44,6 +44,8 @@ export interface SelectionFilterImplementationArgs
 	items: TItem[];
 	multiple: boolean;
 	onClose?: () => void;
+	preloadedData?: SelectedData;
+	showExcludeToggle?: boolean;
 }
 
 interface SelectedData {
@@ -213,8 +215,10 @@ function SelectionFilter({
 	items: initialItems,
 	multiple,
 	onClose,
+	preloadedData,
 	selectedData,
 	setFilter,
+	showExcludeToggle = true,
 }: SelectionFilterImplementationArgs) {
 	const [searchOptions, setSearchOptions] = useState({
 		currentPage: 1,
@@ -234,14 +238,18 @@ function SelectionFilter({
 	const [scrollingAreaRendered, setScrollingAreaRendered] = useState(false);
 	const infiniteLoaderRef = useRef(null);
 	const [infiniteLoaderRendered, setInfiniteLoaderRendered] = useState(false);
-	const [exclude, setExclude] = useState(!!selectedData?.exclude);
+	const configuredExclude = !!preloadedData?.exclude;
+
+	const [exclude, setExclude] = useState(
+		selectedData ? !!selectedData.exclude : configuredExclude
+	);
 
 	const loaderVisible = !localItems.length && items?.length < total;
 
 	useEffect(() => {
-		setExclude(!!selectedData?.exclude);
+		setExclude(selectedData ? !!selectedData.exclude : configuredExclude);
 		setSelectedItems(selectedData?.selectedItems || []);
-	}, [selectedData]);
+	}, [configuredExclude, selectedData]);
 
 	const handleAutocompleteQuery: (value: string) => void = debounce(
 
@@ -445,27 +453,29 @@ function SelectionFilter({
 							</div>
 						</ClayDropDown.Caption>
 
-						<Divider />
+						{showExcludeToggle && <Divider />}
 					</>
 				) : null}
 
-				<ClayDropDown.Caption className="pb-0">
-					<div className="row">
-						<div className="col">
-							<label htmlFor={`autocomplete-exclude-${id}`}>
-								{Liferay.Language.get('exclude')}
-							</label>
-						</div>
+				{showExcludeToggle && (
+					<ClayDropDown.Caption className="pb-0">
+						<div className="row">
+							<div className="col">
+								<label htmlFor={`autocomplete-exclude-${id}`}>
+									{Liferay.Language.get('exclude')}
+								</label>
+							</div>
 
-						<div className="col-auto">
-							<ClayToggle
-								id={`autocomplete-exclude-${id}`}
-								onToggle={() => setExclude(!exclude)}
-								toggled={exclude}
-							/>
+							<div className="col-auto">
+								<ClayToggle
+									id={`autocomplete-exclude-${id}`}
+									onToggle={() => setExclude(!exclude)}
+									toggled={exclude}
+								/>
+							</div>
 						</div>
-					</div>
-				</ClayDropDown.Caption>
+					</ClayDropDown.Caption>
+				)}
 
 				<Divider />
 
@@ -539,7 +549,7 @@ function SelectionFilter({
 							setFilter({
 								active: false,
 								selectedData: {
-									exclude: false,
+									exclude,
 									selectedItems: [],
 								},
 							});

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
@@ -573,6 +573,7 @@ interface ISelectionFilterState extends IBaseFilterState {
 		exclude: boolean;
 		selectedItems: Array<ISelectionFilterStateItem>;
 	};
+	showExcludeToggle?: boolean;
 }
 interface IFDSState {
 	filters: Array<IBaseFilterState>;

--- a/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
@@ -36,7 +36,9 @@ export class FDSSamplePage {
 	readonly emptyStateContainer: Locator;
 	readonly fdsWrapper: Locator;
 	readonly fileDropModal: Locator;
+	readonly filterDeleteButton: Locator;
 	readonly filterDropdownMenu: Locator;
+	readonly filterExcludeToggle: Locator;
 	readonly filterMenu: Locator;
 	readonly filterMenuSearchInput: Locator;
 	readonly filterShowResultsOrAddButton: Locator;
@@ -128,7 +130,12 @@ export class FDSSamplePage {
 			name: 'Custom dummy file uploader',
 		});
 		this.filterDropdownMenu = page.locator('.data-set-filter');
+		this.filterExcludeToggle =
+			this.filterDropdownMenu.getByLabel('Exclude');
 		this.filterMenu = page.locator('.dropdown-menu');
+		this.filterDeleteButton = this.filterMenu.getByRole('button', {
+			name: 'Delete Filter',
+		});
 		this.filterMenuSearchInput = this.filterMenu
 			.getByLabel('Search')
 			.first();
@@ -325,6 +332,23 @@ export class FDSSamplePage {
 		await workflowModal.getByRole('button', {name: 'Save'}).click();
 
 		await workflowModal.waitFor({state: 'hidden'});
+	}
+
+	getFilterItemCheckbox(label: string) {
+		return this.filterDropdownMenu.getByRole('checkbox', {name: label});
+	}
+
+	getFilterRemoveButton(label: string) {
+		return this.activeFiltersToolbar.container
+			.getByRole('group')
+			.filter({hasText: `${label}:`})
+			.getByRole('button', {name: 'Remove Filter'});
+	}
+
+	getFilterSummaryButton(label: string) {
+		return this.activeFiltersToolbar.container
+			.getByRole('button')
+			.filter({hasText: new RegExp(`^${label}:`)});
 	}
 
 	async search(value: string) {

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/hidden_exclude_toggle/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/hidden_exclude_toggle/filters.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../../fixtures/loginTest';
+import {waitForFDS} from '../../../../../utils/waitFor';
+import {fdsSamplePageTest} from '../../fixtures/fdsSamplePageTest';
+
+const test = mergeTests(
+	apiHelpersTest,
+	fdsSamplePageTest,
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest()
+);
+
+test(
+	'Behavior of a selection filter that hides the "Exclude" toggle',
+	{
+		tag: ['@LPD-103049'],
+	},
+	async ({fdsSamplePage, page, site}) => {
+		let blueCells: Locator;
+		let colorFilterSummaryButton: Locator;
+		let greenCells: Locator;
+		let redCells: Locator;
+
+		await test.step('Go to Hidden Exclude Toggle sample tab', async () => {
+			await fdsSamplePage.setupFDSSampleWidget({site});
+
+			await fdsSamplePage.selectTab('Hidden Exclude Toggle');
+
+			await waitForFDS({page});
+
+			blueCells = fdsSamplePage.table.container.getByRole('cell', {
+				name: 'Blue',
+			});
+
+			colorFilterSummaryButton =
+				fdsSamplePage.getFilterSummaryButton('Color');
+
+			greenCells = fdsSamplePage.table.container.getByRole('cell', {
+				name: 'Green',
+			});
+
+			redCells = fdsSamplePage.table.container.getByRole('cell', {
+				name: 'Red',
+			});
+		});
+
+		await test.step('Check the preloaded "Exclude" value excludes the "Blue" color', async () => {
+			await expect(colorFilterSummaryButton).toBeVisible();
+
+			await expect(blueCells).toHaveCount(0);
+		});
+
+		await test.step('Open the "Color" filter and check the "Exclude" toggle is not displayed', async () => {
+			await colorFilterSummaryButton.click();
+
+			await expect(
+				fdsSamplePage.getFilterItemCheckbox('Blue')
+			).toBeChecked();
+
+			await expect(fdsSamplePage.filterExcludeToggle).toHaveCount(0);
+		});
+
+		await test.step('Select the "Green" color and check both colors are excluded', async () => {
+			await fdsSamplePage.getFilterItemCheckbox('Green').check();
+
+			await fdsSamplePage.filterShowResultsOrAddButton.click();
+
+			await expect(blueCells).toHaveCount(0);
+			await expect(greenCells).toHaveCount(0);
+		});
+
+		await test.step('Clear the selection and check every color is displayed', async () => {
+			await colorFilterSummaryButton.click();
+
+			await fdsSamplePage.getFilterItemCheckbox('Blue').uncheck();
+			await fdsSamplePage.getFilterItemCheckbox('Green').uncheck();
+
+			await fdsSamplePage.filterDeleteButton.click();
+
+			await expect(colorFilterSummaryButton).toHaveCount(0);
+
+			await expect(blueCells).not.toHaveCount(0);
+		});
+
+		await test.step('Select the "Red" color and check the configured "Exclude" value still applies', async () => {
+			await fdsSamplePage.managementToolbar.filterButton.click();
+
+			await fdsSamplePage.filterMenu
+				.getByRole('menuitem', {name: 'Color'})
+				.click();
+
+			await expect(fdsSamplePage.filterExcludeToggle).toHaveCount(0);
+
+			await fdsSamplePage.getFilterItemCheckbox('Red').check();
+
+			await fdsSamplePage.filterShowResultsOrAddButton.click();
+
+			await expect(redCells).toHaveCount(0);
+		});
+
+		await test.step('Remove the filter chip and check the preloaded "Exclude" value comes back', async () => {
+			await fdsSamplePage.getFilterRemoveButton('Color').click();
+
+			await expect(colorFilterSummaryButton).toHaveCount(0);
+
+			await fdsSamplePage.managementToolbar.filterButton.click();
+
+			await expect(
+				fdsSamplePage.getFilterItemCheckbox('Green')
+			).toBeVisible();
+
+			await expect(fdsSamplePage.filterExcludeToggle).toHaveCount(0);
+
+			await fdsSamplePage.getFilterItemCheckbox('Green').check();
+
+			await fdsSamplePage.filterShowResultsOrAddButton.click();
+
+			await expect(greenCells).toHaveCount(0);
+			await expect(blueCells).not.toHaveCount(0);
+		});
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103049

## What Is Being Fixed

Analytics Cloud has several FDS tables whose selection filters show an Exclude toggle that makes no sense for their use case. The toggle was rendered unconditionally by the runtime selection filter, with no way to hide it from the filter definition.

## How It Is Being Fixed

A props transformer can now set `showExcludeToggle` to false on a selection filter. The prop is purely visual: it stops the toggle from rendering and nothing else. The exclude value keeps coming from whatever reaches the filter, be it the URL, a saved view or its preloaded data, so hiding the control never changes how the selection is negated, and the user can still change which items are selected.

Two places where the component wrote an exclude value of its own were corrected so that holds, both unconditionally rather than only when the toggle is hidden: clearing a filter's selection no longer stores an exclude of false, and a filter with no selected data falls back to its preloaded value. This is a behavior change for filters that keep the toggle too, since a deleted filter now reopens with its last value instead of resetting to off, and it is what keeps a configured mode from being lost through a control the user can no longer see.

The divider above the item list is now rendered independently of the toggle, and the one that follows the selected items only while the toggle is visible, so the item list always keeps exactly one separator above it.

The capability is reachable only from code, so coverage goes through a new sample: a Hidden Exclude Toggle tab in frontend-data-set-sample-web whose color filter preloads an exclude of Blue and hides the toggle through a props transformer. The Playwright test on it covers the preloaded exclude being applied, the toggle being absent while the items stay selectable, the exclusion following a changed selection, and the configured mode surviving a clear and refilter cycle. Filters without the prop are covered by the existing advanced sample tests, which still check and toggle the Exclude control.

Hiding the toggle pins nothing on its own: the filter has to carry its include and exclude value in `preloadedData` for the mode to survive. A filter defined in Java through `FDSFilter.getPreloadedData()`, which is the Analytics Cloud case this iteration targets, controls that value directly. A filter defined in the Data Set Manager does not always send it, because `CustomFDSSerializer` serializes the form's flag only inside `preloadedData` and only when the filter has preselected values, so one set to Exclude without preselected values leaves the client with no value and hiding its toggle leaves it including. That gap predates this change, since such a filter already opens with its toggle off today, and closing it needs the Java serializer along with the admin facing iteration described in LPD-103048.

## PR Check

**pr-check: PASS** — tested on `a306bdc54733540bc5c0a26477654e2ffe4e6643`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a306bdc54733540bc5c0a26477654e2ffe4e6643"} -->
