### PR TITLE
LPD-104239 Browse the Item Selector from the CKEditor 5 link dialog

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/LinkItemSelector.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/LinkItemSelector.tsx
@@ -1,0 +1,231 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Plugin} from '@ckeditor/ckeditor5-core/dist/index.js';
+import {Link, LinkUI} from '@ckeditor/ckeditor5-link/dist/index.js';
+import {Config} from '@ckeditor/ckeditor5-utils/dist/index.js';
+import {openModal, openSelectionModal} from 'frontend-js-components-web';
+import React, {useState} from 'react';
+
+import {LiferayEditorConfig} from '../utils/types';
+
+interface LinkDialogValues {
+	linkText: string;
+	url: string;
+}
+
+/**
+ * Decorates a method once, so that several listeners can hook into it without
+ * wrapping it more than once.
+ */
+function decorateOnce(linkUI: any, methodName: string) {
+	const flag = `_linkItemSelectorDecorated${methodName}`;
+
+	if (linkUI[flag]) {
+		return;
+	}
+
+	linkUI[flag] = true;
+
+	linkUI.decorate(methodName);
+}
+
+/**
+ * Replicates the CKEditor 4 link dialog: a modal owning the fields, plus a
+ * button that browses the Item Selector portlet in a nested iframe modal.
+ */
+function openLinkDialog({
+	browseURL,
+	initialValues,
+	itemSelectorEventName,
+	onSubmit,
+}: {
+	browseURL: string;
+	initialValues: LinkDialogValues;
+	itemSelectorEventName?: string;
+	onSubmit: (values: LinkDialogValues) => void;
+}) {
+	const values: LinkDialogValues = {...initialValues};
+
+	const LinkDialogBody = () => {
+		const [linkText, setLinkText] = useState(values.linkText);
+		const [url, setURL] = useState(values.url);
+
+		const updateLinkText = (value: string) => {
+			values.linkText = value;
+
+			setLinkText(value);
+		};
+
+		const updateURL = (value: string) => {
+			values.url = value;
+
+			setURL(value);
+		};
+
+		return (
+			<>
+				<div className="form-group">
+					<label htmlFor="lfr-ck-link-text">
+						{Liferay.Language.get('link-text')}
+					</label>
+
+					<input
+						className="form-control"
+						id="lfr-ck-link-text"
+						onChange={(event) => updateLinkText(event.target.value)}
+						type="text"
+						value={linkText}
+					/>
+				</div>
+
+				<div className="form-group">
+					<label htmlFor="lfr-ck-link-url">
+						{Liferay.Language.get('url')}
+					</label>
+
+					<div className="input-group">
+						<div className="input-group-item">
+							<input
+								className="form-control"
+								id="lfr-ck-link-url"
+								onChange={(event) =>
+									updateURL(event.target.value)
+								}
+								type="text"
+								value={url}
+							/>
+						</div>
+
+						<div className="input-group-item input-group-item-shrink">
+							<button
+								className="btn btn-secondary"
+								onClick={() =>
+									openSelectionModal<{value: string}>({
+										onSelect: ({value}) => updateURL(value),
+										selectEventName: itemSelectorEventName,
+										title: Liferay.Language.get(
+											'select-item'
+										),
+										url: browseURL,
+										zIndex: Liferay.zIndex.WINDOW + 20,
+									})
+								}
+								type="button"
+							>
+								{Liferay.Language.get('browse')}
+							</button>
+						</div>
+					</div>
+				</div>
+			</>
+		);
+	};
+
+	openModal({
+		bodyComponent: LinkDialogBody,
+		buttons: [
+			{
+				displayType: 'secondary',
+				label: Liferay.Language.get('cancel'),
+				type: 'cancel',
+			},
+			{
+				label: Liferay.Language.get('ok'),
+				onClick: ({processClose}: {processClose: () => void}) => {
+					if (values.url) {
+						onSubmit(values);
+					}
+
+					processClose();
+				},
+			},
+		],
+		size: 'md',
+		title: Liferay.Language.get('link'),
+		zIndex: Liferay.zIndex.WINDOW + 10,
+	});
+}
+
+class LinkItemSelector extends Plugin {
+	static get pluginName() {
+		return 'LinkItemSelector' as const;
+	}
+
+	static get requires() {
+		return [Link];
+	}
+
+	afterInit() {
+		const editor = this.editor;
+
+		const config: Config<LiferayEditorConfig> = editor.config;
+
+		const browseURL = config.get('filebrowserBrowseUrl');
+
+		if (!browseURL) {
+			return;
+		}
+
+		const linkCommand = editor.commands.get('link')!;
+		const linkUI = editor.plugins.get(LinkUI) as any;
+
+		const openDialog = () =>
+			openLinkDialog({
+				browseURL,
+				initialValues: {
+					linkText: linkUI.selectedLinkableText || '',
+					url: (linkCommand.value as string) || '',
+				},
+				itemSelectorEventName: config.get('itemSelectorEventName'),
+				onSubmit: ({linkText, url}) =>
+					editor.execute(
+						'link',
+						url,
+						{},
+						linkText === linkUI.selectedLinkableText
+							? undefined
+							: linkText
+					),
+			});
+
+		// Creating a link never reaches the balloon form.
+
+		decorateOnce(linkUI, '_showUI');
+
+		this.listenTo(
+			linkUI,
+			'_showUI',
+			(event: any) => {
+				if (linkCommand.value) {
+					return;
+				}
+
+				event.stop();
+
+				openDialog();
+			},
+			{priority: 'high'}
+		);
+
+		// An existing link keeps the native preview toolbar, so that it can
+		// still be opened and removed, but "Edit link" opens the dialog too.
+
+		decorateOnce(linkUI, '_addFormView');
+
+		this.listenTo(
+			linkUI,
+			'_addFormView',
+			(event: any) => {
+				event.stop();
+
+				openDialog();
+			},
+			{priority: 'high'}
+		);
+	}
+}
+
+export default LinkItemSelector;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
@@ -54,6 +54,7 @@ import {sub} from 'frontend-js-web';
 import AICreator from '../plugins/AICreator';
 import HeadlessItemSelector from '../plugins/HeadlessItemSelector';
 import ItemSelector from '../plugins/ItemSelector';
+import LinkItemSelector from '../plugins/LinkItemSelector';
 import {EEditorConfigPreset, EEditorVariant} from './types';
 
 const getDefaultEditorConfig = ({
@@ -78,6 +79,7 @@ const getDefaultEditorConfig = ({
 		Image,
 		Link,
 		LinkImage,
+		LinkItemSelector,
 		List,
 		Paragraph,
 		PasteFromOffice,

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
@@ -28,6 +28,7 @@ export interface LiferayEditorConfig extends EditorConfig {
 	editorType?: EEditorType;
 	editorVariant?: EEditorVariant;
 	editorVersion?: string;
+	filebrowserBrowseUrl?: string;
 	filebrowserImageBrowseUrl?: string;
 	filebrowserVideoBrowseUrl?: string;
 	itemSelectorEventName?: string;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104239

## What Is Being Fixed

CKEditor 4 shipped a "Browse Server" button in its link dialog that opened the Liferay Item Selector, so an editor could pick a Page or a Documents & Media item and get its relative URL inserted (`/home`, `/documents/d/guest/astronaut-png`). That capability was lost in the migration to CKEditor 5, which only offers an inline balloon accepting manually typed URLs, forcing editors to hardcode absolute URLs throughout their content.

This spike had to answer whether CKEditor 5's official Link plugin exposes enough extension surface to restore it, or whether a custom link plugin written from scratch is required.

## How It Is Being Fixed

The official plugin can be extended; neither a fork nor a rewrite is needed. `LinkUI` remains the real plugin instance, so `LinkImage` and `Bookmark` keep resolving their dependency on it, and `LinkEditing`, `LinkCommand`, `AutoLink` and the decorators are all preserved.

Only two of its methods are intercepted, through `ObservableMixin#decorate()` — public API, which turns a method into an event instead of reassigning it. `_showUI` is stopped when the selection is not inside a link, so creating a link opens a modal reproducing the CKEditor 4 dialog: `Link Text`, `URL`, and a `Browse` button that loads the Item Selector portlet in an iframe. `_addFormView` is stopped as well, so `Edit link` opens that same modal prefilled. An existing link deliberately keeps the native preview toolbar, because the advanced preset has no separate unlink button and hijacking every path would make removing a link impossible.

Note that `LinkImage` also routes through `_showUI` (`linkimageui.js:87`), so linking an image goes through the same dialog with no extra hook.

No Java is involved. `DocumentsAndMediaURLEditorConfigContributor` already publishes `filebrowserBrowseUrl` — built from `FileItemSelectorCriterion` + `LayoutItemSelectorCriterion` + `URLItemSelectorReturnType` — for every editor, because it declares no `editor.name` property and `BaseEditorProvider` treats an empty property set as matching all of them.

Full write-up: https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/5345804300

## Why Are There No Tests?

This PR is the deliverable of a spike, opened as a draft to document and discuss the approach rather than to merge. Playwright coverage was written and verified locally while validating it — the full `advanced_classic.spec.ts` suite passed 16/16, including two new tests for the dialog and the browse flow — but was deliberately left out of the commit at the author's request. The implementation ticket, LPD-91686, will carry the final tests.

## PR Check

**pr-check: SKIPPED** — Spike proof of concept opened as a draft for discussion, not for merge.

<!-- pr-check {"reason": "Spike proof of concept opened as a draft for discussion, not for merge.", "result": "skipped", "sha": "04b4cfe7979fdcca47a393c8da4f11fa5567c62a"} -->
