### PR TITLE
LPD-88688 Stop DataGuard from deleting the Data Set Objects

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/serializer/test/SystemFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/serializer/test/SystemFDSSerializerTest.java
@@ -55,8 +55,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Juanjo Fernandez
  */
-@FeatureFlag("LPS-164563")
 @DataGuard(scope = DataGuard.Scope.NONE)
+@FeatureFlag("LPS-164563")
 @RunWith(Arquillian.class)
 public class SystemFDSSerializerTest {
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/serializer/test/SystemFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/serializer/test/SystemFDSSerializerTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -55,6 +56,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
  * @author Juanjo Fernandez
  */
 @FeatureFlag("LPS-164563")
+@DataGuard(scope = DataGuard.Scope.NONE)
 @RunWith(Arquillian.class)
 public class SystemFDSSerializerTest {
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -48,6 +49,7 @@ import org.junit.runner.RunWith;
  * @author Juanjo Fernandez
  */
 @FeatureFlag("LPS-164563")
+@DataGuard(scope = DataGuard.Scope.NONE)
 @RunWith(Arquillian.class)
 public class DataSetSnapshotSharingEntryInterpreterTest {
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
@@ -48,8 +48,8 @@ import org.junit.runner.RunWith;
 /**
  * @author Juanjo Fernandez
  */
-@FeatureFlag("LPS-164563")
 @DataGuard(scope = DataGuard.Scope.NONE)
+@FeatureFlag("LPS-164563")
 @RunWith(Arquillian.class)
 public class DataSetSnapshotSharingEntryInterpreterTest {
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/upgrade/v1_0_0/test/DataSetOrderValuesUpgradeProcessTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/upgrade/v1_0_0/test/DataSetOrderValuesUpgradeProcessTest.java
@@ -41,8 +41,8 @@ import org.junit.runner.RunWith;
 /**
  * @author Daniel Sanz
  */
-@FeatureFlag("LPS-164563")
 @DataGuard(scope = DataGuard.Scope.NONE)
+@FeatureFlag("LPS-164563")
 @RunWith(Arquillian.class)
 public class DataSetOrderValuesUpgradeProcessTest {
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/upgrade/v1_0_0/test/DataSetOrderValuesUpgradeProcessTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/upgrade/v1_0_0/test/DataSetOrderValuesUpgradeProcessTest.java
@@ -15,6 +15,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -41,6 +42,7 @@ import org.junit.runner.RunWith;
  * @author Daniel Sanz
  */
 @FeatureFlag("LPS-164563")
+@DataGuard(scope = DataGuard.Scope.NONE)
 @RunWith(Arquillian.class)
 public class DataSetOrderValuesUpgradeProcessTest {
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/upgrade/v1_1_0/test/DataSetShowSearchUpgradeProcessTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/upgrade/v1_1_0/test/DataSetShowSearchUpgradeProcessTest.java
@@ -40,8 +40,8 @@ import org.junit.runner.RunWith;
 /**
  * @author Antonio Ortega
  */
-@FeatureFlag("LPS-164563")
 @DataGuard(scope = DataGuard.Scope.NONE)
+@FeatureFlag("LPS-164563")
 @RunWith(Arquillian.class)
 public class DataSetShowSearchUpgradeProcessTest {
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/upgrade/v1_1_0/test/DataSetShowSearchUpgradeProcessTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/upgrade/v1_1_0/test/DataSetShowSearchUpgradeProcessTest.java
@@ -15,6 +15,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -40,6 +41,7 @@ import org.junit.runner.RunWith;
  * @author Antonio Ortega
  */
 @FeatureFlag("LPS-164563")
+@DataGuard(scope = DataGuard.Scope.NONE)
 @RunWith(Arquillian.class)
 public class DataSetShowSearchUpgradeProcessTest {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88688

## What Is Being Fixed

Three of the four integration tests in `frontend-data-set-test` have failed on every `[master] ci:test:frontend` build since June 1, including `DataSetShowSearchUpgradeProcessTest` and `DataSetOrderValuesUpgradeProcessTest`.

`FrontendDataSetTestUtil.initialize` runs the batch import that seeds the Data Set system object definitions, and that import creates both the definition rows and the physical tables those definitions describe. DataGuard deletes the rows as leftover test data after each test class, but nothing drops the tables, so the first class to run leaves orphaned tables behind. Every later class re-runs the import, fails to find the definitions by external reference code, takes the create path instead of the update path, and hits `CREATE TABLE` against a table that already exists. That is why `SystemFDSSerializerTest` passes while the other three fail.

## How It Is Being Fixed

Each of the four test classes gets `@DataGuard(scope = DataGuard.Scope.NONE)`, so DataGuard leaves the seeded definitions in place. Later classes then find them by external reference code and update rather than create, and no `CREATE TABLE` is issued.

The annotation goes on all four rather than only the ones that fail, because the orphaned tables are left by whichever class runs first and a class only protects its own rows. These are system object definitions seeded by a deployment step rather than test fixtures, so keeping them past the end of a test class is the correct outcome.

## Why Are There No Tests?

This change contains no product code. It annotates four existing integration test classes so the test framework stops deleting the system object definitions they seed. The existing tests in `frontend-data-set-test` are the coverage — three of the four currently fail in CI and should pass with this change.

## PR Check

**pr-check: PASS** — tested on `7a4f5392d6b7a89745f27c7f1997443753c65ee1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | NOT VERIFIED |
| Integration Test Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Source Format found and auto-fixed annotation ordering in all four files, placing `@DataGuard` before `@FeatureFlag`, committed as `7a4f539 LPD-88688 SF`. No unfixable violations. The yarn side was skipped rather than clean — the diff contains no frontend file types, so `skip.node.task` was set and the yarn formatter never ran.

Per-Module Compile verified nothing. Its deploy set came out empty because the only changed module, `frontend-data-set-test`, has all four of its Java changes under `src/testIntegration`, which the validation excludes by design since Integration Test Compile covers those and a `-test` module deploys no runtime bundle. The lockfile check ran and had nothing to compare — no `package.json` or `yarn.lock` in the diff.

Integration Test Compile verified nothing, on an environment failure rather than a branch one. `com.liferay.portal.kernel.*` is absent from `testIntegrationCompileClasspath` in this tree, the `install-portal-snapshots` unsubstituted-token shape. The control module `apps:blogs:blogs-test` — no dependency on anything the diff touched, and importing every package the failure named — failed identically with 1457 errors against our 91. `DataGuard` appears nowhere in the 998-line error log, so the symbol the diff adds resolves while the kernel packages do not. Re-run once `portal-impl` resolves with the kernel present.

Java Unit Tests verified nothing. No counterpart unit test exists for any of the four changed classes — they are themselves integration tests, so the parallel-name lookup seeks `…TestTest.java`. Coverage for this change is the integration suite in `frontend-data-set-test`, which this validation does not run.

Baseline compared the whole universe and found nothing. The changed-exporting-module count is 0 because `frontend-data-set-test` declares no `Export-Package:` — the same filter `baseline-all` applies — so semantic versioning does not apply to this diff. Local Version Check passed: no `public` or `protected` lines added or removed anywhere in the diff.

<!-- pr-check {"result": "success", "sha": "7a4f5392d6b7a89745f27c7f1997443753c65ee1"} -->
